### PR TITLE
Make Company column scrollable on mobile; only # stays sticky

### DIFF
--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -920,7 +920,7 @@ export function DatabasePage() {
                             key={header.id}
                             className={`px-3 py-2.5 text-left text-[10px] font-semibold text-muted-foreground uppercase tracking-wider whitespace-nowrap select-none ${
                               canSort ? 'cursor-pointer hover:text-foreground transition-colors' : ''
-                            } ${i === 1 ? 'sticky left-[44px] z-10 bg-background border-r border-border/40' : ''} ${i === 0 ? 'sticky left-0 z-10 bg-background' : ''} ${mobileHiddenColumns.has(header.id) ? 'hidden md:table-cell' : ''}`}
+                            } ${i === 0 ? 'sticky left-0 z-10 bg-background border-r border-border/40' : ''} ${mobileHiddenColumns.has(header.id) ? 'hidden md:table-cell' : ''}`}
                             style={{ width: header.getSize(), minWidth: header.getSize() }}
                             onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
                           >
@@ -968,7 +968,7 @@ export function DatabasePage() {
                             key={cell.id}
                             className={`px-3 py-2 ${
                               mobileHiddenColumns.has(cell.column.id) ? 'hidden md:table-cell' : ''
-                            } ${cellIdx === 0 ? 'sticky left-0 z-10 bg-background' : ''} ${cellIdx === 1 ? 'sticky left-[44px] z-10 bg-background border-r border-border/40' : ''}`}
+                            } ${cellIdx === 0 ? 'sticky left-0 z-10 bg-background border-r border-border/40' : ''}`}
                             style={{ width: cell.column.getSize(), minWidth: cell.column.getSize() }}
                           >
                             {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -908,7 +908,7 @@ export function DatabasePage() {
               className="overflow-x-auto"
               style={{ WebkitOverflowScrolling: 'touch' }}
             >
-              <table className="w-full text-xs font-mono border-collapse">
+              <table className="w-full text-xs font-mono border-collapse" style={{ minWidth: 'max-content' }}>
                 <thead>
                   {table.getHeaderGroups().map((headerGroup) => (
                     <tr key={headerGroup.id} className="border-b border-border bg-muted/30">
@@ -920,7 +920,7 @@ export function DatabasePage() {
                             key={header.id}
                             className={`px-3 py-2.5 text-left text-[10px] font-semibold text-muted-foreground uppercase tracking-wider whitespace-nowrap select-none ${
                               canSort ? 'cursor-pointer hover:text-foreground transition-colors' : ''
-                            } ${i === 1 ? 'sticky left-[44px] z-10 bg-muted/30' : ''} ${i === 0 ? 'sticky left-0 z-10 bg-muted/30' : ''} ${mobileHiddenColumns.has(header.id) ? 'hidden md:table-cell' : ''}`}
+                            } ${i === 1 ? 'sticky left-[44px] z-10 bg-background border-r border-border/40' : ''} ${i === 0 ? 'sticky left-0 z-10 bg-background' : ''} ${mobileHiddenColumns.has(header.id) ? 'hidden md:table-cell' : ''}`}
                             style={{ width: header.getSize(), minWidth: header.getSize() }}
                             onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
                           >
@@ -968,7 +968,7 @@ export function DatabasePage() {
                             key={cell.id}
                             className={`px-3 py-2 ${
                               mobileHiddenColumns.has(cell.column.id) ? 'hidden md:table-cell' : ''
-                            } ${cellIdx === 0 ? `sticky left-0 z-10 ${rowIdx % 2 === 1 ? 'bg-muted/5' : 'bg-background'}` : ''} ${cellIdx === 1 ? `sticky left-[44px] z-10 ${rowIdx % 2 === 1 ? 'bg-muted/5' : 'bg-background'}` : ''}`}
+                            } ${cellIdx === 0 ? 'sticky left-0 z-10 bg-background' : ''} ${cellIdx === 1 ? 'sticky left-[44px] z-10 bg-background border-r border-border/40' : ''}`}
                             style={{ width: cell.column.getSize(), minWidth: cell.column.getSize() }}
                           >
                             {flexRender(cell.column.columnDef.cell, cell.getContext())}


### PR DESCRIPTION
## Summary

The Company column (220px) and `#` column (44px) were both sticky, consuming 264px of a 375px mobile viewport — 70% of the screen — leaving only ~111px of visible area for the scrolling columns.

Removed sticky positioning from the Company column so it scrolls freely with the rest of the table. The `#` column (44px) remains sticky at `left-0` to provide row numbering context with negligible space cost. Moved the `border-r` separator to the `#` column so the sticky boundary is still visually indicated.

---
_Generated by [Claude Code](https://claude.ai/code/session_013XsZSM7E8ShnL5hohYaLWu)_