### PR TITLE
Fix sticky column bleed-through when scrolling table on mobile

### DIFF
--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -50,6 +50,12 @@ import { Input } from '../components/ui/input';
 
 const PAGE_SIZE = 50;
 
+const mobileHiddenColumns = new Set([
+  'subindustry', 'all_locations', 'team_size', 'stage',
+  'nonprofit', 'funding_last_round_name', 'employee_count',
+  'employee_growth_6m', 'website',
+]);
+
 const GITHUB_REPO = 'konstantinmb/exploreyc';
 const GITHUB_URL = `https://github.com/${GITHUB_REPO}`;
 
@@ -565,7 +571,7 @@ export function DatabasePage() {
   const totalBatches = stats?.by_batch ? Object.keys(stats.by_batch).length : 0;
 
   return (
-    <div className="relative min-h-screen bg-background">
+    <div className="relative min-h-screen bg-background overflow-x-hidden">
       <Helmet>
         <title>YC Company Database | ExploreYC</title>
         <meta name="description" content="Browse and export all Y Combinator companies in a sortable, filterable table." />
@@ -660,26 +666,27 @@ export function DatabasePage() {
         >
           <HackerCard className="p-3" glowColor="orange">
             <div className="flex flex-wrap gap-2 items-center">
-              <SlidersHorizontal className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
-
-              {/* Search */}
-              <div className="relative flex-1 min-w-[180px] max-w-xs">
-                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
-                <Input
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Search companies..."
-                  className="pl-8 h-8 text-xs font-mono bg-background/50"
-                />
-                {search && (
-                  <button
-                    onClick={() => setSearch('')}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
-                )}
-              </div>
+              {/* Search group: full-width on mobile, constrained on sm+ */}
+              <div className="flex items-center gap-2 w-full sm:w-auto sm:flex-1 sm:max-w-xs min-w-0">
+                <SlidersHorizontal className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
+                <div className="relative flex-1 min-w-0">
+                  <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+                  <Input
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search companies..."
+                    className="pl-8 h-8 text-xs font-mono bg-background/50 w-full"
+                  />
+                  {search && (
+                    <button
+                      onClick={() => setSearch('')}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  )}
+                </div>
+              </div>{/* end search group */}
 
               {/* Batch */}
               <select
@@ -775,7 +782,7 @@ export function DatabasePage() {
               className="overflow-x-auto"
               style={{ WebkitOverflowScrolling: 'touch' }}
             >
-              <table className="w-full text-xs font-mono border-collapse" style={{ minWidth: '1400px' }}>
+              <table className="w-full text-xs font-mono border-collapse">
                 <thead>
                   {table.getHeaderGroups().map((headerGroup) => (
                     <tr key={headerGroup.id} className="border-b border-border bg-muted/30">
@@ -787,7 +794,7 @@ export function DatabasePage() {
                             key={header.id}
                             className={`px-3 py-2.5 text-left text-[10px] font-semibold text-muted-foreground uppercase tracking-wider whitespace-nowrap select-none ${
                               canSort ? 'cursor-pointer hover:text-foreground transition-colors' : ''
-                            } ${i === 1 ? 'sticky left-[44px] z-10 bg-muted/30' : ''} ${i === 0 ? 'sticky left-0 z-10 bg-muted/30' : ''}`}
+                            } ${i === 1 ? 'sticky left-[44px] z-10 bg-muted/30' : ''} ${i === 0 ? 'sticky left-0 z-10 bg-muted/30' : ''} ${mobileHiddenColumns.has(header.id) ? 'hidden md:table-cell' : ''}`}
                             style={{ width: header.getSize(), minWidth: header.getSize() }}
                             onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
                           >
@@ -834,8 +841,8 @@ export function DatabasePage() {
                           <td
                             key={cell.id}
                             className={`px-3 py-2 ${
-                              cellIdx === 0 ? 'sticky left-0 z-10 bg-background' : ''
-                            } ${cellIdx === 1 ? 'sticky left-[44px] z-10 bg-background' : ''}`}
+                              mobileHiddenColumns.has(cell.column.id) ? 'hidden md:table-cell' : ''
+                            } ${cellIdx === 0 ? `sticky left-0 z-10 ${rowIdx % 2 === 1 ? 'bg-muted/5' : 'bg-background'}` : ''} ${cellIdx === 1 ? `sticky left-[44px] z-10 ${rowIdx % 2 === 1 ? 'bg-muted/5' : 'bg-background'}` : ''}`}
                             style={{ width: cell.column.getSize(), minWidth: cell.column.getSize() }}
                           >
                             {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -849,8 +856,8 @@ export function DatabasePage() {
             </div>
 
             {/* Pagination */}
-            <div className="flex items-center justify-between px-4 py-3 border-t border-border bg-muted/10">
-              <div className="text-xs text-muted-foreground font-mono">
+            <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-3 border-t border-border bg-muted/10">
+              <div className="hidden sm:block text-xs text-muted-foreground font-mono">
                 {total > 0 && (
                   <>
                     Showing{' '}

--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -782,7 +782,7 @@ export function DatabasePage() {
               className="overflow-x-auto"
               style={{ WebkitOverflowScrolling: 'touch' }}
             >
-              <table className="w-full text-xs font-mono border-collapse">
+              <table className="w-full text-xs font-mono border-collapse" style={{ minWidth: 'max-content' }}>
                 <thead>
                   {table.getHeaderGroups().map((headerGroup) => (
                     <tr key={headerGroup.id} className="border-b border-border bg-muted/30">
@@ -794,7 +794,7 @@ export function DatabasePage() {
                             key={header.id}
                             className={`px-3 py-2.5 text-left text-[10px] font-semibold text-muted-foreground uppercase tracking-wider whitespace-nowrap select-none ${
                               canSort ? 'cursor-pointer hover:text-foreground transition-colors' : ''
-                            } ${i === 1 ? 'sticky left-[44px] z-10 bg-muted/30' : ''} ${i === 0 ? 'sticky left-0 z-10 bg-muted/30' : ''} ${mobileHiddenColumns.has(header.id) ? 'hidden md:table-cell' : ''}`}
+                            } ${i === 1 ? 'sticky left-[44px] z-10 bg-background border-r border-border/40' : ''} ${i === 0 ? 'sticky left-0 z-10 bg-background' : ''} ${mobileHiddenColumns.has(header.id) ? 'hidden md:table-cell' : ''}`}
                             style={{ width: header.getSize(), minWidth: header.getSize() }}
                             onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
                           >
@@ -842,7 +842,7 @@ export function DatabasePage() {
                             key={cell.id}
                             className={`px-3 py-2 ${
                               mobileHiddenColumns.has(cell.column.id) ? 'hidden md:table-cell' : ''
-                            } ${cellIdx === 0 ? `sticky left-0 z-10 ${rowIdx % 2 === 1 ? 'bg-muted/5' : 'bg-background'}` : ''} ${cellIdx === 1 ? `sticky left-[44px] z-10 ${rowIdx % 2 === 1 ? 'bg-muted/5' : 'bg-background'}` : ''}`}
+                            } ${cellIdx === 0 ? 'sticky left-0 z-10 bg-background' : ''} ${cellIdx === 1 ? 'sticky left-[44px] z-10 bg-background border-r border-border/40' : ''}`}
                             style={{ width: cell.column.getSize(), minWidth: cell.column.getSize() }}
                           >
                             {flexRender(cell.column.columnDef.cell, cell.getContext())}


### PR DESCRIPTION
## Summary

Two bugs introduced in PR #23 caused content from scrolling columns to visually bleed through the sticky `#` and Company columns when scrolling horizontally on mobile.

**Root cause 1 (alternating row bug — primary):** Sticky `<td>` cells on odd rows were given `bg-muted/5` (5% opacity), making them nearly transparent. Scrolling columns were passing behind the sticky column as intended, but showing through the transparent cell background. Every other row appeared broken. Fixed by reverting sticky cells to always use `bg-background` (fully opaque).

**Root cause 2 (header):** Sticky `<th>` cells used `bg-muted/30` (30% opacity), same class as the header row tint. Changed to `bg-background` so the sticky header cells are also fully opaque when other header cells scroll under them.

**Root cause 3 (table compression):** Removing the table `minWidth` in PR #23 left only `w-full`, which forced the table to 343px on mobile. `table-layout: auto` ignores cell-level `minWidth` hints when the table is width-constrained, compressing all columns. Fixed with `minWidth: 'max-content'` — table is at least as wide as its visible columns require (~942px on mobile, ~1400px on desktop), while still filling wider containers via `w-full`.

**Visual polish:** Added a subtle `border-r border-border/40` to the Company column to visually delineate the sticky area from the scrolling content.

---
_Generated by [Claude Code](https://claude.ai/code/session_013XsZSM7E8ShnL5hohYaLWu)_