### PR TITLE
Public API (backend): dev accounts, API keys, rate limits, admin

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -223,6 +223,57 @@ class Database:
                 )
             ''')
 
+            # ---- Public API: developer accounts, keys, usage, sessions ----
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS api_users (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    email TEXT NOT NULL UNIQUE,
+                    password_hash TEXT NOT NULL,
+                    company_name TEXT,
+                    plan TEXT NOT NULL DEFAULT 'free',
+                    status TEXT NOT NULL DEFAULT 'active',
+                    email_verified BOOLEAN NOT NULL DEFAULT 0,
+                    verification_token TEXT,
+                    stripe_customer_id TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            ''')
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS api_keys (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    key_prefix TEXT NOT NULL,
+                    key_hash TEXT NOT NULL UNIQUE,
+                    name TEXT,
+                    is_active BOOLEAN NOT NULL DEFAULT 1,
+                    revoked_at TIMESTAMP,
+                    last_used_at TIMESTAMP,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (user_id) REFERENCES api_users(id)
+                )
+            ''')
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS api_usage (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    api_key_id INTEGER NOT NULL,
+                    endpoint TEXT,
+                    status_code INTEGER,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (api_key_id) REFERENCES api_keys(id)
+                )
+            ''')
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS api_sessions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    token_hash TEXT NOT NULL UNIQUE,
+                    expires_at TIMESTAMP NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (user_id) REFERENCES api_users(id)
+                )
+            ''')
+
             # Bring existing databases up to the multi-source schema before indexing
             self._migrate_schema(cursor)
 
@@ -241,6 +292,10 @@ class Database:
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_hiring_company_id ON hiring_jobs(company_id)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_hiring_role ON hiring_jobs(pretty_role)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_hiring_updated ON hiring_jobs(pretty_updated_at)')
+            cursor.execute('CREATE INDEX IF NOT EXISTS idx_api_keys_user ON api_keys(user_id)')
+            cursor.execute('CREATE INDEX IF NOT EXISTS idx_api_usage_key_created ON api_usage(api_key_id, created_at)')
+            cursor.execute('CREATE INDEX IF NOT EXISTS idx_api_sessions_token ON api_sessions(token_hash)')
+            cursor.execute('CREATE INDEX IF NOT EXISTS idx_api_sessions_expires ON api_sessions(expires_at)')
 
     def _migrate_schema(self, cursor):
         """Bring an existing SQLite DB up to the multi-source schema.
@@ -286,6 +341,166 @@ class Database:
             cursor.execute(f"INSERT INTO companies_new ({col_list}) SELECT {col_list} FROM companies")
             cursor.execute("DROP TABLE companies")
             cursor.execute("ALTER TABLE companies_new RENAME TO companies")
+
+    # ========================================================================
+    # PUBLIC API: developer accounts, keys, usage, sessions
+    # ========================================================================
+
+    @staticmethod
+    def _fmt_dt(value):
+        """Format a datetime for SQLite's CURRENT_TIMESTAMP text comparison (UTC)."""
+        return value.strftime('%Y-%m-%d %H:%M:%S') if hasattr(value, 'strftime') else value
+
+    def create_api_user(self, email, password_hash, company_name=None, verification_token=None) -> int:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                'INSERT INTO api_users (email, password_hash, company_name, verification_token) VALUES (?, ?, ?, ?)',
+                (email, password_hash, company_name, verification_token))
+            return cur.lastrowid
+
+    def get_api_user_by_email(self, email) -> Optional[Dict]:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('SELECT * FROM api_users WHERE email = ?', (email,))
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def get_api_user_by_id(self, user_id) -> Optional[Dict]:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('SELECT * FROM api_users WHERE id = ?', (user_id,))
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def verify_api_user_email(self, token) -> bool:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                'UPDATE api_users SET email_verified = 1, verification_token = NULL, updated_at = CURRENT_TIMESTAMP '
+                'WHERE verification_token = ?', (token,))
+            return cur.rowcount > 0
+
+    def set_api_user_plan(self, user_id, plan) -> bool:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('UPDATE api_users SET plan = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?', (plan, user_id))
+            return cur.rowcount > 0
+
+    def set_api_user_status(self, user_id, status) -> bool:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('UPDATE api_users SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?', (status, user_id))
+            return cur.rowcount > 0
+
+    def set_api_user_stripe_customer(self, user_id, customer_id) -> bool:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('UPDATE api_users SET stripe_customer_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+                        (customer_id, user_id))
+            return cur.rowcount > 0
+
+    def list_api_users(self) -> List[Dict]:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('''
+                SELECT u.id, u.email, u.company_name, u.plan, u.status, u.email_verified, u.created_at,
+                       (SELECT COUNT(*) FROM api_keys k WHERE k.user_id = u.id AND k.is_active = 1) AS active_keys
+                FROM api_users u ORDER BY u.created_at DESC''')
+            return [dict(r) for r in cur.fetchall()]
+
+    def create_api_key(self, user_id, key_prefix, key_hash, name=None) -> int:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('INSERT INTO api_keys (user_id, key_prefix, key_hash, name) VALUES (?, ?, ?, ?)',
+                        (user_id, key_prefix, key_hash, name))
+            return cur.lastrowid
+
+    def get_api_key_by_hash(self, key_hash) -> Optional[Dict]:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('''
+                SELECT k.id, k.user_id, k.is_active, u.plan, u.status AS user_status
+                FROM api_keys k JOIN api_users u ON u.id = k.user_id
+                WHERE k.key_hash = ?''', (key_hash,))
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def list_api_keys_for_user(self, user_id) -> List[Dict]:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('''
+                SELECT k.id, k.key_prefix, k.name, k.is_active, k.revoked_at, k.created_at,
+                       (SELECT MAX(created_at) FROM api_usage WHERE api_key_id = k.id) AS last_used_at
+                FROM api_keys k WHERE k.user_id = ? ORDER BY k.created_at DESC''', (user_id,))
+            return [dict(r) for r in cur.fetchall()]
+
+    def revoke_api_key(self, key_id, user_id=None) -> bool:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            if user_id is not None:
+                cur.execute('UPDATE api_keys SET is_active = 0, revoked_at = CURRENT_TIMESTAMP WHERE id = ? AND user_id = ?',
+                            (key_id, user_id))
+            else:
+                cur.execute('UPDATE api_keys SET is_active = 0, revoked_at = CURRENT_TIMESTAMP WHERE id = ?', (key_id,))
+            return cur.rowcount > 0
+
+    def list_all_api_keys(self) -> List[Dict]:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('''
+                SELECT k.id, k.user_id, u.email, k.key_prefix, k.name, k.is_active, k.revoked_at, k.created_at,
+                       (SELECT MAX(created_at) FROM api_usage WHERE api_key_id = k.id) AS last_used_at
+                FROM api_keys k JOIN api_users u ON u.id = k.user_id ORDER BY k.created_at DESC''')
+            return [dict(r) for r in cur.fetchall()]
+
+    def log_api_usage(self, api_key_id, endpoint, status_code) -> None:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('INSERT INTO api_usage (api_key_id, endpoint, status_code) VALUES (?, ?, ?)',
+                        (api_key_id, endpoint, status_code))
+
+    def count_api_usage_since(self, api_key_id, since):
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('SELECT COUNT(*), MIN(created_at) FROM api_usage WHERE api_key_id = ? AND created_at > ?',
+                        (api_key_id, self._fmt_dt(since)))
+            row = cur.fetchone()
+            return (row[0] or 0, row[1])
+
+    def create_api_session(self, user_id, token_hash, expires_at) -> int:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('INSERT INTO api_sessions (user_id, token_hash, expires_at) VALUES (?, ?, ?)',
+                        (user_id, token_hash, self._fmt_dt(expires_at)))
+            return cur.lastrowid
+
+    def get_api_session(self, token_hash) -> Optional[Dict]:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('''
+                SELECT s.user_id, s.expires_at, u.email, u.company_name, u.plan, u.status AS user_status
+                FROM api_sessions s JOIN api_users u ON u.id = s.user_id
+                WHERE s.token_hash = ? AND s.expires_at > CURRENT_TIMESTAMP''', (token_hash,))
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def delete_api_session(self, token_hash) -> None:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('DELETE FROM api_sessions WHERE token_hash = ?', (token_hash,))
+
+    def delete_expired_api_sessions(self) -> int:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('DELETE FROM api_sessions WHERE expires_at < CURRENT_TIMESTAMP')
+            return cur.rowcount
+
+    def cleanup_api_usage(self, older_than) -> int:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('DELETE FROM api_usage WHERE created_at < ?', (self._fmt_dt(older_than),))
+            return cur.rowcount
 
     def insert_company(self, company: Dict[str, Any]) -> int:
         """Insert or update a company"""

--- a/backend/database_postgres.py
+++ b/backend/database_postgres.py
@@ -1919,6 +1919,162 @@ class DatabasePostgres:
                     })
                 return results
 
+    # ========================================================================
+    # PUBLIC API: developer accounts, keys, usage, sessions
+    # ========================================================================
+
+    def create_api_user(self, email, password_hash, company_name=None, verification_token=None) -> int:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    'INSERT INTO api_users (email, password_hash, company_name, verification_token) '
+                    'VALUES (%s, %s, %s, %s) RETURNING id',
+                    (email, password_hash, company_name, verification_token))
+                return cur.fetchone()[0]
+
+    def get_api_user_by_email(self, email) -> Optional[Dict]:
+        with self.get_connection() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute('SELECT * FROM api_users WHERE email = %s', (email,))
+                row = cur.fetchone()
+                return dict(row) if row else None
+
+    def get_api_user_by_id(self, user_id) -> Optional[Dict]:
+        with self.get_connection() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute('SELECT * FROM api_users WHERE id = %s', (user_id,))
+                row = cur.fetchone()
+                return dict(row) if row else None
+
+    def verify_api_user_email(self, token) -> bool:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    'UPDATE api_users SET email_verified = TRUE, verification_token = NULL, updated_at = NOW() '
+                    'WHERE verification_token = %s', (token,))
+                return cur.rowcount > 0
+
+    def set_api_user_plan(self, user_id, plan) -> bool:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute('UPDATE api_users SET plan = %s, updated_at = NOW() WHERE id = %s', (plan, user_id))
+                return cur.rowcount > 0
+
+    def set_api_user_status(self, user_id, status) -> bool:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute('UPDATE api_users SET status = %s, updated_at = NOW() WHERE id = %s', (status, user_id))
+                return cur.rowcount > 0
+
+    def set_api_user_stripe_customer(self, user_id, customer_id) -> bool:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute('UPDATE api_users SET stripe_customer_id = %s, updated_at = NOW() WHERE id = %s',
+                            (customer_id, user_id))
+                return cur.rowcount > 0
+
+    def list_api_users(self) -> List[Dict]:
+        with self.get_connection() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute('''
+                    SELECT u.id, u.email, u.company_name, u.plan, u.status, u.email_verified, u.created_at,
+                           (SELECT COUNT(*) FROM api_keys k WHERE k.user_id = u.id AND k.is_active = TRUE) AS active_keys
+                    FROM api_users u ORDER BY u.created_at DESC''')
+                return [dict(r) for r in cur.fetchall()]
+
+    def create_api_key(self, user_id, key_prefix, key_hash, name=None) -> int:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute('INSERT INTO api_keys (user_id, key_prefix, key_hash, name) '
+                            'VALUES (%s, %s, %s, %s) RETURNING id', (user_id, key_prefix, key_hash, name))
+                return cur.fetchone()[0]
+
+    def get_api_key_by_hash(self, key_hash) -> Optional[Dict]:
+        with self.get_connection() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute('''
+                    SELECT k.id, k.user_id, k.is_active, u.plan, u.status AS user_status
+                    FROM api_keys k JOIN api_users u ON u.id = k.user_id
+                    WHERE k.key_hash = %s''', (key_hash,))
+                row = cur.fetchone()
+                return dict(row) if row else None
+
+    def list_api_keys_for_user(self, user_id) -> List[Dict]:
+        with self.get_connection() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute('''
+                    SELECT k.id, k.key_prefix, k.name, k.is_active, k.revoked_at, k.created_at,
+                           (SELECT MAX(created_at) FROM api_usage WHERE api_key_id = k.id) AS last_used_at
+                    FROM api_keys k WHERE k.user_id = %s ORDER BY k.created_at DESC''', (user_id,))
+                return [dict(r) for r in cur.fetchall()]
+
+    def revoke_api_key(self, key_id, user_id=None) -> bool:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                if user_id is not None:
+                    cur.execute('UPDATE api_keys SET is_active = FALSE, revoked_at = NOW() WHERE id = %s AND user_id = %s',
+                                (key_id, user_id))
+                else:
+                    cur.execute('UPDATE api_keys SET is_active = FALSE, revoked_at = NOW() WHERE id = %s', (key_id,))
+                return cur.rowcount > 0
+
+    def list_all_api_keys(self) -> List[Dict]:
+        with self.get_connection() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute('''
+                    SELECT k.id, k.user_id, u.email, k.key_prefix, k.name, k.is_active, k.revoked_at, k.created_at,
+                           (SELECT MAX(created_at) FROM api_usage WHERE api_key_id = k.id) AS last_used_at
+                    FROM api_keys k JOIN api_users u ON u.id = k.user_id ORDER BY k.created_at DESC''')
+                return [dict(r) for r in cur.fetchall()]
+
+    def log_api_usage(self, api_key_id, endpoint, status_code) -> None:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute('INSERT INTO api_usage (api_key_id, endpoint, status_code) VALUES (%s, %s, %s)',
+                            (api_key_id, endpoint, status_code))
+
+    def count_api_usage_since(self, api_key_id, since):
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute('SELECT COUNT(*), MIN(created_at) FROM api_usage WHERE api_key_id = %s AND created_at > %s',
+                            (api_key_id, since))
+                row = cur.fetchone()
+                return (row[0] or 0, row[1])
+
+    def create_api_session(self, user_id, token_hash, expires_at) -> int:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute('INSERT INTO api_sessions (user_id, token_hash, expires_at) '
+                            'VALUES (%s, %s, %s) RETURNING id', (user_id, token_hash, expires_at))
+                return cur.fetchone()[0]
+
+    def get_api_session(self, token_hash) -> Optional[Dict]:
+        with self.get_connection() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute('''
+                    SELECT s.user_id, s.expires_at, u.email, u.company_name, u.plan, u.status AS user_status
+                    FROM api_sessions s JOIN api_users u ON u.id = s.user_id
+                    WHERE s.token_hash = %s AND s.expires_at > NOW()''', (token_hash,))
+                row = cur.fetchone()
+                return dict(row) if row else None
+
+    def delete_api_session(self, token_hash) -> None:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute('DELETE FROM api_sessions WHERE token_hash = %s', (token_hash,))
+
+    def delete_expired_api_sessions(self) -> int:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute('DELETE FROM api_sessions WHERE expires_at < NOW()')
+                return cur.rowcount
+
+    def cleanup_api_usage(self, older_than) -> int:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute('DELETE FROM api_usage WHERE created_at < %s', (older_than,))
+                return cur.rowcount
+
     def get_research_stats(self) -> Dict:
         """Get research statistics"""
         with self.get_connection() as conn:

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,7 +20,7 @@ import os
 import secrets
 import requests
 from urllib.parse import urlparse
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from collections import defaultdict
 from time import time
 
@@ -39,7 +39,16 @@ from perplexity_service import get_perplexity_service
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="YC Company Scraper API", version="1.0.0")
+# Hide the internal API's docs/OpenAPI in production so admin/cron routes aren't published.
+# The public API keeps its own docs at /api/v1/docs.
+_IS_PROD = os.environ.get("ENV", "").lower() == "production"
+app = FastAPI(
+    title="YC Company Scraper API",
+    version="1.0.0",
+    docs_url=None if _IS_PROD else "/docs",
+    redoc_url=None if _IS_PROD else "/redoc",
+    openapi_url=None if _IS_PROD else "/openapi.json",
+)
 
 
 # Rate Limiter for Research Endpoint
@@ -86,6 +95,7 @@ gamified_predict_limiter = ResearchRateLimiter(max_requests=5, window_seconds=60
 research_query_limiter = ResearchRateLimiter(max_requests=5, window_seconds=60)
 subscribe_limiter = ResearchRateLimiter(max_requests=3, window_seconds=60)
 scrape_limiter = ResearchRateLimiter(max_requests=3, window_seconds=3600)
+dev_auth_limiter = ResearchRateLimiter(max_requests=10, window_seconds=3600)  # signup/login per IP
 
 
 def _enforce_rate_limit(limiter: ResearchRateLimiter, request_obj: Request, label: str) -> None:
@@ -3057,6 +3067,201 @@ async def search_research_history(request: ResearchSearchRequest):
     except Exception as e:
         logger.error(f"Error searching research history: {e}")
         raise HTTPException(status_code=500, detail="Failed to search research")
+
+
+# ============================================================================
+# PUBLIC API: developer accounts, API keys, admin management, sub-app mount
+# ============================================================================
+import re as _re
+from password_utils import hash_password, verify_password, hash_token
+from plans import plan_limit, is_valid_plan, PLAN_META, PLAN_LIMITS
+from public_api import create_public_api
+
+API_KEY_PREFIX = "eyc_live_"
+DEV_SESSION_TTL = timedelta(days=30)
+_EMAIL_RE = _re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+class DevSignupRequest(BaseModel):
+    email: str
+    password: str
+    company_name: Optional[str] = None
+
+
+class DevLoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+class CreateKeyRequest(BaseModel):
+    name: Optional[str] = None
+
+
+class SetPlanRequest(BaseModel):
+    plan: str
+
+
+class SetStatusRequest(BaseModel):
+    status: str
+
+
+def _dev_user_public(user: dict) -> dict:
+    limit = plan_limit(user.get("plan"))
+    return {
+        "id": user["id"], "email": user["email"], "company_name": user.get("company_name"),
+        "plan": user.get("plan", "free"),
+        "plan_name": PLAN_META.get(user.get("plan", "free"), {}).get("name"),
+        "status": user.get("status", "active"), "email_verified": bool(user.get("email_verified")),
+        "daily_limit": limit,
+    }
+
+
+def verify_dev_session(authorization: Optional[str] = Header(None)) -> dict:
+    """DB-backed developer session (multi-instance safe, unlike admin_sessions)."""
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing authorization header")
+    session = db.get_api_session(hash_token(authorization[7:].strip()))
+    if not session:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if session.get("user_status") != "active":
+        raise HTTPException(status_code=403, detail="Account suspended")
+    return session
+
+
+@app.post("/api/dev/signup")
+async def dev_signup(req: DevSignupRequest, request_obj: Request):
+    _enforce_rate_limit(dev_auth_limiter, request_obj, "signup")
+    email = (req.email or "").strip().lower()
+    if not _EMAIL_RE.match(email):
+        raise HTTPException(status_code=400, detail="Invalid email address")
+    if len(req.password or "") < 8:
+        raise HTTPException(status_code=400, detail="Password must be at least 8 characters")
+    if db.get_api_user_by_email(email):
+        raise HTTPException(status_code=409, detail="An account with this email already exists")
+    verification_token = secrets.token_urlsafe(32)
+    user_id = db.create_api_user(email, hash_password(req.password), req.company_name, verification_token)
+    try:
+        if hasattr(email_service, "send_dev_verification_email"):
+            email_service.send_dev_verification_email(email, verification_token)
+    except Exception as e:
+        logger.warning(f"dev verification email failed: {e}")
+    token = secrets.token_urlsafe(32)
+    db.create_api_session(user_id, hash_token(token), datetime.now(timezone.utc) + DEV_SESSION_TTL)
+    return {"token": token, "user": _dev_user_public(db.get_api_user_by_id(user_id))}
+
+
+@app.post("/api/dev/login")
+async def dev_login(req: DevLoginRequest, request_obj: Request):
+    _enforce_rate_limit(dev_auth_limiter, request_obj, "login")
+    email = (req.email or "").strip().lower()
+    user = db.get_api_user_by_email(email)
+    if not user or not verify_password(req.password or "", user["password_hash"]):
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+    if user.get("status") != "active":
+        raise HTTPException(status_code=403, detail="Account suspended")
+    token = secrets.token_urlsafe(32)
+    db.create_api_session(user["id"], hash_token(token), datetime.now(timezone.utc) + DEV_SESSION_TTL)
+    return {"token": token, "user": _dev_user_public(user)}
+
+
+@app.post("/api/dev/logout")
+async def dev_logout(authorization: Optional[str] = Header(None)):
+    if authorization and authorization.startswith("Bearer "):
+        db.delete_api_session(hash_token(authorization[7:].strip()))
+    return {"success": True}
+
+
+@app.get("/api/dev/me")
+async def dev_me(session: dict = Depends(verify_dev_session)):
+    user = db.get_api_user_by_id(session["user_id"])
+    info = _dev_user_public(user)
+    keys = db.list_api_keys_for_user(user["id"])
+    used = 0
+    for k in keys:
+        if k.get("is_active"):
+            count, _ = db.count_api_usage_since(k["id"], datetime.now(timezone.utc) - timedelta(hours=24))
+            used += count
+    info["usage"] = {"used_24h": used, "limit": info["daily_limit"],
+                     "remaining": max(0, info["daily_limit"] - used)}
+    info["keys"] = keys
+    return info
+
+
+@app.get("/api/dev/verify-email/{token}")
+async def dev_verify_email(token: str):
+    if not db.verify_api_user_email(token):
+        raise HTTPException(status_code=404, detail="Invalid or expired verification token")
+    return {"success": True}
+
+
+@app.post("/api/dev/keys")
+async def dev_create_key(req: CreateKeyRequest, session: dict = Depends(verify_dev_session)):
+    raw = API_KEY_PREFIX + secrets.token_urlsafe(32)
+    prefix = raw[:16]
+    key_id = db.create_api_key(session["user_id"], prefix, hash_token(raw), req.name)
+    return {"id": key_id, "api_key": raw, "key_prefix": prefix, "name": req.name,
+            "warning": "Store this key now — it will not be shown again."}
+
+
+@app.get("/api/dev/keys")
+async def dev_list_keys(session: dict = Depends(verify_dev_session)):
+    return {"keys": db.list_api_keys_for_user(session["user_id"])}
+
+
+@app.post("/api/dev/keys/{key_id}/revoke")
+async def dev_revoke_key(key_id: int, session: dict = Depends(verify_dev_session)):
+    if not db.revoke_api_key(key_id, user_id=session["user_id"]):
+        raise HTTPException(status_code=404, detail="Key not found")
+    return {"success": True}
+
+
+# ---- Admin management of API users/keys ----
+@app.get("/api/admin/api-users")
+async def admin_list_api_users(session: dict = Depends(verify_admin_session)):
+    return {"users": db.list_api_users()}
+
+
+@app.get("/api/admin/api-keys")
+async def admin_list_api_keys(session: dict = Depends(verify_admin_session)):
+    return {"keys": db.list_all_api_keys()}
+
+
+@app.post("/api/admin/api-keys/{key_id}/revoke")
+async def admin_revoke_api_key(key_id: int, session: dict = Depends(verify_admin_session)):
+    if not db.revoke_api_key(key_id):
+        raise HTTPException(status_code=404, detail="Key not found")
+    return {"success": True}
+
+
+@app.post("/api/admin/api-users/{user_id}/plan")
+async def admin_set_plan(user_id: int, req: SetPlanRequest, session: dict = Depends(verify_admin_session)):
+    if not is_valid_plan(req.plan):
+        raise HTTPException(status_code=400, detail=f"Invalid plan. Valid: {list(PLAN_LIMITS)}")
+    if not db.set_api_user_plan(user_id, req.plan):
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"success": True, "plan": req.plan}
+
+
+@app.post("/api/admin/api-users/{user_id}/status")
+async def admin_set_status(user_id: int, req: SetStatusRequest, session: dict = Depends(verify_admin_session)):
+    if req.status not in ("active", "suspended"):
+        raise HTTPException(status_code=400, detail="status must be 'active' or 'suspended'")
+    if not db.set_api_user_status(user_id, req.status):
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"success": True, "status": req.status}
+
+
+# ---- Cron: bound api_usage / api_sessions growth ----
+@app.post("/api/cron/cleanup-api")
+async def cron_cleanup_api(request: Request):
+    _verify_cron_secret(request)
+    usage_deleted = db.cleanup_api_usage(datetime.now(timezone.utc) - timedelta(days=30))
+    sessions_deleted = db.delete_expired_api_sessions()
+    return {"usage_deleted": usage_deleted, "sessions_deleted": sessions_deleted}
+
+
+# ---- Mount the public API sub-app (own docs + CORS at /api/v1) ----
+app.mount("/api/v1", create_public_api(db, company_cache))
 
 
 if __name__ == "__main__":

--- a/backend/password_utils.py
+++ b/backend/password_utils.py
@@ -1,0 +1,43 @@
+"""
+Password + token hashing utilities for the public-API developer accounts.
+
+Uses stdlib PBKDF2-HMAC-SHA256 (no new dependency, no bcrypt build/version footguns,
+no scrypt memory spikes on Render). The stored format embeds the algorithm and
+iteration count so the cost can be raised or the scheme migrated later:
+
+    pbkdf2$<iterations>$<salt_hex>$<hash_hex>
+
+API keys and session tokens are high-entropy random strings, so they are stored as a
+plain SHA-256 (fast, indexable equality lookup) — a slow KDF is only for low-entropy
+human passwords.
+"""
+
+import hashlib
+import hmac
+import os
+
+_ITERATIONS = 600_000
+
+
+def hash_password(password: str) -> str:
+    """Hash a plaintext password for storage."""
+    salt = os.urandom(16)
+    dk = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, _ITERATIONS)
+    return f"pbkdf2${_ITERATIONS}${salt.hex()}${dk.hex()}"
+
+
+def verify_password(password: str, stored: str) -> bool:
+    """Constant-time verify a plaintext password against a stored hash."""
+    try:
+        scheme, iters, salt_hex, dk_hex = stored.split("$")
+        if scheme != "pbkdf2":
+            return False
+        dk = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), bytes.fromhex(salt_hex), int(iters))
+        return hmac.compare_digest(dk.hex(), dk_hex)
+    except (ValueError, AttributeError):
+        return False
+
+
+def hash_token(token: str) -> str:
+    """SHA-256 hex of a high-entropy token (API key or session token) for storage/lookup."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()

--- a/backend/plans.py
+++ b/backend/plans.py
@@ -1,0 +1,39 @@
+"""
+Public API plans — single source of truth for rate limits and tier metadata.
+
+The `plan` column on api_users drives everything. `verify_api_key` reads PLAN_LIMITS
+to enforce the daily cap; the dashboard/admin read PLAN_META for display; a future
+Stripe webhook maps a purchased price back to a plan key and calls set_api_user_plan.
+
+Daily limits are per rolling 24h window. Free = 5/day (product requirement); paid
+tiers are configurable — tune the numbers/prices without touching call sites.
+"""
+
+from typing import Dict
+
+DEFAULT_PLAN = "free"
+
+# Requests allowed per rolling 24h window, per API key.
+PLAN_LIMITS: Dict[str, int] = {
+    "free": 5,
+    "starter": 500,
+    "pro": 5_000,
+    "enterprise": 50_000,
+}
+
+# Display / billing metadata. `stripe_price_id` is wired when Stripe lands (fast-follow).
+PLAN_META: Dict[str, Dict] = {
+    "free": {"name": "Free", "price_usd_month": 0, "stripe_price_id": None},
+    "starter": {"name": "Starter", "price_usd_month": 29, "stripe_price_id": None},
+    "pro": {"name": "Pro", "price_usd_month": 99, "stripe_price_id": None},
+    "enterprise": {"name": "Enterprise", "price_usd_month": None, "stripe_price_id": None},
+}
+
+
+def plan_limit(plan: str) -> int:
+    """Daily request limit for a plan key, falling back to the free tier."""
+    return PLAN_LIMITS.get(plan or DEFAULT_PLAN, PLAN_LIMITS[DEFAULT_PLAN])
+
+
+def is_valid_plan(plan: str) -> bool:
+    return plan in PLAN_LIMITS

--- a/backend/public_api.py
+++ b/backend/public_api.py
@@ -1,0 +1,255 @@
+"""
+ExploreYC Public API — a mounted FastAPI sub-app served at /api/v1.
+
+Isolated from the internal app so its OpenAPI (/api/v1/docs, /api/v1/openapi.json)
+exposes ONLY the public read-only endpoints and gets its own permissive CORS. Every
+route requires a valid API key (Authorization: Bearer eyc_live_… or X-API-Key) and is
+rate-limited per key against the DB-backed usage log (plans in backend/plans.py).
+
+Mounted from main.py:  app.mount("/api/v1", create_public_api(db, company_cache))
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+from fastapi import FastAPI, APIRouter, Depends, Header, HTTPException, Query, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import HTTPBearer
+from pydantic import BaseModel
+
+from password_utils import hash_token
+from plans import plan_limit
+
+RATE_WINDOW = timedelta(hours=24)
+MAX_PAGE = 100
+
+
+def _to_epoch(value) -> Optional[int]:
+    """Normalize a DB timestamp (SQLite 'YYYY-MM-DD HH:MM:SS' str or PG datetime) to unix seconds (UTC)."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            dt = datetime.strptime(value, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
+    else:
+        dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp())
+
+
+class PublicCompany(BaseModel):
+    id: int
+    source: Optional[str] = None
+    source_id: Optional[str] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+    website: Optional[str] = None
+    one_liner: Optional[str] = None
+    long_description: Optional[str] = None
+    team_size: Optional[int] = None
+    batch: Optional[str] = None
+    status: Optional[str] = None
+    industry: Optional[str] = None
+    subindustry: Optional[str] = None
+    all_locations: Optional[str] = None
+    is_hiring: Optional[bool] = None
+    top_company: Optional[bool] = None
+    nonprofit: Optional[bool] = None
+    stage: Optional[str] = None
+    country: Optional[str] = None
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    small_logo_thumb_url: Optional[str] = None
+    founders: Optional[str] = None
+    year_founded: Optional[int] = None
+    exit_type: Optional[str] = None
+    acquirer: Optional[str] = None
+    ticker_symbol: Optional[str] = None
+    funded_date: Optional[str] = None
+    source_url: Optional[str] = None
+    funding_total_usd: Optional[float] = None
+    funding_last_round_usd: Optional[float] = None
+    funding_last_round_name: Optional[str] = None
+    funding_last_round_date: Optional[str] = None
+    valuation_usd: Optional[float] = None
+    employee_count: Optional[int] = None
+    employee_growth_6m: Optional[float] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+    class Config:
+        extra = "ignore"  # cache dicts carry internal fields (raw_json, …) — dropped from the public shape
+
+
+class CompanyListResponse(BaseModel):
+    companies: List[PublicCompany]
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+
+
+def create_public_api(db, company_cache) -> FastAPI:
+    api = FastAPI(
+        title="ExploreYC Public API",
+        version="1.0.0",
+        description=(
+            "Read-only programmatic access to the ExploreYC dataset: Y Combinator and a16z "
+            "portfolio companies with funding, stage, and exit data.\n\n"
+            "**Auth:** send your key as `Authorization: Bearer eyc_live_…` (or `X-API-Key`). "
+            "Create a key at https://exploreyc.com/dashboard.\n\n"
+            "**Rate limits:** per key, rolling 24h. Free = 5 requests/day. "
+            "Responses include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`."
+        ),
+        docs_url="/docs",
+        redoc_url="/redoc",
+        openapi_url="/openapi.json",
+    )
+
+    # Public API is server-to-server with an API key (no cookies) -> wildcard origins,
+    # no credentials. (You cannot combine '*' with allow_credentials=True.)
+    api.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=False,
+        allow_methods=["GET", "OPTIONS"],
+        allow_headers=["Authorization", "X-API-Key", "Content-Type"],
+    )
+
+    bearer = HTTPBearer(auto_error=False, description="Your ExploreYC API key (eyc_live_…)")
+
+    def verify_api_key(
+        request: Request,
+        authorization: Optional[str] = Header(None),
+        x_api_key: Optional[str] = Header(None),
+        _scheme=Depends(bearer),  # populates the Swagger "Authorize" box
+    ) -> dict:
+        raw = x_api_key
+        if not raw and authorization and authorization.startswith("Bearer "):
+            raw = authorization[7:].strip()
+        if not raw:
+            raise HTTPException(status_code=401, detail="Missing API key. Send 'Authorization: Bearer <key>' or 'X-API-Key'.")
+
+        row = db.get_api_key_by_hash(hash_token(raw))
+        if not row or not row.get("is_active") or row.get("user_status") != "active":
+            raise HTTPException(status_code=401, detail="Invalid, revoked, or suspended API key.")
+
+        now = datetime.now(timezone.utc)
+        now_epoch = int(now.timestamp())
+        limit = plan_limit(row.get("plan"))
+        used, oldest = db.count_api_usage_since(row["id"], now - RATE_WINDOW)
+        reset = (_to_epoch(oldest) or now_epoch) + int(RATE_WINDOW.total_seconds())
+        if used >= limit:
+            raise HTTPException(
+                status_code=429, detail="Rate limit exceeded for your plan. Upgrade for a higher limit.",
+                headers={"X-RateLimit-Limit": str(limit), "X-RateLimit-Remaining": "0",
+                         "X-RateLimit-Reset": str(reset), "Retry-After": str(max(1, reset - now_epoch))},
+            )
+
+        # Allowed: stamp state so the middleware logs usage + sets headers after the response.
+        request.state.api_key_id = row["id"]
+        request.state.rate_limit = limit
+        request.state.rate_remaining = max(0, limit - used - 1)
+        request.state.rate_reset = reset
+        return row
+
+    @api.middleware("http")
+    async def usage_and_headers(request: Request, call_next):
+        response = await call_next(request)
+        key_id = getattr(request.state, "api_key_id", None)
+        if key_id is not None:
+            try:
+                db.log_api_usage(key_id, request.url.path, response.status_code)
+            except Exception:
+                pass  # never fail a request because usage logging hiccuped
+            response.headers["X-RateLimit-Limit"] = str(getattr(request.state, "rate_limit", ""))
+            response.headers["X-RateLimit-Remaining"] = str(getattr(request.state, "rate_remaining", ""))
+            response.headers["X-RateLimit-Reset"] = str(getattr(request.state, "rate_reset", ""))
+        return response
+
+    v1 = APIRouter(dependencies=[Depends(verify_api_key)])
+
+    @v1.get("/companies", response_model=CompanyListResponse, tags=["Companies"], summary="List / filter companies")
+    def list_companies(
+        limit: int = Query(50, ge=1, le=MAX_PAGE),
+        offset: int = Query(0, ge=0),
+        source: Optional[str] = Query("all", description="'yc', 'a16z', or 'all' (default)"),
+        batch: Optional[str] = None,
+        industry: Optional[str] = None,
+        country: Optional[str] = None,
+        is_hiring: Optional[bool] = None,
+        top_company: Optional[bool] = None,
+        search: Optional[str] = None,
+    ):
+        kwargs = dict(batch=batch, is_hiring=is_hiring, industry=industry, country=country,
+                      search=search, top_company=top_company, source=source)
+        companies = company_cache.get_companies(limit=limit, offset=offset, **kwargs)
+        total = company_cache.count_companies(**kwargs)
+        return {"companies": companies, "total": total, "limit": limit, "offset": offset,
+                "has_more": (offset + limit) < total}
+
+    @v1.get("/companies/{company_id}", response_model=PublicCompany, tags=["Companies"], summary="Company by id")
+    def get_company(company_id: int):
+        company = company_cache.get_company_by_id(company_id)
+        if not company and hasattr(db, "get_company_by_id"):
+            company = db.get_company_by_id(company_id)
+        if not company:
+            raise HTTPException(status_code=404, detail="Company not found")
+        return company
+
+    @v1.get("/companies/slug/{slug}", response_model=PublicCompany, tags=["Companies"], summary="Company by slug")
+    def get_company_by_slug(slug: str):
+        company = db.get_company_by_slug(slug) if hasattr(db, "get_company_by_slug") else None
+        if not company:
+            match = [c for c in company_cache.get_companies(limit=1, offset=0, source="all", search=None)
+                     if c.get("slug") == slug]
+            company = match[0] if match else None
+        if not company:
+            raise HTTPException(status_code=404, detail="Company not found")
+        return company
+
+    @v1.get("/search", response_model=CompanyListResponse, tags=["Companies"], summary="Full-text company search")
+    def search_companies(q: str = Query(..., min_length=1), limit: int = Query(50, ge=1, le=MAX_PAGE),
+                         offset: int = Query(0, ge=0), source: Optional[str] = Query("all")):
+        companies = company_cache.get_companies(limit=limit, offset=offset, search=q, source=source)
+        total = company_cache.count_companies(search=q, source=source)
+        return {"companies": companies, "total": total, "limit": limit, "offset": offset,
+                "has_more": (offset + limit) < total}
+
+    @v1.get("/stats", tags=["Analytics"], summary="Portfolio stats (Y Combinator)")
+    def stats():
+        return company_cache.get_stats()
+
+    @v1.get("/sources", tags=["Metadata"], summary="Available sources (incubators / VCs)")
+    def sources():
+        return {"sources": company_cache.get_sources()}
+
+    @v1.get("/batches", tags=["Metadata"], summary="Distinct YC batches")
+    def batches():
+        return {"batches": company_cache.get_unique_batches()}
+
+    @v1.get("/industries", tags=["Metadata"], summary="Distinct industries")
+    def industries():
+        return {"industries": company_cache.get_unique_industries()}
+
+    @v1.get("/countries", tags=["Metadata"], summary="Distinct countries")
+    def countries():
+        return {"countries": company_cache.get_unique_countries()}
+
+    @v1.get("/map", tags=["Analytics"], summary="Geo-located companies")
+    def geo(batch: Optional[str] = None, is_hiring: Optional[bool] = None):
+        companies = company_cache.get_companies_for_map(batch=batch, is_hiring=is_hiring)
+        return {"companies": companies, "total": len(companies)}
+
+    @v1.get("/batch/{batch_name}/wrapped", tags=["Analytics"], summary="Batch 'wrapped' analytics")
+    def batch_wrapped(batch_name: str):
+        if not hasattr(db, "get_batch_wrapped_stats"):
+            raise HTTPException(status_code=501, detail="Batch analytics unavailable on this deployment")
+        data = db.get_batch_wrapped_stats(batch_name)
+        if not data:
+            raise HTTPException(status_code=404, detail="Batch not found")
+        return data
+
+    api.include_router(v1)
+    return api

--- a/supabase/migrations/20260707000000_add_public_api.sql
+++ b/supabase/migrations/20260707000000_add_public_api.sql
@@ -1,0 +1,49 @@
+-- Public API: developer accounts, non-expiring API keys, usage log (rate limiting),
+-- and DB-backed dashboard sessions (multi-instance safe, unlike the in-memory admin sessions).
+
+CREATE TABLE IF NOT EXISTS api_users (
+    id BIGSERIAL PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    password_hash TEXT NOT NULL,
+    company_name TEXT,
+    plan TEXT NOT NULL DEFAULT 'free',        -- see backend/plans.py
+    status TEXT NOT NULL DEFAULT 'active',     -- 'active' | 'suspended'
+    email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    verification_token TEXT,
+    stripe_customer_id TEXT,                   -- populated when Stripe lands
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS api_keys (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES api_users(id) ON DELETE CASCADE,
+    key_prefix TEXT NOT NULL,                  -- e.g. 'eyc_live_A1b2C3d4' for display
+    key_hash TEXT NOT NULL UNIQUE,             -- sha256 hex of the full key; plaintext never stored
+    name TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    revoked_at TIMESTAMPTZ,
+    last_used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS api_usage (
+    id BIGSERIAL PRIMARY KEY,
+    api_key_id BIGINT NOT NULL REFERENCES api_keys(id) ON DELETE CASCADE,
+    endpoint TEXT,
+    status_code INTEGER,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS api_sessions (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES api_users(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL UNIQUE,           -- sha256 hex of the session token
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_user         ON api_keys(user_id);
+CREATE INDEX IF NOT EXISTS idx_api_usage_key_created ON api_usage(api_key_id, created_at);  -- rate-limit query
+CREATE INDEX IF NOT EXISTS idx_api_sessions_token    ON api_sessions(token_hash);
+CREATE INDEX IF NOT EXISTS idx_api_sessions_expires  ON api_sessions(expires_at);


### PR DESCRIPTION
Phase 1 of the paywalled public API (per the approved plan). Ships the whole backend; frontend (signup/dashboard/docs) is a follow-up PR.

## What developers get
Register (email, password, company) → non-expiring API key → call read-only **`/api/v1`**. Free = **5 req/day** (rolling 24h); paid tiers are **admin-granted** now (Stripe is a fast-follow). Admins can **revoke keys / suspend users**.

## Data model
New tables in **both** layers (SQLite in-code + `supabase/migrations/20260707000000_add_public_api.sql`): `api_users`, `api_keys`, `api_usage`, `api_sessions` + indexes (incl. `api_usage(api_key_id, created_at)` for the rate-limit query). Mirrored DB methods added to `database.py` and `database_postgres.py`.

## Security
- Passwords: stdlib **PBKDF2-HMAC-SHA256** (`backend/password_utils.py`) — no new deps, no bcrypt/scrypt footguns.
- API keys + session tokens stored as **sha256 only**; key plaintext (`eyc_live_…`) shown **once** at creation.
- **DB-backed sessions** (multi-instance safe, unlike the in-memory `admin_sessions`).
- IP-limited signup/login; `/companies` `limit` capped at 100; 404 (not 403) for unknown ids.
- Internal `/docs` + `/openapi.json` **disabled when `ENV=production`** (admin/cron routes stay unpublished); the public `/api/v1/docs` stays open with an Authorize box.

## Public API — `backend/public_api.py` (mounted sub-app)
Own OpenAPI (`/api/v1/docs`, `/api/v1/openapi.json`) + permissive CORS (`*`, no credentials — server-to-server keys). `verify_api_key` does DB-backed rolling-24h rate limiting (emits `X-RateLimit-*` + `Retry-After`) and logs usage in one place. Endpoints reuse `CompanyCache`: `/companies` (filter by source/batch/industry/country/hiring/search), `/companies/{id}`, `/companies/slug/{slug}`, `/search`, `/stats`, `/sources`, `/batches`, `/industries`, `/countries`, `/map`, `/batch/{name}/wrapped`. Pydantic models strip internal fields (`raw_json`, …).

## Endpoints added to `main.py`
`/api/dev/{signup,login,logout,me,keys,keys/{id}/revoke,verify-email/{token}}`; admin `/api/admin/api-users`, `/api/admin/api-keys`, `.../revoke`, `.../plan`, `.../status`; cron `/api/cron/cleanup-api`.

## Verification (end-to-end on SQLite, via TestClient)
signup / dup→409 / weak-pw→400 · key issuance (`eyc_live_…`) · `/api/v1/companies` 200 with rate headers · a16z detail exposes exit/ticker + strips `raw_json` · rate limit **[200,200,200,429]**, 6th → 429 with **86400s Retry-After** · invalid/missing/revoked → 401 · admin revoke + `plan=pro` reflected in `/api/dev/me` (5000) · passwords stored as pbkdf2, keys as sha256 (no plaintext). Fixed a timezone bug in the Retry-After/window math (now UTC-aware — matters for prod Postgres).

## Deploy steps (when merging)
1. Apply the Postgres migration to Supabase.
2. Set `ENV=production` on Render (hides internal docs).
3. Add `POST /api/cron/cleanup-api` to the GitHub Actions cron (bounds `api_usage`/`api_sessions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)