### PR TITLE
Make Company column scrollable; only # stays sticky on mobile

### DIFF
--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -920,7 +920,7 @@ export function DatabasePage() {
                             key={header.id}
                             className={`px-3 py-2.5 text-left text-[10px] font-semibold text-muted-foreground uppercase tracking-wider whitespace-nowrap select-none ${
                               canSort ? 'cursor-pointer hover:text-foreground transition-colors' : ''
-                            } ${i === 1 ? 'sticky left-[44px] z-10 bg-background border-r border-border/40' : ''} ${i === 0 ? 'sticky left-0 z-10 bg-background' : ''} ${mobileHiddenColumns.has(header.id) ? 'hidden md:table-cell' : ''}`}
+                            } ${i === 0 ? 'sticky left-0 z-10 bg-background border-r border-border/40' : ''} ${mobileHiddenColumns.has(header.id) ? 'hidden md:table-cell' : ''}`}
                             style={{ width: header.getSize(), minWidth: header.getSize() }}
                             onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
                           >
@@ -968,7 +968,7 @@ export function DatabasePage() {
                             key={cell.id}
                             className={`px-3 py-2 ${
                               mobileHiddenColumns.has(cell.column.id) ? 'hidden md:table-cell' : ''
-                            } ${cellIdx === 0 ? 'sticky left-0 z-10 bg-background' : ''} ${cellIdx === 1 ? 'sticky left-[44px] z-10 bg-background border-r border-border/40' : ''}`}
+                            } ${cellIdx === 0 ? 'sticky left-0 z-10 bg-background border-r border-border/40' : ''}`}
                             style={{ width: cell.column.getSize(), minWidth: cell.column.getSize() }}
                           >
                             {flexRender(cell.column.columnDef.cell, cell.getContext())}


### PR DESCRIPTION
## Summary

Removes sticky positioning from the Company column (220px wide). Previously both `#` (44px) and Company (220px) were sticky, consuming 264px — 70% of a 375px mobile screen — leaving very little room to view other columns. Now only the `#` column stays pinned at `left-0`, freeing up 220px of scrolling area. The `border-r` separator was moved to the `#` column so the sticky boundary is still visually clear.

---
_Generated by [Claude Code](https://claude.ai/code/session_013XsZSM7E8ShnL5hohYaLWu)_