### PR TITLE
Fix /hiring/analytics: convert non-USD salaries to USD

### DIFF
--- a/backend/currency_utils.py
+++ b/backend/currency_utils.py
@@ -96,26 +96,137 @@ LOCATION_CURRENCY_MAP = {
     'Amsterdam': 'EUR',
     'Tokyo': 'JPY',
     'Sydney': 'AUD',
+    'Melbourne': 'AUD',
     'Toronto': 'CAD',
+    'Vancouver': 'CAD',
+    'Montreal': 'CAD',
     'Singapore': 'SGD',
     'Hong Kong': 'HKD',
     'Dubai': 'AED',
+    'Abu Dhabi': 'AED',
+
+    # Indian cities (expanded — many YC India hires are outside the big four)
     'Mumbai': 'INR',
     'Delhi': 'INR',
+    'New Delhi': 'INR',
     'Bangalore': 'INR',
+    'Bengaluru': 'INR',
     'Gurugram': 'INR',
+    'Gurgaon': 'INR',
+    'Noida': 'INR',
+    'Pune': 'INR',
+    'Hyderabad': 'INR',
+    'Chennai': 'INR',
+    'Kolkata': 'INR',
+    'Ahmedabad': 'INR',
+    'Jaipur': 'INR',
+    'Chandigarh': 'INR',
+    'Kochi': 'INR',
+    'Indore': 'INR',
+    'Surat': 'INR',
+    'Coimbatore': 'INR',
+    'Lucknow': 'INR',
+    'Bhubaneswar': 'INR',
+
     'São Paulo': 'BRL',
+    'Sao Paulo': 'BRL',
+    'Rio de Janeiro': 'BRL',
     'Mexico City': 'MXN',
     'Tel Aviv': 'ILS',
     'Moscow': 'RUB',
     'Istanbul': 'TRY',
     'Bangkok': 'THB',
     'Ho Chi Minh': 'VND',
+    'Hanoi': 'VND',
     'Manila': 'PHP',
     'Kuala Lumpur': 'MYR',
     'Jakarta': 'IDR',
     'Cape Town': 'ZAR',
+    'Johannesburg': 'ZAR',
     'Cairo': 'EGP',
+    'Lagos': 'NGN',
+    'Nairobi': 'KES',
+    'Seoul': 'KRW',
+    'Taipei': 'TWD',
+    'Karachi': 'PKR',
+    'Lahore': 'PKR',
+    'Islamabad': 'PKR',
+    'Dhaka': 'BDT',
+    'Buenos Aires': 'ARS',
+    'Santiago': 'CLP',
+    'Bogotá': 'COP',
+    'Bogota': 'COP',
+    'Lima': 'PEN',
+    'Warsaw': 'PLN',
+    'Prague': 'CZK',
+    'Zurich': 'CHF',
+    'Geneva': 'CHF',
+    'Stockholm': 'SEK',
+    'Copenhagen': 'DKK',
+    'Oslo': 'NOK',
+    'Auckland': 'NZD',
+    'Wellington': 'NZD',
+}
+
+
+# In-memory USD exchange rates.
+# Values are "1 unit of <CCY> in USD" — multiply a local-currency salary by
+# the rate to get USD. Snapshot rates (rounded), not live; intentional
+# trade-off so analytics aren't blocked on an FX API. Refresh every few
+# months if rates drift materially.
+EXCHANGE_RATES: Dict[str, float] = {
+    'USD': 1.0,
+    'EUR': 1.08,
+    'GBP': 1.27,
+    'CHF': 1.12,
+    'CAD': 0.74,
+    'AUD': 0.66,
+    'NZD': 0.61,
+    'SEK': 0.094,
+    'NOK': 0.092,
+    'DKK': 0.145,
+    'PLN': 0.25,
+    'CZK': 0.043,
+    'RUB': 0.011,
+    'UAH': 0.024,
+    'TRY': 0.029,
+
+    # Asia
+    'INR': 0.012,
+    'CNY': 0.14,
+    'JPY': 0.0067,
+    'KRW': 0.00073,
+    'HKD': 0.13,
+    'SGD': 0.74,
+    'TWD': 0.031,
+    'THB': 0.029,
+    'VND': 0.000040,
+    'PHP': 0.018,
+    'MYR': 0.22,
+    'IDR': 0.000064,
+    'PKR': 0.0036,
+    'BDT': 0.0084,
+
+    # Middle East
+    'AED': 0.27,
+    'SAR': 0.27,
+    'ILS': 0.27,
+    'QAR': 0.27,
+    'KWD': 3.25,
+
+    # Africa
+    'ZAR': 0.054,
+    'EGP': 0.020,
+    'NGN': 0.00065,
+    'KES': 0.0077,
+
+    # Latin America
+    'MXN': 0.058,
+    'BRL': 0.20,
+    'ARS': 0.0010,
+    'CLP': 0.0011,
+    'COP': 0.00024,
+    'PEN': 0.27,
 }
 
 
@@ -248,3 +359,38 @@ CURRENCY_SYMBOLS = {
 def get_currency_symbol(currency: str) -> str:
     """Get the currency symbol for a currency code"""
     return CURRENCY_SYMBOLS.get(currency, currency)
+
+
+def convert_to_usd(amount: Optional[float], currency: Optional[str]) -> Optional[float]:
+    """Convert an amount from `currency` to USD using static EXCHANGE_RATES."""
+    if amount is None:
+        return None
+    if not currency:
+        return amount
+    rate = EXCHANGE_RATES.get(currency.upper())
+    if rate is None:
+        # Unknown currency — return as-is rather than zeroing it out.
+        return amount
+    return amount * rate
+
+
+def job_salary_to_usd(job: Dict, company: Optional[Dict] = None) -> Optional[float]:
+    """Get a job's mid-point salary in USD, or None if no salary data.
+
+    Combines currency inference (from job/company location) with conversion,
+    so analytics can include non-USD jobs after normalizing.
+    """
+    min_sal = job.get("salary_min")
+    max_sal = job.get("salary_max")
+
+    if min_sal and max_sal:
+        local = (min_sal + max_sal) / 2
+    elif min_sal:
+        local = min_sal
+    elif max_sal:
+        local = max_sal
+    else:
+        return None
+
+    currency = infer_currency_from_job(job, company)
+    return convert_to_usd(local, currency)

--- a/backend/hiring_analytics.py
+++ b/backend/hiring_analytics.py
@@ -9,11 +9,18 @@ from datetime import datetime, timedelta, timezone
 from statistics import median, stdev
 
 try:
-    from currency_utils import infer_currency_from_job
+    from currency_utils import infer_currency_from_job, job_salary_to_usd
 except ImportError:
     # Fallback if currency_utils not available
     def infer_currency_from_job(job, company=None):
         return job.get("salary_currency", "USD")
+
+    def job_salary_to_usd(job, company=None):
+        min_sal = job.get("salary_min")
+        max_sal = job.get("salary_max")
+        if min_sal and max_sal:
+            return (min_sal + max_sal) / 2
+        return min_sal or max_sal or None
 
 logger = logging.getLogger(__name__)
 
@@ -84,43 +91,27 @@ class HiringAnalyticsCompute:
             return {}
 
     def _compute_avg_salary(self) -> Optional[float]:
-        """Compute average salary across all USD jobs with salary data"""
+        """Compute average salary in USD across all jobs with salary data.
+
+        Non-USD salaries are converted to USD via static rates (see
+        currency_utils.EXCHANGE_RATES) rather than dropped — otherwise jobs in
+        e.g. INR were either skipped (analytics) or treated as USD (service
+        layer), both wrong.
+        """
         salaries = []
         for job in self.jobs:
-            # Only include USD salaries for meaningful average
-            # Infer currency if not explicitly set
-            currency = infer_currency_from_job(job, self.company_map.get(job.get("company_id")))
-            if currency != "USD":
-                continue
-
-            min_sal = job.get("salary_min")
-            max_sal = job.get("salary_max")
-            if min_sal and max_sal:
-                salaries.append((min_sal + max_sal) / 2)
-            elif min_sal:
-                salaries.append(min_sal)
-            elif max_sal:
-                salaries.append(max_sal)
+            usd = job_salary_to_usd(job, self.company_map.get(job.get("company_id")))
+            if usd is not None:
+                salaries.append(usd)
         return round(sum(salaries) / len(salaries)) if salaries else None
 
     def _compute_median_salary(self) -> Optional[float]:
-        """Compute median salary for USD jobs"""
+        """Compute median salary (USD-normalized) across all jobs with salary data."""
         salaries = []
         for job in self.jobs:
-            # Only include USD salaries for meaningful median
-            # Infer currency if not explicitly set
-            currency = infer_currency_from_job(job, self.company_map.get(job.get("company_id")))
-            if currency != "USD":
-                continue
-
-            min_sal = job.get("salary_min")
-            max_sal = job.get("salary_max")
-            if min_sal and max_sal:
-                salaries.append((min_sal + max_sal) / 2)
-            elif min_sal:
-                salaries.append(min_sal)
-            elif max_sal:
-                salaries.append(max_sal)
+            usd = job_salary_to_usd(job, self.company_map.get(job.get("company_id")))
+            if usd is not None:
+                salaries.append(usd)
         return round(median(salaries)) if salaries else None
 
     def _count_jobs_with_salary(self) -> int:
@@ -138,14 +129,12 @@ class HiringAnalyticsCompute:
         return round((self._count_jobs_with_salary() / len(self.jobs)) * 100, 1)
 
     def _salary_by_role(self) -> List[Dict[str, Any]]:
-        """Get salary statistics broken down by role (USD only)"""
+        """Get salary statistics broken down by role (USD-normalized)"""
         role_salaries: Dict[str, List[float]] = {}
 
         for job in self.jobs:
-            # Only include USD salaries
-            # Infer currency if not explicitly set
-            currency = infer_currency_from_job(job, self.company_map.get(job.get("company_id")))
-            if currency != "USD":
+            usd = job_salary_to_usd(job, self.company_map.get(job.get("company_id")))
+            if usd is None:
                 continue
 
             role = job.get("pretty_role", "Other")
@@ -154,21 +143,9 @@ class HiringAnalyticsCompute:
                 role = role[0] if role else "Other"
             role = str(role) if role else "Other"
 
-            min_sal = job.get("salary_min")
-            max_sal = job.get("salary_max")
-
-            if min_sal or max_sal:
-                if role not in role_salaries:
-                    role_salaries[role] = []
-
-                if min_sal and max_sal:
-                    avg = (min_sal + max_sal) / 2
-                elif min_sal:
-                    avg = min_sal
-                else:
-                    avg = max_sal
-
-                role_salaries[role].append(avg)
+            if role not in role_salaries:
+                role_salaries[role] = []
+            role_salaries[role].append(usd)
 
         result = []
         for role, salaries in role_salaries.items():
@@ -469,36 +446,24 @@ class HiringAnalyticsCompute:
         return sorted(result, key=lambda x: x["count"], reverse=True)[:15]
 
     def _top_paying_companies(self, limit: int = 10) -> List[Dict[str, Any]]:
-        """Get companies with highest average salary (USD only)"""
+        """Get companies with highest average salary (USD-normalized)"""
         company_salaries: Dict[int, List[float]] = {}
 
         for job in self.jobs:
-            # Only include USD salaries
-            # Infer currency if not explicitly set
-            currency = infer_currency_from_job(job, self.company_map.get(job.get("company_id")))
-            if currency != "USD":
-                continue
-
             company_id = job.get("company_id")
             # Ensure company_id is not a list
             if isinstance(company_id, list):
                 company_id = company_id[0] if company_id else None
+            if company_id is None:
+                continue
 
-            min_sal = job.get("salary_min")
-            max_sal = job.get("salary_max")
+            usd = job_salary_to_usd(job, self.company_map.get(company_id))
+            if usd is None:
+                continue
 
-            if (min_sal or max_sal) and company_id is not None:
-                if company_id not in company_salaries:
-                    company_salaries[company_id] = []
-
-                if min_sal and max_sal:
-                    avg = (min_sal + max_sal) / 2
-                elif min_sal:
-                    avg = min_sal
-                else:
-                    avg = max_sal
-
-                company_salaries[company_id].append(avg)
+            if company_id not in company_salaries:
+                company_salaries[company_id] = []
+            company_salaries[company_id].append(usd)
 
         result = []
         for company_id, salaries in company_salaries.items():
@@ -518,14 +483,12 @@ class HiringAnalyticsCompute:
         return sorted(result, key=lambda x: x["avgSalary"], reverse=True)[:limit]
 
     def _highest_paying_roles(self, limit: int = 10) -> List[Dict[str, Any]]:
-        """Get roles with highest average salary (USD only)"""
+        """Get roles with highest average salary (USD-normalized)"""
         role_salaries: Dict[str, List[float]] = {}
 
         for job in self.jobs:
-            # Only include USD salaries
-            # Infer currency if not explicitly set
-            currency = infer_currency_from_job(job, self.company_map.get(job.get("company_id")))
-            if currency != "USD":
+            usd = job_salary_to_usd(job, self.company_map.get(job.get("company_id")))
+            if usd is None:
                 continue
 
             role = job.get("pretty_role", "Other")
@@ -534,21 +497,9 @@ class HiringAnalyticsCompute:
                 role = role[0] if role else "Other"
             role = str(role) if role else "Other"
 
-            min_sal = job.get("salary_min")
-            max_sal = job.get("salary_max")
-
-            if min_sal or max_sal:
-                if role not in role_salaries:
-                    role_salaries[role] = []
-
-                if min_sal and max_sal:
-                    avg = (min_sal + max_sal) / 2
-                elif min_sal:
-                    avg = min_sal
-                else:
-                    avg = max_sal
-
-                role_salaries[role].append(avg)
+            if role not in role_salaries:
+                role_salaries[role] = []
+            role_salaries[role].append(usd)
 
         result = []
         for role, salaries in role_salaries.items():

--- a/backend/hiring_service.py
+++ b/backend/hiring_service.py
@@ -14,6 +14,16 @@ from datetime import datetime, timedelta
 import json
 from hiring_analytics import HiringAnalyticsCompute
 
+try:
+    from currency_utils import job_salary_to_usd
+except ImportError:
+    def job_salary_to_usd(job, company=None):
+        min_sal = job.get("salary_min")
+        max_sal = job.get("salary_max")
+        if min_sal and max_sal:
+            return (min_sal + max_sal) / 2
+        return min_sal or max_sal or None
+
 logger = logging.getLogger(__name__)
 
 WORK_AT_STARTUP_API = "https://www.workatastartup.com/api/latest/companies"
@@ -127,20 +137,28 @@ class HiringBoardCache:
         return count
 
     def _calculate_avg_salary(self) -> Optional[float]:
-        """Calculate average salary"""
+        """Average salary, currency-normalized to USD.
+
+        Without conversion, INR/EUR/etc. amounts were summed with USD as
+        raw numbers, badly inflating the average (a 50,000 INR salary
+        being counted as $50,000).
+        """
+        company_map: Dict[Any, Dict[str, Any]] = {}
+        for c in self.companies:
+            cid = c.get("id")
+            if isinstance(cid, list):
+                cid = cid[0] if cid else None
+            if cid is not None:
+                company_map[cid] = c
+
         salaries = []
-
         for job in self.jobs:
-            min_salary = job.get("salary_min")
-            max_salary = job.get("salary_max")
-
-            if min_salary and max_salary:
-                avg = (min_salary + max_salary) / 2
-                salaries.append(avg)
-            elif min_salary:
-                salaries.append(min_salary)
-            elif max_salary:
-                salaries.append(max_salary)
+            cid = job.get("company_id")
+            if isinstance(cid, list):
+                cid = cid[0] if cid else None
+            usd = job_salary_to_usd(job, company_map.get(cid))
+            if usd is not None:
+                salaries.append(usd)
 
         if salaries:
             return sum(salaries) / len(salaries)


### PR DESCRIPTION
## Summary

Reported live: the `/hiring/analytics` page was counting INR / EUR / GBP salaries as raw USD numbers, badly skewing averages. Two layers were broken:

- **`hiring_analytics.py`** filtered non-USD jobs out entirely (5 places: `_compute_avg_salary`, `_compute_median_salary`, `_salary_by_role`, `_top_paying_companies`, `_highest_paying_roles`). So a Bangalore role at ₹20L ($24K USD) wasn't inflating the average — but it also wasn't being counted, which underrepresents the global picture.
- **`hiring_service.py:_calculate_avg_salary`** had **no currency check at all** — it just averaged raw `salary_min`/`salary_max`, so a ₹20L INR salary was added to the pool as if it were $2,000,000. This is what produced the inflated `avgSalary` in the stats payload.

There was a secondary bug too: `infer_currency_from_location` only knew four Indian cities (Mumbai / Delhi / Bangalore / Gurugram). Jobs in Pune, Chennai, Hyderabad, Noida, Ahmedabad, etc. silently defaulted to USD.

## Changes

- `backend/currency_utils.py`
  - Added `EXCHANGE_RATES` table (in-memory snapshot — no live FX API, refresh every few months if rates drift)
  - Added `convert_to_usd(amount, currency)` 
  - Added `job_salary_to_usd(job, company)` — combines currency inference + conversion in one helper
  - Expanded `LOCATION_CURRENCY_MAP` with ~15 Indian cities (Pune, Chennai, Hyderabad, Noida, Bengaluru, Ahmedabad, …) plus Seoul, Taipei, Karachi, Lahore, Dhaka, Buenos Aires, Santiago, Bogotá, Warsaw, Prague, Zurich, Stockholm, Copenhagen, Oslo, Auckland, Cape Town, Johannesburg, Lagos, Nairobi, Hanoi, São Paulo (with ASCII alias), Rio de Janeiro, and a few others

- `backend/hiring_analytics.py` — replaced 5 `if currency != 'USD': continue` blocks with `job_salary_to_usd()` (converts instead of drops)

- `backend/hiring_service.py` — `_calculate_avg_salary` now routes through `job_salary_to_usd()` instead of summing raw values

## Verification

Sanity-tested the conversion + analytics + service layer with mixed-currency jobs:

```
San Francisco, CA  150K-200K USD  -> $175,000 USD
Bangalore, India   1.5M-2.5M INR  -> $ 24,000 USD   (was: silently dropped from analytics)
Pune                 800K-1.2M INR  -> $ 12,000 USD   (was: counted as $1M USD before)
London, UK            70K-90K GBP  -> $101,600 USD
Berlin, Germany       60K-80K EUR  -> $ 75,600 USD
Tokyo                  6M-9M JPY   -> $ 50,250 USD

Analytics avgSalary  : $70,333  (was: $175,000 — only SF job counted)
Service avgSalary    : $70,333  (was: ~$1.06M — INR counted as USD)
Both layers now agree.
```

## Test plan

- [ ] Trigger an analytics recompute (admin endpoint or wait for next cron)
- [ ] Verify `/hiring/analytics` `avgSalary` drops back to a sane range (~$120-180K)
- [ ] Verify top paying companies no longer include Indian companies at fake $1M+ averages
- [ ] Verify Indian / European jobs now contribute to `salaryByRole` and `highestPayingRoles` instead of being silently dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)