### PR TITLE
Set per-page document titles + rebrand to ExploreYC

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/yc-logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>YC Company Explorer</title>
+    <title>ExploreYC — explore the Y Combinator portfolio</title>
 
     <!-- Open Graph / Social Media Meta Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://exploreyc.com/" />
-    <meta property="og:title" content="YC Company Explorer" />
+    <meta property="og:title" content="ExploreYC — explore the Y Combinator portfolio" />
     <meta property="og:description" content="Search, analyze, and discover insights from Y Combinator's portfolio. 5,801+ companies, 10+ countries, 10+ industries." />
     <meta property="og:image" content="https://exploreyc.com/og-image.png" />
     <meta property="og:image:width" content="1200" />
@@ -18,7 +18,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content="https://exploreyc.com/" />
-    <meta property="twitter:title" content="YC Company Explorer" />
+    <meta property="twitter:title" content="ExploreYC — explore the Y Combinator portfolio" />
     <meta property="twitter:description" content="Search, analyze, and discover insights from Y Combinator's portfolio. 5,801+ companies, 10+ countries, 10+ industries." />
     <meta property="twitter:image" content="https://exploreyc.com/og-image.png" />
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import { ShareHub } from './pages/ShareHub';
 import { CompanyCardPage } from './pages/CompanyCardPage';
 import { HiringBoardPagePaginated } from './pages/HiringBoardPagePaginated';
 import { HiringAnalyticsPage } from './pages/HiringAnalyticsPage';
+import { PageTitleManager } from './components/PageTitleManager';
 import './index.css';
 
 const queryClient = new QueryClient({
@@ -195,6 +196,7 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <HelmetProvider>
         <BrowserRouter>
+          <PageTitleManager />
           <AppProvider>
             <AnimatedRoutes />
           </AppProvider>

--- a/frontend/src/components/PageTitleManager.tsx
+++ b/frontend/src/components/PageTitleManager.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+const BRAND = 'ExploreYC';
+const DEFAULT_TITLE = `${BRAND} — explore the Y Combinator portfolio`;
+
+const EXACT: Record<string, string> = {
+  '/': DEFAULT_TITLE,
+  '/analytics': 'Analytics',
+  '/analytics/batches': 'Batch Analytics',
+  '/funding': 'Funding',
+  '/tools': 'Tools',
+  '/hiring': 'YC Hiring Board',
+  '/hiring/analytics': 'Hiring Analytics',
+  '/founders': 'For Founders',
+  '/roadmap': 'Roadmap',
+  '/share': 'Share',
+  '/validator': 'Idea Validator',
+  '/success-predictor': 'Startup Success Predictor',
+  '/research': 'Company Research',
+  '/research-hub': 'Research Hub',
+  '/admin': 'Admin',
+  '/verify-email': 'Verify your email',
+  '/explore': DEFAULT_TITLE,
+};
+
+function titleForPath(pathname: string): string {
+  const exact = EXACT[pathname];
+  if (exact) return exact === DEFAULT_TITLE ? exact : `${exact} — ${BRAND}`;
+
+  // Dynamic routes — match by prefix / pattern.
+  if (pathname.startsWith('/company/')) return `Company — ${BRAND}`;
+  if (pathname.startsWith('/share/company')) return `Share company — ${BRAND}`;
+  if (pathname.match(/^\/batch\/.+\/wrapped$/)) return `Batch Wrapped — ${BRAND}`;
+
+  // Unknown route — NotFoundPage sets its own title via Helmet, but provide
+  // a sensible default in case the title manager fires first.
+  return `Page not found — ${BRAND}`;
+}
+
+export function PageTitleManager() {
+  const location = useLocation();
+  React.useEffect(() => {
+    document.title = titleForPath(location.pathname);
+  }, [location.pathname]);
+  return null;
+}


### PR DESCRIPTION
## Summary

Closes #10.

Every page used to render the same stale \`<title>YC Company Explorer</title>\` — including the homepage's \`og:title\` and \`twitter:title\` that propagate to every social share. Confirmed via gstack QA: `$B js 'document.title'` returned the same value on \`/\`, \`/companies\`, \`/hiring\`, \`/validator\`, \`/analytics/batches\`, \`/predict\`, \`/founders\`.

## Approach

A single router-level \`PageTitleManager\` component listens to \`useLocation()\` and updates \`document.title\` on every navigation. Trade-off: one centralized file + one route→title map vs. 23 \`<Helmet>\` blocks scattered across page components. Centralized wins on maintainability — adding a new route = one line in the map.

## Per-route titles

| Route | Title |
| --- | --- |
| \`/\` | \`ExploreYC — explore the Y Combinator portfolio\` |
| \`/hiring\` | \`YC Hiring Board — ExploreYC\` |
| \`/hiring/analytics\` | \`Hiring Analytics — ExploreYC\` |
| \`/validator\` | \`Idea Validator — ExploreYC\` |
| \`/success-predictor\` | \`Startup Success Predictor — ExploreYC\` |
| \`/analytics/batches\` | \`Batch Analytics — ExploreYC\` |
| \`/founders\` | \`For Founders — ExploreYC\` |
| \`/funding\` | \`Funding — ExploreYC\` |
| \`/research\`, \`/research-hub\` | \`Company Research / Research Hub — ExploreYC\` |
| \`/company/:slug\` | \`Company — ExploreYC\` |
| \`/batch/:b/wrapped\` | \`Batch Wrapped — ExploreYC\` |
| (unknown) | \`Page not found — ExploreYC\` |

## Files changed

| File | What |
|------|------|
| \`frontend/src/components/PageTitleManager.tsx\` | New — route → title map + \`document.title\` setter |
| \`frontend/src/App.tsx\` | Mount \`<PageTitleManager />\` inside \`<BrowserRouter>\` (before AppProvider, so it doesn't wait for data load) |
| \`frontend/index.html\` | Replace \`YC Company Explorer\` in \`<title>\`, \`og:title\`, and \`twitter:title\` with the new ExploreYC default |

## Test plan

- [ ] Run \`cd frontend && npm run dev\`
- [ ] Visit \`/\` — tab title is \`ExploreYC — explore the Y Combinator portfolio\`
- [ ] Visit \`/validator\` — tab title is \`Idea Validator — ExploreYC\`
- [ ] Visit \`/analytics/batches\` — tab title is \`Batch Analytics — ExploreYC\`
- [ ] View source on \`/\` — \`<title>\`, \`og:title\`, \`twitter:title\` all say ExploreYC
- [ ] After deploy, share any URL on Twitter/LinkedIn — preview shows correct brand
- [ ] After deploy, \`curl -s https://exploreyc.com/ | grep title\` shows ExploreYC (this is what non-JS crawlers see)

## Follow-up worth doing separately

The static \`og:image\` at \`/og-image.png\` was likely designed with the old "YC Company Explorer" wordmark on it. Regenerating it with the ExploreYC brand is its own design task. Not blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)