### PR TITLE
Add industry mix by batch chart, fix SQLite schema, improve setup docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ ExploreYC — a full-stack web app that scrapes Y Combinator's Algolia API for c
 cd frontend && npm install && npm run dev
 
 # Backend dev server
-cd backend && pip install -r requirements.txt && uvicorn main:app --reload
+cd backend && python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt && python3 -m uvicorn main:app --reload
 
 # Production frontend build (from repo root)
 npm run build
@@ -32,6 +32,18 @@ python -m pytest test_pagination.py
 ```
 
 No frontend test suite exists. Backend tests are integration-focused (`test_*.py` files in `backend/`).
+
+**Seeding local data:** With `DATABASE_URL` unset the backend uses SQLite (`backend/yc_companies.db`, auto-created). Scrape YC data from the public Algolia API (no keys needed):
+
+```bash
+# Seed last 3 batches (with backend running)
+curl -X POST http://localhost:8000/api/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"batch": ["Winter 2025", "Summer 2024", "Winter 2024"], "hits_per_page": 1000, "max_pages": 20}'
+
+# Check progress
+curl http://localhost:8000/api/scrape/status/1
+```
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ cd exploreyc
 
 # Backend
 cd backend
+python3 -m venv venv
+source venv/bin/activate
 pip install -r requirements.txt
 cp ../.env.example ../.env   # fill in the keys you have
-uvicorn main:app --reload    # → http://localhost:8000
+python3 -m uvicorn main:app --reload    # → http://localhost:8000
 
 # Frontend (new shell)
 cd ../frontend
@@ -80,6 +82,25 @@ npm run dev                  # → http://localhost:5173
 The Vite dev server proxies `/api` and `/ws` to `localhost:8000`, so the frontend talks to your local backend automatically.
 
 **Minimum viable local setup:** leave `DATABASE_URL` unset (falls back to SQLite) and provide just an `OPENAI_API_KEY` for the idea-validator features. Every other integration degrades gracefully if its key is missing — see [`.env.example`](.env.example) for the full list.
+
+### Seeding local data
+
+The local SQLite database starts empty. To populate it, scrape YC company data from the public Algolia API (no API keys needed):
+
+```bash
+# With the backend running, seed the last 3 batches (~500+ companies)
+curl -X POST http://localhost:8000/api/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"batch": ["Winter 2025", "Summer 2024", "Winter 2024"], "hits_per_page": 1000, "max_pages": 20}'
+
+# Check progress (replace 1 with the job_id returned above)
+curl http://localhost:8000/api/scrape/status/1
+
+# Verify data loaded
+curl http://localhost:8000/api/stats
+```
+
+Once the scrape completes (usually under a minute), refresh the frontend to see charts and data populate. To scrape all batches, omit the `batch` filter — but this takes longer and hits the 3-requests-per-hour rate limit.
 
 ## Project layout
 

--- a/backend/company_cache.py
+++ b/backend/company_cache.py
@@ -81,6 +81,15 @@ class CompanyCache:
             s = c.get("status") or "unknown"
             by_status[s] = by_status.get(s, 0) + 1
 
+        by_batch_industry: Dict[str, Dict[str, int]] = {}
+        for c in companies:
+            b = c.get("batch")
+            ind = c.get("industry")
+            if b and ind:
+                if b not in by_batch_industry:
+                    by_batch_industry[b] = {}
+                by_batch_industry[b][ind] = by_batch_industry[b].get(ind, 0) + 1
+
         self._stats = {
             "total_companies": total,
             "hiring": hiring,
@@ -88,6 +97,7 @@ class CompanyCache:
             "by_industry": by_industry,
             "by_country": by_country,
             "by_status": by_status,
+            "by_batch_industry": by_batch_industry,
         }
 
         # Filter lists

--- a/backend/database.py
+++ b/backend/database.py
@@ -180,6 +180,40 @@ class Database:
                 )
             ''')
 
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS company_changes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    company_id INTEGER NOT NULL,
+                    change_type TEXT NOT NULL,
+                    field_name TEXT,
+                    old_value TEXT,
+                    new_value TEXT,
+                    changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            ''')
+
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS predictions (
+                    id TEXT PRIMARY KEY,
+                    idea_description TEXT,
+                    team_info TEXT,
+                    industry TEXT,
+                    location TEXT,
+                    market_type TEXT,
+                    idea_score REAL,
+                    team_score REAL,
+                    market_score REAL,
+                    combined_score REAL,
+                    percentile REAL,
+                    tier TEXT,
+                    top_matches TEXT,
+                    achievements TEXT,
+                    challenges TEXT,
+                    username TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            ''')
+
             # Create indexes
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_batch ON companies(batch)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_hiring ON companies(is_hiring)')

--- a/frontend/src/components/BatchIndustryChart.tsx
+++ b/frontend/src/components/BatchIndustryChart.tsx
@@ -1,0 +1,279 @@
+import { useState, useMemo, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import { HackerCard } from './ui/hacker-card';
+import { Layers } from 'lucide-react';
+import { getSortedBatches, batchToShortFormat } from '../lib/batchUtils';
+
+interface BatchIndustryChartProps {
+  byBatch: Record<string, number>;
+  byBatchIndustry: Record<string, Record<string, number>>;
+}
+
+const INDUSTRY_COLORS = [
+  '#FB651E', '#3B82F6', '#8B5CF6', '#10B981', '#F59E0B',
+  '#EF4444', '#06B6D4', '#EC4899', '#84CC16', '#F97316',
+  '#6366F1', '#14B8A6', '#E11D48', '#A855F7', '#0EA5E9',
+  '#D946EF', '#22C55E', '#FACC15', '#64748B', '#78716C',
+];
+
+const MUTED_OPACITY = 0.15;
+
+export function BatchIndustryChart({ byBatch, byBatchIndustry }: BatchIndustryChartProps) {
+  const [selectedIndustry, setSelectedIndustry] = useState<string | null>(null);
+  const [hoveredBar, setHoveredBar] = useState<number | null>(null);
+  const [showMoreDropdown, setShowMoreDropdown] = useState(false);
+
+  const sortedBatches = useMemo(() => {
+    return getSortedBatches(byBatch).reverse();
+  }, [byBatch]);
+
+  const allIndustries = useMemo(() => {
+    const totals: Record<string, number> = {};
+    for (const batchIndustries of Object.values(byBatchIndustry)) {
+      for (const [ind, count] of Object.entries(batchIndustries)) {
+        totals[ind] = (totals[ind] || 0) + count;
+      }
+    }
+    return Object.entries(totals)
+      .sort(([, a], [, b]) => b - a)
+      .map(([name]) => name);
+  }, [byBatchIndustry]);
+
+  const top5 = useMemo(() => new Set(allIndustries.slice(0, 5)), [allIndustries]);
+
+  const industryColorMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    allIndustries.forEach((ind, i) => {
+      map[ind] = INDUSTRY_COLORS[i % INDUSTRY_COLORS.length];
+    });
+    return map;
+  }, [allIndustries]);
+
+  const barData = useMemo(() => {
+    return sortedBatches.map(batch => {
+      const industries = byBatchIndustry[batch.name] || {};
+      const total = Object.values(industries).reduce((s, v) => s + v, 0);
+      const segments = allIndustries
+        .map(ind => ({
+          industry: ind,
+          count: industries[ind] || 0,
+          pct: total > 0 ? ((industries[ind] || 0) / total) * 100 : 0,
+        }))
+        .filter(s => s.count > 0);
+      return { batch: batch.name, total, segments };
+    });
+  }, [sortedBatches, byBatchIndustry, allIndustries]);
+
+  const handleLegendClick = useCallback((industry: string) => {
+    setSelectedIndustry(prev => prev === industry ? null : industry);
+  }, []);
+
+  const legendIndustries = useMemo(() => {
+    if (selectedIndustry && !top5.has(selectedIndustry)) {
+      return [...allIndustries.slice(0, 5), selectedIndustry];
+    }
+    return allIndustries.slice(0, 5);
+  }, [allIndustries, top5, selectedIndustry]);
+
+  const otherIndustries = useMemo(() => {
+    const legendSet = new Set(legendIndustries);
+    return allIndustries.filter(i => !legendSet.has(i));
+  }, [allIndustries, legendIndustries]);
+
+  return (
+    <HackerCard glowColor="blue" className="p-6">
+      <div className="flex items-center gap-2 mb-4 font-mono">
+        <Layers className="h-5 w-5 text-blue-500" />
+        <span className="text-muted-foreground">$</span>
+        <h3 className="font-bold">Industry Mix by Batch</h3>
+        <span className="text-xs text-muted-foreground ml-auto">% of companies per batch</span>
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1.5 mb-4 font-mono text-xs">
+        {legendIndustries.map(ind => {
+          const isSelected = selectedIndustry === ind;
+          return (
+            <button
+              key={ind}
+              onClick={() => handleLegendClick(ind)}
+              className={`flex items-center gap-1.5 transition-opacity hover:opacity-100 ${
+                selectedIndustry && !isSelected ? 'opacity-40' : 'opacity-100'
+              }`}
+            >
+              <span
+                className="inline-block w-2.5 h-2.5 shrink-0"
+                style={{
+                  backgroundColor: industryColorMap[ind],
+                  opacity: isSelected ? 1 : 0.8,
+                  outline: isSelected ? '2px solid currentColor' : 'none',
+                  outlineOffset: '1px',
+                }}
+              />
+              <span className={isSelected ? 'text-foreground' : 'text-muted-foreground'}>
+                {ind}
+              </span>
+            </button>
+          );
+        })}
+        {otherIndustries.length > 0 && (
+          <div
+            className="relative"
+            onMouseEnter={() => setShowMoreDropdown(true)}
+            onMouseLeave={() => setShowMoreDropdown(false)}
+          >
+            <button className="flex items-center gap-1.5 text-muted-foreground hover:text-foreground transition-colors">
+              <span className="inline-block w-2.5 h-2.5 shrink-0 border border-muted-foreground/40" />
+              <span>+{otherIndustries.length} more</span>
+            </button>
+            {showMoreDropdown && (
+              <div className="absolute z-50 top-full left-0 pt-1">
+                <div className="bg-card border border-border p-3 shadow-lg max-h-60 overflow-y-auto min-w-48">
+                  <div className="space-y-1">
+                    {otherIndustries.map(ind => (
+                      <button
+                        key={ind}
+                        onClick={() => { handleLegendClick(ind); setShowMoreDropdown(false); }}
+                        className="flex items-center gap-1.5 w-full text-left hover:text-foreground transition-colors"
+                      >
+                        <span
+                          className="inline-block w-2 h-2 shrink-0"
+                          style={{ backgroundColor: industryColorMap[ind] }}
+                        />
+                        <span className={selectedIndustry === ind ? 'text-foreground' : 'text-muted-foreground'}>
+                          {ind}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+        {selectedIndustry && (
+          <button
+            onClick={() => setSelectedIndustry(null)}
+            className="text-muted-foreground hover:text-foreground transition-colors ml-2"
+          >
+            [clear]
+          </button>
+        )}
+      </div>
+
+      {/* Chart */}
+      <div className="w-full h-[320px] flex">
+        {/* Y-axis labels */}
+        <div className="flex flex-col justify-between text-xs text-muted-foreground font-mono py-0.5 pr-2 shrink-0">
+          <span>100%</span>
+          <span>50%</span>
+          <span>0%</span>
+        </div>
+
+        {/* Chart area */}
+        <div className="flex-1 relative">
+          <svg className="w-full h-full" viewBox={`0 0 ${barData.length * 10} 100`} preserveAspectRatio="none">
+            {[0, 25, 50, 75, 100].map(y => (
+              <line
+                key={y}
+                x1="0"
+                y1={y}
+                x2={barData.length * 10}
+                y2={y}
+                stroke="currentColor"
+                strokeWidth="0.15"
+                opacity="0.1"
+                vectorEffect="non-scaling-stroke"
+              />
+            ))}
+
+            {barData.map((bar, barIdx) => {
+              const barWidth = 10;
+              const x = barIdx * barWidth;
+              let yOffset = 0;
+
+              return (
+                <g
+                  key={bar.batch}
+                  onMouseEnter={() => setHoveredBar(barIdx)}
+                  onMouseLeave={() => setHoveredBar(null)}
+                >
+                  {bar.segments.map(seg => {
+                    const segHeight = seg.pct;
+                    const segY = 100 - yOffset - segHeight;
+                    yOffset += segHeight;
+
+                    const isHighlighted = selectedIndustry === seg.industry;
+                    const isMuted = selectedIndustry !== null && !isHighlighted;
+
+                    return (
+                      <rect
+                        key={seg.industry}
+                        x={x + barWidth * 0.1}
+                        y={segY}
+                        width={barWidth * 0.8}
+                        height={Math.max(segHeight, 0.2)}
+                        fill={industryColorMap[seg.industry]}
+                        opacity={isMuted ? MUTED_OPACITY : 0.85}
+                        className="transition-opacity duration-150"
+                      >
+                        <title>{`${bar.batch}\n${seg.industry}: ${seg.count} (${seg.pct.toFixed(1)}%)`}</title>
+                      </rect>
+                    );
+                  })}
+                </g>
+              );
+            })}
+          </svg>
+
+          {/* X-axis labels */}
+          <div className="absolute -bottom-6 left-0 right-0 flex justify-between px-1 text-xs text-muted-foreground font-mono">
+            {barData[0] && <span>{batchToShortFormat(barData[0].batch)}</span>}
+            {barData[Math.floor(barData.length / 2)] && (
+              <span>{batchToShortFormat(barData[Math.floor(barData.length / 2)].batch)}</span>
+            )}
+            {barData[barData.length - 1] && (
+              <span>{batchToShortFormat(barData[barData.length - 1].batch)}</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Hover tooltip */}
+      {hoveredBar !== null && barData[hoveredBar] && (
+        <motion.div
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mt-8 pt-3 border-t border-border"
+        >
+          <div className="font-mono text-xs">
+            <span className="text-[#FB651E]">&gt;</span>{' '}
+            <span className="text-foreground font-bold">{barData[hoveredBar].batch}</span>
+            <span className="text-muted-foreground"> — {barData[hoveredBar].total} companies</span>
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 mt-1.5 font-mono text-xs text-muted-foreground">
+            {barData[hoveredBar].segments
+              .sort((a, b) => b.count - a.count)
+              .slice(0, 8)
+              .map(seg => (
+                <span key={seg.industry} className="flex items-center gap-1">
+                  <span
+                    className="inline-block w-1.5 h-1.5"
+                    style={{ backgroundColor: industryColorMap[seg.industry] }}
+                  />
+                  {seg.industry}: {seg.pct.toFixed(1)}%
+                </span>
+              ))}
+          </div>
+        </motion.div>
+      )}
+
+      {hoveredBar === null && (
+        <div className="mt-8 pt-3 border-t border-border flex items-center gap-2 text-xs font-mono text-muted-foreground">
+          <span className="text-[#FB651E]">&gt;</span>
+          Hover over a bar to see breakdown. Click an industry to highlight it across batches.
+        </div>
+      )}
+    </HackerCard>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -81,6 +81,7 @@ export interface Stats {
   by_industry: Record<string, number>
   by_country: Record<string, number>
   by_status: Record<string, number>
+  by_batch_industry?: Record<string, Record<string, number>>
 }
 
 export interface ScrapeJob {

--- a/frontend/src/pages/AllBatchesPage.tsx
+++ b/frontend/src/pages/AllBatchesPage.tsx
@@ -6,6 +6,7 @@ import { HackerCard } from '../components/ui/hacker-card';
 import { DotPattern } from '../components/ui/dot-pattern';
 import { GridPattern } from '../components/ui/grid-pattern';
 import { TrendingUp, Building2, Users, Calendar, Globe2, Briefcase, Terminal, ArrowLeft } from 'lucide-react';
+import { BatchIndustryChart } from '../components/BatchIndustryChart';
 import { Link } from 'react-router-dom';
 
 const container = {
@@ -268,6 +269,21 @@ export function AllBatchesPage() {
             </div>
           </HackerCard>
         </motion.div>
+
+        {/* Industry Mix by Batch */}
+        {stats?.by_batch_industry && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.25 }}
+            className="mb-8"
+          >
+            <BatchIndustryChart
+              byBatch={stats.by_batch}
+              byBatchIndustry={stats.by_batch_industry}
+            />
+          </motion.div>
+        )}
 
         {/* Two Column Layout for Industry and Country Trends */}
         <div className="grid md:grid-cols-2 gap-6 mb-8">


### PR DESCRIPTION
## Summary

- **New chart**: Stacked percentage bar chart on `/analytics/batches` showing industry distribution across YC batches. Each bar represents one batch, segmented by industry (%). Top 5 industries highlighted in the legend, with a dropdown to browse and select any industry — selecting one highlights that segment across all batches.
- **SQLite schema fix**: Added missing `company_changes` and `predictions` table definitions to `database.py`. These tables were used throughout the codebase but never created for the local SQLite path, causing scraping and predictions to fail with `no such table` errors.
- **Backend stats**: Added `by_batch_industry` cross-tabulation to the existing stats computation — no new API endpoint needed.
- **Setup docs**: Updated README.md and CLAUDE.md with Python virtual environment instructions and a new "Seeding local data" section showing how to populate the local SQLite DB via the public Algolia scraper (no API keys required).

## Changed files

| File | What |
|------|------|
| `frontend/src/components/BatchIndustryChart.tsx` | New chart component (custom SVG, same style as existing charts) |
| `frontend/src/pages/AllBatchesPage.tsx` | Integrate chart below Batch Size Evolution |
| `frontend/src/lib/api.ts` | Add `by_batch_industry` to `Stats` interface |
| `backend/company_cache.py` | Compute batch×industry cross-tabulation in stats |
| `backend/database.py` | Add missing `company_changes` and `predictions` tables |
| `README.md` | Venv setup + local data seeding instructions |
| `CLAUDE.md` | Same setup improvements |

## Test plan

- [ ] Start backend with no `DATABASE_URL` (SQLite mode), run scrape via `curl -X POST http://localhost:8000/api/scrape -H "Content-Type: application/json" -d '{"batch": ["Winter 2025", "Summer 2024", "Winter 2024"]}'` — should succeed (previously crashed on missing table)
- [ ] Navigate to `/analytics/batches` — new "Industry Mix by Batch" chart renders below Batch Size Evolution
- [ ] Click an industry in the legend — highlights that segment across all batch bars
- [ ] Hover "+N more" dropdown — opens downward, stays open while moving mouse to click
- [ ] Selecting from dropdown closes it and highlights the industry
- [ ] Y-axis percentage labels (0%, 50%, 100%) are fully visible, not clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)