### PR TITLE
Fix asymmetric embedding bug that destroyed validator relevance

### DIFF
--- a/backend/embedding_service.py
+++ b/backend/embedding_service.py
@@ -167,8 +167,15 @@ class EmbeddingService:
 
     def generate_embedding_for_idea(self, idea: str) -> List[float]:
         """
-        Generate embedding specifically for a startup idea
-        Adds context to improve matching quality
+        Generate embedding for a user-submitted startup idea.
+
+        MUST match how company descriptions are embedded in
+        scripts/generate_embeddings.py — that script calls
+        generate_embedding(search_text) directly, with no prefix. Any
+        asymmetry between the two pipelines (e.g. prefixing the user's
+        idea with "Startup idea: ") shifts the query embedding into a
+        different region of vector space than where company embeddings
+        live, which destroys cosine-similarity relevance ranking.
 
         Args:
             idea: The startup idea description
@@ -176,11 +183,7 @@ class EmbeddingService:
         Returns:
             Embedding vector
         """
-        # Add context to improve matching
-        # This helps the embedding understand it's a startup concept
-        enhanced_text = f"Startup idea: {idea}"
-
-        return self.generate_embedding(enhanced_text)
+        return self.generate_embedding(idea)
 
     def get_cache_stats(self) -> Dict[str, int]:
         """Get statistics about the cache"""


### PR DESCRIPTION
## Summary

The `/validator` page returns matches that don't actually relate to what the user typed. Root cause: **asymmetric embedding pipelines**.

- `scripts/generate_embeddings.py:95` embeds **company descriptions** as raw text, no prefix.
- `backend/embedding_service.py:181` embeds **user ideas** with `"Startup idea: "` prepended via `generate_embedding_for_idea()`.

That two-sided asymmetry pushed user queries into a different region of vector space than where company embeddings live, so cosine similarity rewarded "startup-y vibes" over actual topical overlap.

## Repro (against live `/api/validate-idea`)

Query: `"A marketplace for local farmers to sell fresh produce directly to restaurants in their city"`

Top matches returned **before this PR**:

```
42% — Swadesi Way: Healthy organic food that creates a positive impact
40% — Forge Rewards: Starbucks app for restaurants
40% — Instacart: Marketplace for grocery delivery and pickup
37% — garten: Creating workplace wellbeing.
37% — Trela: Your one-stop shop to eat well in Brazil
36% — Nextstore: Mobile optimized storefronts for Shopify
36% — Rebellyous Foods: Food manufacturing technology
34% — The Essential: E-commerce 2.0
33% — Sekilo: Poultry processing & supply chain for SME foodservice  ← closest actual match, ranked 9th
33% — Tiny: ERP for factories
```

The actually-closest YC company in the portfolio — *Sekilo* — ranks 9th at 33%, while semantically-unrelated companies (workplace wellbeing, Shopify storefronts, Starbucks-for-restaurants) all rank higher. Scores hover around 33-42%, artificially compressed because the query embedding lives in the wrong neighborhood.

## Fix

One-line behavior change in `embedding_service.py`: drop the prefix.

```diff
 def generate_embedding_for_idea(self, idea: str) -> List[float]:
-    enhanced_text = f"Startup idea: {idea}"
-    return self.generate_embedding(enhanced_text)
+    return self.generate_embedding(idea)
```

Now both sides use the same raw-text pipeline. Cosine similarity reflects actual semantic overlap.

**No re-embedding required.** Only the query-side embedding path changes. The 5,801+ existing company embeddings in Supabase are correct as-is.

I also added a defensive comment to `generate_embedding_for_idea` so the next person reading this code can't accidentally re-introduce the asymmetry.

## Expected impact

After deploy, the same query above should return matches in this neighborhood:
- B2B food supply chain companies (poultry, produce, restaurant procurement)
- Farm-to-table / farmer-direct platforms
- Restaurant marketplaces

…and similarity scores should rise meaningfully (the closest actual match should jump from ~33% to ~55-70%).

## Test plan

- [ ] Deploy to staging / preview
- [ ] Hit `/api/validate-idea` with the repro query — verify top 5 are topically relevant (B2B food, farm-to-restaurant)
- [ ] Hit it with 2-3 other ideas to spot-check
- [ ] Numbers in the UI may now read higher (50-70% for tight matches). Acceptable — they reflect actual similarity.

## Follow-up worth considering separately

The min-similarity threshold is currently `0.32` in `backend/main.py:986`. That made sense when embeddings were misaligned and even good matches scored low. After this fix, real matches will score 0.5+. Consider raising the threshold to ~0.4 so the user doesn't see weak matches as "competitors" — but I'd suggest deploying this fix first, observing the new score distribution, then tuning. Not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)