### PR TITLE
Fix sticky column bleed-through when scrolling table on mobile

### DIFF
--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -908,7 +908,7 @@ export function DatabasePage() {
               className="overflow-x-auto"
               style={{ WebkitOverflowScrolling: 'touch' }}
             >
-              <table className="w-full text-xs font-mono border-collapse">
+              <table className="w-full text-xs font-mono border-collapse" style={{ minWidth: 'max-content' }}>
                 <thead>
                   {table.getHeaderGroups().map((headerGroup) => (
                     <tr key={headerGroup.id} className="border-b border-border bg-muted/30">
@@ -920,7 +920,7 @@ export function DatabasePage() {
                             key={header.id}
                             className={`px-3 py-2.5 text-left text-[10px] font-semibold text-muted-foreground uppercase tracking-wider whitespace-nowrap select-none ${
                               canSort ? 'cursor-pointer hover:text-foreground transition-colors' : ''
-                            } ${i === 1 ? 'sticky left-[44px] z-10 bg-muted/30' : ''} ${i === 0 ? 'sticky left-0 z-10 bg-muted/30' : ''} ${mobileHiddenColumns.has(header.id) ? 'hidden md:table-cell' : ''}`}
+                            } ${i === 1 ? 'sticky left-[44px] z-10 bg-background border-r border-border/40' : ''} ${i === 0 ? 'sticky left-0 z-10 bg-background' : ''} ${mobileHiddenColumns.has(header.id) ? 'hidden md:table-cell' : ''}`}
                             style={{ width: header.getSize(), minWidth: header.getSize() }}
                             onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
                           >
@@ -968,7 +968,7 @@ export function DatabasePage() {
                             key={cell.id}
                             className={`px-3 py-2 ${
                               mobileHiddenColumns.has(cell.column.id) ? 'hidden md:table-cell' : ''
-                            } ${cellIdx === 0 ? `sticky left-0 z-10 ${rowIdx % 2 === 1 ? 'bg-muted/5' : 'bg-background'}` : ''} ${cellIdx === 1 ? `sticky left-[44px] z-10 ${rowIdx % 2 === 1 ? 'bg-muted/5' : 'bg-background'}` : ''}`}
+                            } ${cellIdx === 0 ? 'sticky left-0 z-10 bg-background' : ''} ${cellIdx === 1 ? 'sticky left-[44px] z-10 bg-background border-r border-border/40' : ''}`}
                             style={{ width: cell.column.getSize(), minWidth: cell.column.getSize() }}
                           >
                             {flexRender(cell.column.columnDef.cell, cell.getContext())}


### PR DESCRIPTION
## Summary

Fixes the visual glitch where batch info, status badges, and industry text bleed through the sticky `#` and Company columns when scrolling the table horizontally on mobile.

**Root cause 1 — alternating row transparency (primary bug):** Sticky `<td>` cells on odd rows were set to `bg-muted/5` (5% opacity) in an earlier PR attempting to match the alternating row tint. At 5% opacity the cell is nearly transparent — scrolling columns pass behind it but are fully visible through it. Every other row was broken. Fixed by reverting sticky cells to always use `bg-background` (fully opaque).

**Root cause 2 — header transparency:** Sticky `<th>` cells used `bg-muted/30` (30% opacity). Changed to `bg-background` so the sticky header cells are opaque when other header cells scroll under them.

**Root cause 3 — table compression on mobile:** Without a `minWidth` on the table element, `w-full` collapses the table to 343px on mobile. `table-layout: auto` ignores cell-level `minWidth` hints when the table itself is constrained, compressing all columns into the viewport. Fixed with `minWidth: 'max-content'` — the table is at least as wide as its visible column sizes require (~942px on mobile with 9 hidden columns, ~1400px on desktop).

**Polish:** Added a subtle `border-r border-border/40` on the Company column to visually delineate the sticky area from scrolling content.

---
_Generated by [Claude Code](https://claude.ai/code/session_013XsZSM7E8ShnL5hohYaLWu)_