### PR TITLE
Add root contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing to ExploreYC
+
+## Quick start for contributors
+
+- Read the full [Contributing section in the README](README.md#contributing) before opening a pull request.
+- For non-trivial changes, open an issue first so the scope and approach can be discussed before you spend time building.
+- Use a focused branch name such as `feature/short-name` or `fix/short-name`.
+- Keep each pull request to one feature or one fix. Smaller, focused diffs are easier to review and merge.
+- Use the repository's issue templates when opening new ideas or bug reports, and add the `idea` label for proposal-style issues.
+- PRs normally need one approval before merging. The maintainer may bypass that requirement for their own admin merges.


### PR DESCRIPTION
## Summary
- add a root `CONTRIBUTING.md` so GitHub can surface the repository's contributing guidelines from the Issues and PR UI
- keep the file as a short TL;DR and link to the detailed Contributing section in the README
- mention issue-first workflow, branch naming, focused PR scope, issue templates, the `idea` label, and the one-approval/admin-bypass review policy requested in the issue

## Verification
- `git diff --check -- CONTRIBUTING.md`
- local content check confirmed the new file includes the requested quick-start heading, README contributing link, issue-first note, `feature/short-name` / `fix/short-name` branch examples, one-feature-per-PR rule, issue templates, `idea` label, one approval, and admin bypass note
- GitHub API/search check showed 0 open duplicate PRs mentioning `#2`, `CONTRIBUTING`, or `README` in `KonstantinMB/exploreyc` at preparation time
