### PR TITLE
Fix export gate bypasses in CommandPalette and Dashboard

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -5,7 +5,6 @@ import {
   Search,
   BarChart3,
   Map,
-  Download,
   ExternalLink,
   Lightbulb,
   Sparkles,
@@ -13,9 +12,9 @@ import {
   Wrench,
   BookOpen,
   Briefcase,
+  Database,
 } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
-import { apiClient } from '../lib/api';
 import { getSecondMostRecentBatch, batchToShortFormat } from '../lib/batchUtils';
 
 interface CommandPaletteProps {
@@ -127,26 +126,12 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
       },
     },
     {
-      id: 'export-json',
+      id: 'database-export',
       type: 'action',
-      label: 'Export as JSON',
-      subtitle: 'Download companies data',
-      icon: <Download className="h-4 w-4" />,
-      action: () => {
-        apiClient.exportJSON({});
-        onClose();
-      },
-    },
-    {
-      id: 'export-csv',
-      type: 'action',
-      label: 'Export as CSV',
-      subtitle: 'Download companies data',
-      icon: <Download className="h-4 w-4" />,
-      action: () => {
-        apiClient.exportCSV({});
-        onClose();
-      },
+      label: 'Database & Export',
+      subtitle: 'Browse all companies and export CSV / JSON',
+      icon: <Database className="h-4 w-4" />,
+      action: () => handleNavigation('/database?export=open'),
     },
   ];
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { Download } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
-import { Button } from '../components/ui/button';
 import { StatsCards } from '../components/StatsCards';
 import { StatsCharts } from '../components/StatsCharts';
 import { ScraperPanel } from '../components/ScraperPanel';
@@ -36,14 +34,6 @@ export function Dashboard() {
     setRefreshTrigger((prev) => prev + 1);
   };
 
-  const handleExport = (format: 'json' | 'csv') => {
-    if (format === 'json') {
-      apiClient.exportJSON({});
-    } else {
-      apiClient.exportCSV({});
-    }
-  };
-
   const topBatch = stats?.by_batch
     ? Object.entries(stats.by_batch)
         .sort(([, a], [, b]) => b - a)[0]
@@ -72,26 +62,7 @@ export function Dashboard() {
               </p>
             </div>
 
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => handleExport('json')}
-                className="bg-white text-[#FF6600] hover:bg-gray-100"
-              >
-                <Download className="h-4 w-4 mr-2" />
-                Export JSON
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => handleExport('csv')}
-                className="bg-white text-[#FF6600] hover:bg-gray-100"
-              >
-                <Download className="h-4 w-4 mr-2" />
-                Export CSV
-              </Button>
-            </div>
+            <div className="flex gap-2" />
           </div>
         </div>
       </motion.header>

--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { Helmet } from 'react-helmet-async';
 import { useQuery } from '@tanstack/react-query';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams, useNavigate } from 'react-router-dom';
 import {
   useReactTable,
   getCoreRowModel,
@@ -452,6 +452,8 @@ const item = {
 
 export function DatabasePage() {
   const { stats } = useApp();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
 
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -463,6 +465,14 @@ export function DatabasePage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [exportOpen, setExportOpen] = useState(false);
+
+  // Auto-open export modal when navigated here with ?export=open (e.g. from command palette)
+  useEffect(() => {
+    if (searchParams.get('export') === 'open') {
+      setExportOpen(true);
+      navigate('/database', { replace: true });
+    }
+  }, [searchParams, navigate]);
 
   // Debounce search input
   useEffect(() => {


### PR DESCRIPTION
## What

Closes two export gate bypasses that allowed downloading CSV/JSON without starring GitHub.

## Root cause

The `CommandPalette` (⌘K) had two entries — "Export as JSON" and "Export as CSV" — that called `apiClient.exportCSV/JSON()` directly, completely skipping the `ExportModal` star gate. The legacy `Dashboard.tsx` had the same ungated buttons.

## Changes

- **`CommandPalette.tsx`**: Replaced the two direct export commands with a single "Database & Export" entry that navigates to `/database?export=open`
- **`DatabasePage.tsx`**: Reads `?export=open` on mount and auto-opens the gated `ExportModal`, then clears the param from the URL
- **`Dashboard.tsx`**: Removed ungated "Export JSON" / "Export CSV" buttons

---
_Generated by [Claude Code](https://claude.ai/code/session_013XsZSM7E8ShnL5hohYaLWu)_