### PR TITLE
Multi-source company model + a16z portfolio scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ private/
 # Accidental venv
 path/
 .gstack/
+
+# Claude Code local state (worktrees, plans, settings)
+.claude/

--- a/backend/a16z_scraper_service.py
+++ b/backend/a16z_scraper_service.py
@@ -1,0 +1,313 @@
+"""
+a16z portfolio scraper.
+
+The a16z portfolio page (https://a16z.com/portfolio/) ships its full dataset inline
+in the HTML as a global JS array `window.a16z_portfolio_companies = [ ... ];` — one
+unauthenticated GET, no API key, no headless browser, no pagination. A small set of
+companies (the exits ticker) additionally carry richer `data-company='{...}'` DOM
+attributes (verticals, permalink, website_description, jobs, ...) which we merge in by id.
+
+Each entry is mapped onto the shared multi-source `companies` schema (see sources.py):
+YC keeps its native ids; a16z ids are offset into a reserved block so they never collide.
+
+Runnable standalone as a seeder:
+
+    cd backend
+    python -m a16z_scraper_service --dry-run        # fetch + parse + map, write nothing
+    python -m a16z_scraper_service --limit 20        # seed only the first 20 (smoke test)
+    python -m a16z_scraper_service                    # seed all ~849
+    DATABASE_URL=postgres://... python -m a16z_scraper_service   # seed Supabase/Postgres
+
+With DATABASE_URL set it writes to Postgres (Supabase); otherwise to local SQLite.
+"""
+
+import asyncio
+import html
+import json
+import re
+from typing import Callable, Dict, List, Optional
+
+import requests
+
+from sources import to_global_id
+
+PORTFOLIO_URL = "https://a16z.com/portfolio/"
+SOURCE = "a16z"
+
+# Stage tokens a16z uses to mark an exit (vs. an active-portfolio stage like Venture/Seed/Growth)
+_EXIT_STAGES = {"IPO", "M&A", "SPAC", "DPO", "EXIT"}
+
+
+def slugify(value: str) -> str:
+    """Lowercase, hyphenate, strip to a URL-safe slug."""
+    value = html.unescape(value or "").lower().strip()
+    value = re.sub(r"[^a-z0-9]+", "-", value).strip("-")
+    return value
+
+
+def _first_nonempty(*vals) -> Optional[str]:
+    for v in vals:
+        if v not in (None, "", []):
+            return v
+    return None
+
+
+class A16ZScraperService:
+    """Fetch, parse, map, and upsert the a16z portfolio into the companies table."""
+
+    def __init__(self, db):
+        self.db = db
+        self.session = requests.Session()
+        self.session.headers.update({
+            "User-Agent": ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                           "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"),
+            "Accept": "text/html,application/xhtml+xml",
+        })
+
+    # ---- fetch + parse -----------------------------------------------------
+
+    def fetch_html(self) -> str:
+        resp = self.session.get(PORTFOLIO_URL, timeout=60)
+        resp.raise_for_status()
+        return resp.text
+
+    def parse_entries(self, html_text: str) -> List[Dict]:
+        """Extract the inline company array; merge richer data-company DOM attrs by id."""
+        m = re.search(r"window\.a16z_portfolio_companies\s*=\s*(\[.*?\])\s*;", html_text, re.DOTALL)
+        if not m:
+            raise ValueError("window.a16z_portfolio_companies not found — a16z page layout may have changed")
+        entries = json.loads(m.group(1))
+
+        # Best-effort: richer per-company attributes (exits ticker), keyed by native id.
+        dom_by_id: Dict[str, Dict] = {}
+        for raw in re.findall(r"data-company='(\{.*?\})'", html_text, re.DOTALL):
+            try:
+                obj = json.loads(raw)
+            except json.JSONDecodeError:
+                try:
+                    obj = json.loads(html.unescape(raw))
+                except json.JSONDecodeError:
+                    continue
+            if obj.get("id") is not None:
+                dom_by_id[str(obj["id"])] = obj
+
+        for e in entries:
+            extra = dom_by_id.get(str(e.get("id")))
+            if extra:
+                e["_dom"] = extra
+        return entries
+
+    # ---- mapping -----------------------------------------------------------
+
+    def _derive_exit(self, entry: Dict, dom: Dict) -> tuple[Optional[str], str]:
+        """Return (exit_type, status). Prefers explicit signals, falls back to stages."""
+        stages = set(entry.get("stages") or [])
+        acquirer = entry.get("acquirer")
+        ticker = entry.get("ticker_symbol")
+
+        if acquirer or "M&A" in stages:
+            return "M&A", "Acquired"
+        if ticker or "IPO" in stages:
+            return "IPO", "Public"
+        if "SPAC" in stages:
+            return "SPAC", "Public"
+        if entry.get("exit_date") or (stages & _EXIT_STAGES):
+            return "Exit", "Exited"
+        return None, "Active"
+
+    def _map_entry(self, entry: Dict, seen_slugs: set) -> Dict:
+        dom = entry.get("_dom") or {}
+        native_id = str(entry.get("id"))
+        name = _first_nonempty(dom.get("name"), entry.get("title"),
+                               dom.get("display_name"), dom.get("post_title")) or f"a16z-{native_id}"
+
+        # slug: prefer a16z's own permalink slug, else slugify name; guarantee uniqueness within source
+        slug = None
+        permalink = dom.get("permalink")
+        if permalink:
+            mslug = re.search(r"/companies/([^/]+)/?", permalink)
+            if mslug:
+                slug = mslug.group(1)
+        slug = slug or slugify(name) or f"a16z-{native_id}"
+        if slug in seen_slugs:
+            slug = f"{slug}-{native_id}"
+        seen_slugs.add(slug)
+
+        # verticals / focus areas -> industry + industries[]
+        verticals_raw = dom.get("verticals") or ""
+        verticals = [v.strip() for v in re.split(r"[;,]", verticals_raw) if v.strip()]
+        focus_areas = dom.get("focus_areas") or []
+        industries = list(dict.fromkeys([*focus_areas, *verticals]))
+        industry = industries[0] if industries else None
+
+        year = entry.get("year_founded")
+        try:
+            year_founded = int(year) if year not in (None, "") else None
+        except (ValueError, TypeError):
+            year_founded = None
+
+        jobs = dom.get("jobs")
+        if jobs in (None, ""):
+            try:
+                jobs = int(dom.get("number_of_jobs") or 0)
+            except (ValueError, TypeError):
+                jobs = 0
+
+        exit_type, status = self._derive_exit(entry, dom)
+
+        overview = entry.get("overview") or ""
+        website_description = dom.get("website_description") or ""
+        one_liner = _first_nonempty(
+            website_description,
+            overview.split(". ")[0] + "." if overview else None,
+            (entry.get("announcement") or {}).get("excerpt"),
+        )
+
+        return {
+            "id": to_global_id(SOURCE, native_id),
+            "source": SOURCE,
+            "source_id": native_id,
+            "name": name,
+            "slug": slug,
+            "website": _first_nonempty(entry.get("web"), dom.get("external_url"),
+                                       dom.get("company_url"), dom.get("url")),
+            "one_liner": one_liner,
+            "long_description": _first_nonempty(overview, website_description),
+            "small_logo_thumb_url": entry.get("logo"),
+            "stage": ", ".join(entry.get("stages") or []) or None,
+            "industry": industry,
+            "industries": industries,
+            "tags": dom.get("tags") or [],
+            "founders": _first_nonempty(entry.get("founders"), dom.get("founders_list")),
+            "year_founded": year_founded,
+            "funded_date": _first_nonempty(dom.get("initial_a16z_date_funded"),
+                                           entry.get("invest_date"), dom.get("investment_date")),
+            "ticker_symbol": entry.get("ticker_symbol") or None,
+            "acquirer": entry.get("acquirer") or None,
+            "exit_type": exit_type,
+            "status": status,
+            "source_url": permalink,
+            "isHiring": bool(jobs and int(jobs) > 0),
+            # source-only fields, preserved in raw_json (no dedicated column)
+            "socials": entry.get("socials") or [],
+            "announcement": entry.get("announcement"),
+            "email": entry.get("email") or None,
+            # explicit non-applicable YC fields (keeps a16z out of YC-shaped views)
+            "batch": None,
+            "team_size": None,
+            "all_locations": None,
+            "regions": [],
+            "top_company": False,
+            "nonprofit": False,
+            "subindustry": None,
+        }
+
+    def map_all(self, entries: List[Dict], limit: Optional[int] = None) -> List[Dict]:
+        seen_slugs: set = set()
+        mapped = []
+        for e in entries:
+            if e.get("id") is None:
+                continue
+            mapped.append(self._map_entry(e, seen_slugs))
+            if limit and len(mapped) >= limit:
+                break
+        return mapped
+
+    # ---- scrape lifecycle --------------------------------------------------
+
+    async def scrape_companies(self, job_id: int,
+                               progress_callback: Optional[Callable] = None,
+                               limit: Optional[int] = None) -> int:
+        total = 0
+        try:
+            loop = asyncio.get_event_loop()
+            html_text = await loop.run_in_executor(None, self.fetch_html)
+            entries = self.parse_entries(html_text)
+            mapped = self.map_all(entries, limit=limit)
+
+            if hasattr(self.db, "bulk_insert_companies"):
+                # Fast path (Postgres/Supabase): one execute_values upsert instead of
+                # ~2,500 sequential connections. Skips per-row change tracking (fine for a seed).
+                await loop.run_in_executor(None, self.db.bulk_insert_companies, mapped)
+                total = len(mapped)
+            else:
+                # Per-row path (SQLite local dev): change tracking + incremental progress.
+                for company in mapped:
+                    existing = self.db.get_company_by_id(company["id"])
+                    self.db.insert_company(company)
+                    if existing is None:
+                        self.db.log_change(company_id=company["id"], change_type="created",
+                                           new_value=company["name"])
+                    total += 1
+                    if total % 50 == 0:
+                        self.db.update_scrape_job(job_id, "running", total, 1)
+                        if progress_callback:
+                            await progress_callback({"job_id": job_id, "status": "running",
+                                                     "total_scraped": total, "current_page": 1})
+
+            self.db.update_scrape_job(job_id, "completed", total, 1)
+            if progress_callback:
+                await progress_callback({"job_id": job_id, "status": "completed",
+                                         "total_scraped": total, "current_page": 1})
+            return total
+        except Exception as e:
+            self.db.update_scrape_job(job_id, "failed", total, 1, str(e))
+            if progress_callback:
+                await progress_callback({"job_id": job_id, "status": "failed",
+                                         "error": str(e), "total_scraped": total, "current_page": 1})
+            raise
+
+
+# --------------------------------------------------------------------------
+# Standalone seeder
+# --------------------------------------------------------------------------
+
+def _main() -> None:
+    import argparse
+
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except ImportError:
+        pass
+
+    parser = argparse.ArgumentParser(description="Seed the a16z portfolio into the companies table")
+    parser.add_argument("--dry-run", action="store_true", help="Fetch + parse + map, write nothing")
+    parser.add_argument("--limit", type=int, default=None, help="Only process the first N companies")
+    args = parser.parse_args()
+
+    import os
+    from database_factory import get_database
+
+    svc = A16ZScraperService(db=None)
+    print(f"Fetching {PORTFOLIO_URL} ...")
+    html_text = svc.fetch_html()
+    entries = svc.parse_entries(html_text)
+    print(f"Parsed {len(entries)} companies from window.a16z_portfolio_companies")
+    mapped = svc.map_all(entries, limit=args.limit)
+    print(f"Mapped {len(mapped)} companies (limit={args.limit})")
+
+    if args.dry_run:
+        print("\n--- dry run: 3 sample mapped rows ---")
+        for row in mapped[:3]:
+            preview = {k: row.get(k) for k in
+                       ("id", "source", "source_id", "name", "slug", "website", "stage",
+                        "industry", "exit_type", "ticker_symbol", "acquirer", "founders")}
+            print(json.dumps(preview, indent=2, ensure_ascii=False))
+        exits = sum(1 for r in mapped if r["exit_type"])
+        print(f"\nsummary: {len(mapped)} total, {exits} exits, "
+              f"{sum(1 for r in mapped if r['website'])} with website, "
+              f"{sum(1 for r in mapped if r['industry'])} with industry")
+        return
+
+    target = "Postgres (DATABASE_URL set)" if os.environ.get("DATABASE_URL") else "local SQLite"
+    print(f"Writing to {target} ...")
+    db = get_database()
+    svc.db = db
+    job_id = db.create_scrape_job({"source": SOURCE, "limit": args.limit})
+    total = asyncio.run(svc.scrape_companies(job_id, limit=args.limit))
+    print(f"✅ Seeded {total} a16z companies (job_id={job_id}).")
+
+
+if __name__ == "__main__":
+    _main()

--- a/backend/company_cache.py
+++ b/backend/company_cache.py
@@ -17,6 +17,7 @@ class CompanyCache:
         self._batches: List[str] = []
         self._industries: List[str] = []
         self._countries: List[str] = []
+        self._source_counts: Dict[str, int] = {}
         self._loaded = False
 
     def load(self, db) -> None:
@@ -40,7 +41,17 @@ class CompanyCache:
         self._companies = sorted(companies, key=sort_key, reverse=True)
         self._companies_by_id = {c["id"]: c for c in companies if c.get("id") is not None}
 
-        # Map subset: companies with geo coordinates
+        # Source breakdown (all sources) for /api/filters/sources
+        self._source_counts: Dict[str, int] = {}
+        for c in companies:
+            s = c.get("source") or "yc"
+            self._source_counts[s] = self._source_counts.get(s, 0) + 1
+
+        # Stats and YC-facing filter lists are computed over Y Combinator rows only
+        # (additive & opt-in): a16z / other sources never pollute YC-shaped views.
+        yc = [c for c in companies if (c.get("source") or "yc") == "yc"]
+
+        # Map subset: companies with geo coordinates (a16z has none, so naturally excluded)
         map_cols = {
             "id", "name", "slug", "website", "one_liner", "batch", "is_hiring",
             "top_company", "small_logo_thumb_url",
@@ -52,37 +63,37 @@ class CompanyCache:
             if c.get("latitude") is not None and c.get("longitude") is not None
         ]
 
-        # Stats
-        total = len(companies)
-        hiring = sum(1 for c in companies if c.get("is_hiring"))
+        # Stats (YC-only)
+        total = len(yc)
+        hiring = sum(1 for c in yc if c.get("is_hiring"))
         by_batch: Dict[str, int] = {}
-        for c in companies:
+        for c in yc:
             b = c.get("batch")
             if b:
                 by_batch[b] = by_batch.get(b, 0) + 1
         by_batch = dict(sorted(by_batch.items(), key=lambda x: -x[1]))
 
         by_industry: Dict[str, int] = {}
-        for c in companies:
+        for c in yc:
             ind = c.get("industry")
             if ind:
                 by_industry[ind] = by_industry.get(ind, 0) + 1
         by_industry = dict(sorted(by_industry.items(), key=lambda x: -x[1])[:10])
 
         by_country: Dict[str, int] = {}
-        for c in companies:
+        for c in yc:
             cnt = c.get("country")
             if cnt:
                 by_country[cnt] = by_country.get(cnt, 0) + 1
         by_country = dict(sorted(by_country.items(), key=lambda x: -x[1])[:10])
 
         by_status: Dict[str, int] = {}
-        for c in companies:
+        for c in yc:
             s = c.get("status") or "unknown"
             by_status[s] = by_status.get(s, 0) + 1
 
         by_batch_industry: Dict[str, Dict[str, int]] = {}
-        for c in companies:
+        for c in yc:
             b = c.get("batch")
             ind = c.get("industry")
             if b and ind:
@@ -100,16 +111,16 @@ class CompanyCache:
             "by_batch_industry": by_batch_industry,
         }
 
-        # Filter lists
+        # Filter lists (YC-only)
         self._batches = sorted(
-            {c.get("batch") for c in companies if c.get("batch")},
+            {c.get("batch") for c in yc if c.get("batch")},
             reverse=True
         )
         self._industries = sorted(
-            {c.get("industry") for c in companies if c.get("industry")}
+            {c.get("industry") for c in yc if c.get("industry")}
         )
         self._countries = sorted(
-            {c.get("country") for c in companies if c.get("country")}
+            {c.get("country") for c in yc if c.get("country")}
         )
 
         self._loaded = True
@@ -128,6 +139,17 @@ class CompanyCache:
                 return True
         return False
 
+    @staticmethod
+    def _source_matches(company: Dict, source: Optional[str]) -> bool:
+        """Source semantics: None -> YC-only (default, no regressions),
+        'all' -> every source, otherwise that exact source key."""
+        csrc = company.get("source") or "yc"
+        if source is None:
+            return csrc == "yc"
+        if source == "all":
+            return True
+        return csrc == source
+
     def _filter_companies(
         self,
         batch: Optional[str] = None,
@@ -136,9 +158,10 @@ class CompanyCache:
         country: Optional[str] = None,
         search: Optional[str] = None,
         top_company: Optional[bool] = None,
+        source: Optional[str] = None,
     ) -> List[Dict]:
         """Apply filters to companies list."""
-        result = self._companies
+        result = [c for c in self._companies if self._source_matches(c, source)]
         if batch:
             result = [c for c in result if c.get("batch") == batch]
         if is_hiring is not None:
@@ -163,9 +186,10 @@ class CompanyCache:
         country: Optional[str] = None,
         search: Optional[str] = None,
         top_company: Optional[bool] = None,
+        source: Optional[str] = None,
     ) -> List[Dict]:
         """Get companies with filters and pagination."""
-        filtered = self._filter_companies(batch, is_hiring, industry, country, search, top_company)
+        filtered = self._filter_companies(batch, is_hiring, industry, country, search, top_company, source)
         return filtered[offset : offset + limit]
 
     def count_companies(
@@ -176,9 +200,10 @@ class CompanyCache:
         country: Optional[str] = None,
         search: Optional[str] = None,
         top_company: Optional[bool] = None,
+        source: Optional[str] = None,
     ) -> int:
         """Count companies matching filters."""
-        filtered = self._filter_companies(batch, is_hiring, industry, country, search, top_company)
+        filtered = self._filter_companies(batch, is_hiring, industry, country, search, top_company, source)
         return len(filtered)
 
     def get_company_by_id(self, company_id: int) -> Optional[Dict]:
@@ -209,6 +234,19 @@ class CompanyCache:
     def get_total_map_companies(self) -> int:
         """Count of companies with geo coordinates."""
         return len(self._map_companies)
+
+    def get_sources(self) -> List[Dict]:
+        """Available sources with display names and company counts (all sources)."""
+        from sources import SOURCES
+        keys = list({**{k: None for k in SOURCES}, **self._source_counts})
+        return [
+            {
+                "key": k,
+                "display_name": SOURCES.get(k, {}).get("display_name", k),
+                "count": self._source_counts.get(k, 0),
+            }
+            for k in keys
+        ]
 
     def get_unique_batches(self) -> List[str]:
         return list(self._batches)

--- a/backend/database.py
+++ b/backend/database.py
@@ -40,8 +40,10 @@ class Database:
             cursor.execute('''
                 CREATE TABLE IF NOT EXISTS companies (
                     id INTEGER PRIMARY KEY,
+                    source TEXT NOT NULL DEFAULT 'yc',
+                    source_id TEXT,
                     name TEXT NOT NULL,
-                    slug TEXT UNIQUE NOT NULL,
+                    slug TEXT NOT NULL,
                     website TEXT,
                     one_liner TEXT,
                     long_description TEXT,
@@ -62,6 +64,13 @@ class Database:
                     latitude REAL,
                     longitude REAL,
                     country TEXT,
+                    founders TEXT,
+                    year_founded INTEGER,
+                    exit_type TEXT,
+                    acquirer TEXT,
+                    ticker_symbol TEXT,
+                    funded_date TEXT,
+                    source_url TEXT,
                     raw_json TEXT,
                     funding_total_usd REAL,
                     funding_last_round_usd REAL,
@@ -214,12 +223,18 @@ class Database:
                 )
             ''')
 
+            # Bring existing databases up to the multi-source schema before indexing
+            self._migrate_schema(cursor)
+
             # Create indexes
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_batch ON companies(batch)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_hiring ON companies(is_hiring)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_industry ON companies(industry)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_country ON companies(country)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_funding_total ON companies(funding_total_usd)')
+            cursor.execute('CREATE INDEX IF NOT EXISTS idx_companies_source ON companies(source)')
+            cursor.execute('CREATE UNIQUE INDEX IF NOT EXISTS uq_companies_source_slug ON companies(source, slug)')
+            cursor.execute('CREATE UNIQUE INDEX IF NOT EXISTS uq_companies_source_native ON companies(source, source_id)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_investor_name ON investors(name)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_company_investor_company ON company_investors(company_id)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_company_investor_investor ON company_investors(investor_id)')
@@ -227,19 +242,68 @@ class Database:
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_hiring_role ON hiring_jobs(pretty_role)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_hiring_updated ON hiring_jobs(pretty_updated_at)')
 
+    def _migrate_schema(self, cursor):
+        """Bring an existing SQLite DB up to the multi-source schema.
+
+        SQLite has no `ADD COLUMN IF NOT EXISTS`, so we gate on PRAGMA table_info.
+        The legacy inline `slug TEXT UNIQUE NOT NULL` creates an un-droppable auto
+        index; we replace it with the composite UNIQUE(source, slug) via a guarded
+        table rebuild. Local-dev only (production is Postgres via database_factory).
+        """
+        existing = {row[1] for row in cursor.execute("PRAGMA table_info(companies)").fetchall()}
+        additions = {
+            "source": "TEXT NOT NULL DEFAULT 'yc'",
+            "source_id": "TEXT",
+            "founders": "TEXT",
+            "year_founded": "INTEGER",
+            "exit_type": "TEXT",
+            "acquirer": "TEXT",
+            "ticker_symbol": "TEXT",
+            "funded_date": "TEXT",
+            "source_url": "TEXT",
+        }
+        for col, ddl in additions.items():
+            if col not in existing:
+                cursor.execute(f"ALTER TABLE companies ADD COLUMN {col} {ddl}")
+
+        # Backfill provenance for pre-existing (YC) rows
+        cursor.execute("UPDATE companies SET source='yc' WHERE source IS NULL")
+        cursor.execute("UPDATE companies SET source_id=CAST(id AS TEXT) WHERE source_id IS NULL")
+
+        # Drop the legacy global UNIQUE(slug) by rebuilding the table, if present.
+        create_sql = cursor.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='companies'"
+        ).fetchone()[0]
+        if "slug TEXT UNIQUE" in create_sql:
+            cols = [row[1] for row in cursor.execute("PRAGMA table_info(companies)").fetchall()]
+            col_list = ", ".join(f'"{c}"' for c in cols)
+            new_sql = (create_sql
+                       .replace("slug TEXT UNIQUE NOT NULL", "slug TEXT NOT NULL")
+                       .replace("CREATE TABLE IF NOT EXISTS companies", "CREATE TABLE companies_new")
+                       .replace("CREATE TABLE companies", "CREATE TABLE companies_new"))
+            cursor.execute("DROP TABLE IF EXISTS companies_new")
+            cursor.execute(new_sql)
+            cursor.execute(f"INSERT INTO companies_new ({col_list}) SELECT {col_list} FROM companies")
+            cursor.execute("DROP TABLE companies")
+            cursor.execute("ALTER TABLE companies_new RENAME TO companies")
+
     def insert_company(self, company: Dict[str, Any]) -> int:
         """Insert or update a company"""
         with self.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute('''
                 INSERT OR REPLACE INTO companies
-                (id, name, slug, website, one_liner, long_description, team_size,
+                (id, source, source_id, name, slug, website, one_liner, long_description, team_size,
                  batch, status, industry, subindustry, all_locations, is_hiring,
                  top_company, nonprofit, stage, small_logo_thumb_url, tags, regions,
-                 industries, latitude, longitude, country, raw_json, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                 industries, latitude, longitude, country,
+                 founders, year_founded, exit_type, acquirer, ticker_symbol, funded_date, source_url,
+                 raw_json, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
             ''', (
                 company.get('id'),
+                company.get('source', 'yc'),
+                company.get('source_id') if company.get('source_id') is not None else str(company.get('id')),
                 company.get('name'),
                 company.get('slug'),
                 company.get('website'),
@@ -262,6 +326,13 @@ class Database:
                 company.get('latitude'),
                 company.get('longitude'),
                 company.get('country'),
+                company.get('founders'),
+                company.get('year_founded'),
+                company.get('exit_type'),
+                company.get('acquirer'),
+                company.get('ticker_symbol'),
+                company.get('funded_date'),
+                company.get('source_url'),
                 json.dumps(company)
             ))
             return cursor.lastrowid

--- a/backend/database_postgres.py
+++ b/backend/database_postgres.py
@@ -54,12 +54,16 @@ class DatabasePostgres:
             with conn.cursor() as cur:
                 cur.execute("""
                     INSERT INTO companies
-                    (id, name, slug, website, one_liner, long_description, team_size,
+                    (id, source, source_id, name, slug, website, one_liner, long_description, team_size,
                      batch, status, industry, subindustry, all_locations, is_hiring,
                      top_company, nonprofit, stage, small_logo_thumb_url, tags, regions,
-                     industries, latitude, longitude, country, raw_json, updated_at)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
+                     industries, latitude, longitude, country,
+                     founders, year_founded, exit_type, acquirer, ticker_symbol, funded_date, source_url,
+                     raw_json, updated_at)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
                     ON CONFLICT (id) DO UPDATE SET
+                        source = EXCLUDED.source,
+                        source_id = EXCLUDED.source_id,
                         name = EXCLUDED.name,
                         slug = EXCLUDED.slug,
                         website = EXCLUDED.website,
@@ -82,10 +86,19 @@ class DatabasePostgres:
                         latitude = EXCLUDED.latitude,
                         longitude = EXCLUDED.longitude,
                         country = EXCLUDED.country,
+                        founders = EXCLUDED.founders,
+                        year_founded = EXCLUDED.year_founded,
+                        exit_type = EXCLUDED.exit_type,
+                        acquirer = EXCLUDED.acquirer,
+                        ticker_symbol = EXCLUDED.ticker_symbol,
+                        funded_date = EXCLUDED.funded_date,
+                        source_url = EXCLUDED.source_url,
                         raw_json = EXCLUDED.raw_json,
                         updated_at = NOW()
                 """, (
                     company.get("id"),
+                    company.get("source", "yc"),
+                    company.get("source_id") if company.get("source_id") is not None else str(company.get("id")),
                     company.get("name"),
                     company.get("slug"),
                     company.get("website"),
@@ -108,6 +121,13 @@ class DatabasePostgres:
                     company.get("latitude"),
                     company.get("longitude"),
                     company.get("country"),
+                    company.get("founders"),
+                    company.get("year_founded"),
+                    company.get("exit_type"),
+                    company.get("acquirer"),
+                    company.get("ticker_symbol"),
+                    company.get("funded_date"),
+                    company.get("source_url"),
                     json.dumps(company) if company else None,
                 ))
                 return cur.rowcount
@@ -135,6 +155,8 @@ class DatabasePostgres:
             is_hiring = company.get("is_hiring") if company.get("is_hiring") is not None else company.get("isHiring")
             return (
                 company.get("id"),
+                company.get("source", "yc"),
+                company.get("source_id") if company.get("source_id") is not None else str(company.get("id")),
                 company.get("name"),
                 company.get("slug"),
                 company.get("website"),
@@ -157,15 +179,23 @@ class DatabasePostgres:
                 company.get("latitude"),
                 company.get("longitude"),
                 company.get("country"),
+                company.get("founders"),
+                company.get("year_founded"),
+                company.get("exit_type"),
+                company.get("acquirer"),
+                company.get("ticker_symbol"),
+                company.get("funded_date"),
+                company.get("source_url"),
                 json.dumps(company) if company else None,
             )
 
         total = 0
-        cols = "(id, name, slug, website, one_liner, long_description, team_size, batch, status, industry, subindustry, all_locations, is_hiring, top_company, nonprofit, stage, small_logo_thumb_url, tags, regions, industries, latitude, longitude, country, raw_json)"
+        cols = "(id, source, source_id, name, slug, website, one_liner, long_description, team_size, batch, status, industry, subindustry, all_locations, is_hiring, top_company, nonprofit, stage, small_logo_thumb_url, tags, regions, industries, latitude, longitude, country, founders, year_founded, exit_type, acquirer, ticker_symbol, funded_date, source_url, raw_json)"
         upsert_sql = f"""
             INSERT INTO companies {cols}
             VALUES %s
             ON CONFLICT (id) DO UPDATE SET
+                source = EXCLUDED.source, source_id = EXCLUDED.source_id,
                 name = EXCLUDED.name, slug = EXCLUDED.slug, website = EXCLUDED.website,
                 one_liner = EXCLUDED.one_liner, long_description = EXCLUDED.long_description,
                 team_size = EXCLUDED.team_size, batch = EXCLUDED.batch, status = EXCLUDED.status,
@@ -175,6 +205,10 @@ class DatabasePostgres:
                 stage = EXCLUDED.stage, small_logo_thumb_url = EXCLUDED.small_logo_thumb_url,
                 tags = EXCLUDED.tags, regions = EXCLUDED.regions, industries = EXCLUDED.industries,
                 latitude = EXCLUDED.latitude, longitude = EXCLUDED.longitude, country = EXCLUDED.country,
+                founders = EXCLUDED.founders, year_founded = EXCLUDED.year_founded,
+                exit_type = EXCLUDED.exit_type, acquirer = EXCLUDED.acquirer,
+                ticker_symbol = EXCLUDED.ticker_symbol, funded_date = EXCLUDED.funded_date,
+                source_url = EXCLUDED.source_url,
                 raw_json = EXCLUDED.raw_json, updated_at = NOW()
         """
         rows = [_row(c) for c in companies]
@@ -727,7 +761,7 @@ class DatabasePostgres:
         with self.get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT COUNT(*) FROM companies WHERE embedding IS NOT NULL"
+                    "SELECT COUNT(*) FROM companies WHERE embedding IS NOT NULL AND source = 'yc'"
                 )
                 return cur.fetchone()[0] or 0
 
@@ -747,6 +781,7 @@ class DatabasePostgres:
                     SELECT id, name, one_liner, long_description
                     FROM companies
                     WHERE embedding IS NULL
+                        AND source = 'yc'
                         AND (one_liner IS NOT NULL OR long_description IS NOT NULL)
                     ORDER BY id DESC
                     LIMIT %s
@@ -815,6 +850,7 @@ class DatabasePostgres:
                         (1 - (embedding <=> %s::vector)) AS similarity_score
                     FROM companies
                     WHERE embedding IS NOT NULL
+                        AND source = 'yc'
                         AND (1 - (embedding <=> %s::vector)) >= %s
                     ORDER BY embedding <=> %s::vector
                     LIMIT %s
@@ -857,6 +893,7 @@ class DatabasePostgres:
                         team_size, all_locations, country, small_logo_thumb_url
                     FROM companies
                     WHERE (one_liner ILIKE %s OR long_description ILIKE %s)
+                        AND source = 'yc'
                         AND (one_liner IS NOT NULL OR long_description IS NOT NULL)
                     ORDER BY CASE WHEN one_liner ILIKE %s THEN 0 ELSE 1 END
                     LIMIT %s
@@ -880,21 +917,21 @@ class DatabasePostgres:
             with conn.cursor() as cur:
                 # Get total companies in industry
                 cur.execute(
-                    "SELECT COUNT(*) FROM companies WHERE industry = %s",
+                    "SELECT COUNT(*) FROM companies WHERE industry = %s AND source = 'yc'",
                     (industry,)
                 )
                 total_companies = cur.fetchone()[0]
 
                 # Get hiring count
                 cur.execute(
-                    "SELECT COUNT(*) FROM companies WHERE industry = %s AND is_hiring = TRUE",
+                    "SELECT COUNT(*) FROM companies WHERE industry = %s AND is_hiring = TRUE AND source = 'yc'",
                     (industry,)
                 )
                 hiring_count = cur.fetchone()[0]
 
                 # Get average team size
                 cur.execute(
-                    "SELECT AVG(team_size) FROM companies WHERE industry = %s AND team_size IS NOT NULL",
+                    "SELECT AVG(team_size) FROM companies WHERE industry = %s AND team_size IS NOT NULL AND source = 'yc'",
                     (industry,)
                 )
                 avg_team_size_result = cur.fetchone()[0]
@@ -904,7 +941,7 @@ class DatabasePostgres:
                 cur.execute("""
                     SELECT batch, COUNT(*) as count
                     FROM companies
-                    WHERE industry = %s AND batch IS NOT NULL
+                    WHERE industry = %s AND batch IS NOT NULL AND source = 'yc'
                     GROUP BY batch
                     ORDER BY count DESC
                     LIMIT 5
@@ -976,7 +1013,7 @@ class DatabasePostgres:
         # Market size percentage (compared to total YC portfolio)
         with self.get_connection() as conn:
             with conn.cursor() as cur:
-                cur.execute("SELECT COUNT(*) FROM companies")
+                cur.execute("SELECT COUNT(*) FROM companies WHERE source = 'yc'")
                 total_yc_companies = cur.fetchone()[0]
                 market_size_percentage = round((total_similar / total_yc_companies * 100), 2) if total_yc_companies > 0 else 0
 
@@ -1504,7 +1541,7 @@ class DatabasePostgres:
                             ELSE 50
                         END as success_score
                     FROM companies
-                    WHERE funding_total_usd IS NOT NULL
+                    WHERE funding_total_usd IS NOT NULL AND source = 'yc'
                     ORDER BY funding_total_usd DESC
                 """)
                 scores = [row[0] for row in cur.fetchall()]

--- a/backend/main.py
+++ b/backend/main.py
@@ -149,6 +149,8 @@ app.add_middleware(
 # Initialize database, scraper service, email service, and company cache
 db = get_database()
 scraper = ScraperService(db)
+from a16z_scraper_service import A16ZScraperService
+a16z_scraper = A16ZScraperService(db)
 email_service = EmailService()
 company_cache = CompanyCache()
 
@@ -254,6 +256,7 @@ class ScrapeRequest(BaseModel):
     nonprofit: Optional[bool] = None
     hits_per_page: int = 1000
     max_pages: int = 10
+    source: str = "yc"  # 'yc' (Algolia) or 'a16z' (portfolio page)
 
 
 class CompanyFilter(BaseModel):
@@ -265,6 +268,7 @@ class CompanyFilter(BaseModel):
     country: Optional[str] = None
     search: Optional[str] = None
     top_company: Optional[bool] = None
+    source: Optional[str] = None  # None -> YC only, 'all' -> every source, or a source key
 
 
 # Background task storage
@@ -382,8 +386,8 @@ async def get_enrichment_stats(session: dict = Depends(verify_admin_session)):
         with db.get_connection() as conn:
             cursor = conn.cursor()
 
-            # Total companies
-            cursor.execute("SELECT COUNT(*) FROM companies")
+            # Total companies (YC only — Coresignal enrichment is YC-scoped)
+            cursor.execute("SELECT COUNT(*) FROM companies WHERE source = 'yc'")
             total_companies = cursor.fetchone()[0]
 
             # Companies enriched (have coresignal data)
@@ -452,6 +456,7 @@ async def start_scrape(request: ScrapeRequest, background_tasks: BackgroundTasks
 
     # Create job in database
     job_id = db.create_scrape_job({
+        'source': request.source,
         'query': request.query,
         'batch': request.batch,
         'industry': request.industry,
@@ -470,19 +475,25 @@ async def start_scrape(request: ScrapeRequest, background_tasks: BackgroundTasks
     # Start scraping in background
     async def run_scrape():
         try:
-            total = await scraper.scrape_companies(
-                job_id=job_id,
-                query=request.query,
-                batch=request.batch,
-                industry=request.industry,
-                region=request.region,
-                is_hiring=request.is_hiring,
-                top_company=request.top_company,
-                nonprofit=request.nonprofit,
-                hits_per_page=request.hits_per_page,
-                max_pages=request.max_pages,
-                progress_callback=progress_callback
-            )
+            if request.source == "a16z":
+                total = await a16z_scraper.scrape_companies(
+                    job_id=job_id,
+                    progress_callback=progress_callback,
+                )
+            else:
+                total = await scraper.scrape_companies(
+                    job_id=job_id,
+                    query=request.query,
+                    batch=request.batch,
+                    industry=request.industry,
+                    region=request.region,
+                    is_hiring=request.is_hiring,
+                    top_company=request.top_company,
+                    nonprofit=request.nonprofit,
+                    hits_per_page=request.hits_per_page,
+                    max_pages=request.max_pages,
+                    progress_callback=progress_callback
+                )
             active_jobs[job_id] = {'status': 'completed', 'total': total}
         except Exception as e:
             active_jobs[job_id] = {'status': 'failed', 'error': str(e)}
@@ -533,6 +544,7 @@ async def get_companies(filters: CompanyFilter):
         country=filters.country,
         search=filters.search,
         top_company=filters.top_company,
+        source=filters.source,
     )
 
     total = company_cache.count_companies(
@@ -542,6 +554,7 @@ async def get_companies(filters: CompanyFilter):
         country=filters.country,
         search=filters.search,
         top_company=filters.top_company,
+        source=filters.source,
     )
 
     return {
@@ -640,6 +653,12 @@ async def get_map_data(
         batch=batch, is_hiring=is_hiring, recent_batches=recent_batches
     )
     return {"companies": companies, "total": len(companies)}
+
+
+@app.get("/api/filters/sources")
+async def get_sources():
+    """Get available company sources (incubators/VCs) with counts"""
+    return {"sources": company_cache.get_sources()}
 
 
 @app.get("/api/filters/batches")

--- a/backend/sources.py
+++ b/backend/sources.py
@@ -1,0 +1,68 @@
+"""
+Source registry for multi-incubator / multi-VC company data.
+
+ExploreYC started as Y-Combinator-only. This module generalizes the notion of a
+"source" (an incubator or VC portfolio) so companies from YC, a16z, and future
+funds can coexist in the single `companies` table.
+
+Two collision problems are solved here:
+
+1. ID collision — every source has its own native id space, and some overlap YC's
+   Algolia id range (e.g. a16z uses ids like 371262 / 15049). The `companies.id`
+   primary key is referenced by foreign keys, so we cannot just store the raw
+   native id. Instead each source gets a reserved 1-billion-wide block in the
+   BIGINT space and the stored `id` is `SOURCE_ID_OFFSETS[source] + int(native_id)`.
+   YC keeps offset 0 so existing YC rows/ids/FKs are completely unchanged.
+
+2. Slug collision — a16z's "pagerduty" could clash with a YC slug. Uniqueness is
+   therefore enforced per-source: UNIQUE(source, slug) and UNIQUE(source, source_id)
+   (see the schema migration), rather than a single global UNIQUE(slug).
+"""
+
+from typing import Dict
+
+# Canonical source key -> display metadata. Add a new entry per incubator/VC.
+SOURCES: Dict[str, Dict[str, str]] = {
+    "yc": {"key": "yc", "display_name": "Y Combinator"},
+    "a16z": {"key": "a16z", "display_name": "Andreessen Horowitz (a16z)"},
+}
+
+# Default source for existing/unspecified rows (backward compatibility).
+DEFAULT_SOURCE = "yc"
+
+# Reserved 1e9-wide id blocks per source. YC = 0 so its ids stay = the Algolia id.
+# Future sources: 3_000_000_000, 4_000_000_000, ... (BIGINT holds ~9.2e18 => ~9B blocks).
+SOURCE_ID_OFFSETS: Dict[str, int] = {
+    "yc": 0,
+    "a16z": 2_000_000_000,
+}
+
+# Width of each source's reserved id block. The precondition for correctness is
+# that every source's native ids stay below this width (YC Algolia ids and a16z
+# ids are both well under 1e9).
+SOURCE_BLOCK_WIDTH = 1_000_000_000
+
+
+def is_known_source(source: str) -> bool:
+    return source in SOURCES
+
+
+def to_global_id(source: str, native_id) -> int:
+    """Map a source's native id to the collision-free global `companies.id`.
+
+    >>> to_global_id("yc", 12345)
+    12345
+    >>> to_global_id("a16z", "371262")
+    2000371262
+    """
+    if source not in SOURCE_ID_OFFSETS:
+        raise ValueError(f"Unknown source: {source!r}")
+    return SOURCE_ID_OFFSETS[source] + int(native_id)
+
+
+def from_global_id(global_id: int) -> tuple[str, int]:
+    """Inverse of to_global_id: recover (source, native_id) from a stored id."""
+    for source, offset in sorted(SOURCE_ID_OFFSETS.items(), key=lambda kv: kv[1], reverse=True):
+        if global_id >= offset:
+            return source, global_id - offset
+    return DEFAULT_SOURCE, global_id

--- a/supabase/migrations/20260706000000_add_company_sources.sql
+++ b/supabase/migrations/20260706000000_add_company_sources.sql
@@ -1,0 +1,32 @@
+-- Multi-source portfolios: generalize the companies table beyond Y Combinator so
+-- it can hold companies from multiple incubators / VCs (a16z, and others later).
+--
+-- Provenance is tracked with `source` (e.g. 'yc', 'a16z') + `source_id` (the native
+-- id in that source's own id space). The integer primary key `id` stays collision-free
+-- across sources via reserved 1e9-wide offset blocks defined in backend/sources.py
+-- (YC keeps offset 0, so existing YC ids / rows / foreign keys are unchanged).
+--
+-- Uniqueness moves from a single global UNIQUE(slug) to per-source composite
+-- uniqueness, because slugs can legitimately repeat across sources (e.g. 'pagerduty').
+
+-- 1. Provenance + source-agnostic columns useful across VC/incubator portfolios
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS source        TEXT NOT NULL DEFAULT 'yc';
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS source_id     TEXT;
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS founders      TEXT;
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS year_founded  INTEGER;
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS exit_type     TEXT;   -- 'IPO' | 'M&A' | 'SPAC' | 'Exit' | NULL
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS acquirer      TEXT;
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS ticker_symbol TEXT;
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS funded_date   TEXT;
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS source_url    TEXT;   -- canonical page on the source's site
+
+-- 2. Backfill existing rows as Y Combinator
+UPDATE companies SET source = 'yc'        WHERE source IS NULL;
+UPDATE companies SET source_id = id::text WHERE source_id IS NULL;
+
+-- 3. Replace the global UNIQUE(slug) with per-source uniqueness.
+--    `companies_slug_key` is the auto-generated name for the inline UNIQUE(slug).
+ALTER TABLE companies DROP CONSTRAINT IF EXISTS companies_slug_key;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_companies_source_slug   ON companies (source, slug);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_companies_source_native ON companies (source, source_id);
+CREATE INDEX        IF NOT EXISTS idx_companies_source        ON companies (source);


### PR DESCRIPTION
## What & why
Generalizes the companies data model beyond Y Combinator so it can hold **multiple incubators/VCs**, and adds an **a16z portfolio scraper**. The 849-company a16z dataset has already been seeded into Supabase; this PR ships the code that makes it safe to serve and additive (YC views are untouched).

## Data model
- New `source` + `source_id` provenance. Collision-free integer PK via **per-source id offsets** (`backend/sources.py`): YC keeps its Algolia ids; a16z ids are offset into a reserved block (a16z `371262` → `2000371262`). No FK changes.
- Global `UNIQUE(slug)` → per-source `UNIQUE(source, slug)` + `UNIQUE(source, source_id)`.
- Source-agnostic columns added: `founders`, `year_founded`, `exit_type`, `acquirer`, `ticker_symbol`, `funded_date`, `source_url`.
- **Postgres migration** `supabase/migrations/20260706000000_add_company_sources.sql` (already applied to Supabase) + **SQLite in-code migrator** that upgrades existing local DBs and rebuilds away the legacy global slug-unique.

## a16z scraper — `backend/a16z_scraper_service.py`
One unauthenticated GET of the portfolio page → regex-extracts the inline `window.a16z_portfolio_companies` array (~849) → merges richer `data-company` DOM attrs → maps to the shared schema (per-source slug dedup). Runs standalone (`python -m a16z_scraper_service [--dry-run] [--limit N]`) or via `POST /api/scrape {"source":"a16z"}` (bulk upsert on Postgres).

## API + cache (additive & opt-in)
- `CompanyFilter.source`: omitted → **YC only** (no behavior change for existing pages); `"a16z"` → a16z; `"all"` → everything.
- In-memory `CompanyCache` stats + filter dropdowns computed over **YC rows only**; a16z never pollutes YC-shaped views.
- YC-specific DB analytics scoped with `source='yc'` (idea validator, **embeddings backfill**, industry stats, market-size denominator, success scores, admin enrichment).
- New `GET /api/filters/sources`.

## Verification
- SQLite old→new migration, cross-source slug collision, fresh-DB path, id-offset roundtrip — all pass.
- End-to-end seed of 849 a16z rows into temp SQLite; exits map correctly (PagerDuty→IPO/PD, Oculus→M&A/Facebook); idempotent re-run.
- Cache source-awareness (YC-default listing, a16z opt-in, YC-only stats/filters) verified; all backend files compile.

## Deploy note
Backend-only; safe to deploy to Render. Frontend Source filter/badge is a **follow-up PR** — nothing user-visible changes until then (or until a client passes `source`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)