### PR TITLE
Public API (frontend): developer portal — signup, dashboard, docs, admin

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,11 @@ import { HiringBoardPagePaginated } from './pages/HiringBoardPagePaginated';
 import { HiringAnalyticsPage } from './pages/HiringAnalyticsPage';
 import { DatabasePage } from './pages/DatabasePage';
 import { PageTitleManager } from './components/PageTitleManager';
+import { DevAuthProvider } from './contexts/DevAuthContext';
+import { SignupPage } from './pages/SignupPage';
+import { DevLoginPage } from './pages/DevLoginPage';
+import { DeveloperDashboard } from './pages/DeveloperDashboard';
+import { ApiDocsPage } from './pages/ApiDocsPage';
 import './index.css';
 
 const queryClient = new QueryClient({
@@ -170,6 +175,11 @@ function AnimatedRoutes() {
       <Route path="/research-hub" element={<ResearchHubPage />} />
       <Route path="/batch/:batch/wrapped" element={<BatchWrappedPage />} />
       <Route path="/admin" element={<AdminPage />} />
+      {/* Public API developer portal */}
+      <Route path="/signup" element={<SignupPage />} />
+      <Route path="/login" element={<DevLoginPage />} />
+      <Route path="/dashboard" element={<DeveloperDashboard />} />
+      <Route path="/api-docs" element={<ApiDocsPage />} />
       <Route path="/company/:slug" element={<CompanyPage />} />
       <Route path="/share/company/:slug" element={<CompanyCardPage />} />
       <Route path="/share/company" element={<CompanyCardPage />} />
@@ -199,9 +209,11 @@ function App() {
       <HelmetProvider>
         <BrowserRouter>
           <PageTitleManager />
-          <AppProvider>
-            <AnimatedRoutes />
-          </AppProvider>
+          <DevAuthProvider>
+            <AppProvider>
+              <AnimatedRoutes />
+            </AppProvider>
+          </DevAuthProvider>
         </BrowserRouter>
         <Analytics />
       </HelmetProvider>

--- a/frontend/src/contexts/DevAuthContext.tsx
+++ b/frontend/src/contexts/DevAuthContext.tsx
@@ -1,0 +1,67 @@
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react'
+import { apiClient, DEV_TOKEN_KEY, type ApiUser } from '../lib/api'
+
+interface DevAuthValue {
+  user: ApiUser | null
+  loading: boolean
+  login: (email: string, password: string) => Promise<void>
+  signup: (email: string, password: string, company?: string) => Promise<void>
+  logout: () => void
+  refresh: () => Promise<void>
+}
+
+const DevAuthContext = createContext<DevAuthValue | undefined>(undefined)
+
+export function DevAuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<ApiUser | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  // Hydrate from an existing session token on mount
+  useEffect(() => {
+    const token = localStorage.getItem(DEV_TOKEN_KEY)
+    if (!token) {
+      setLoading(false)
+      return
+    }
+    apiClient
+      .devMe()
+      .then((r) => setUser(r.data))
+      .catch(() => localStorage.removeItem(DEV_TOKEN_KEY))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const login = useCallback(async (email: string, password: string) => {
+    const { data } = await apiClient.devLogin(email, password)
+    localStorage.setItem(DEV_TOKEN_KEY, data.token)
+    setUser(data.user)
+  }, [])
+
+  const signup = useCallback(async (email: string, password: string, company?: string) => {
+    const { data } = await apiClient.devSignup(email, password, company)
+    localStorage.setItem(DEV_TOKEN_KEY, data.token)
+    setUser(data.user)
+  }, [])
+
+  const logout = useCallback(() => {
+    apiClient.devLogout().catch(() => {})
+    localStorage.removeItem(DEV_TOKEN_KEY)
+    setUser(null)
+  }, [])
+
+  const refresh = useCallback(async () => {
+    const r = await apiClient.devMe()
+    setUser(r.data)
+  }, [])
+
+  return (
+    <DevAuthContext.Provider value={{ user, loading, login, signup, logout, refresh }}>
+      {children}
+    </DevAuthContext.Provider>
+  )
+}
+
+export function useDevAuth() {
+  const ctx = useContext(DevAuthContext)
+  if (!ctx) throw new Error('useDevAuth must be used within DevAuthProvider')
+  return ctx
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13,6 +13,18 @@ const api = axios.create({
   },
 })
 
+// Public-API developer account client — injects the dashboard session token from localStorage.
+export const DEV_TOKEN_KEY = 'dev_token'
+const devApi = axios.create({
+  baseURL: API_BASE_URL,
+  headers: { 'Content-Type': 'application/json' },
+})
+devApi.interceptors.request.use((config) => {
+  const token = localStorage.getItem(DEV_TOKEN_KEY)
+  if (token) config.headers.Authorization = `Bearer ${token}`
+  return config
+})
+
 export interface Company {
   id: number
   source?: string
@@ -92,6 +104,47 @@ export interface Source {
   count: number
 }
 
+// ---- Public API developer accounts ----
+export interface ApiUser {
+  id: number
+  email: string
+  company_name?: string
+  plan: string
+  plan_name?: string
+  status: string
+  email_verified: boolean
+  daily_limit: number
+}
+
+export interface ApiKey {
+  id: number
+  key_prefix: string
+  name?: string
+  is_active: boolean
+  revoked_at?: string | null
+  last_used_at?: string | null
+  created_at: string
+}
+
+export interface UsageSummary {
+  used_24h: number
+  limit: number
+  remaining: number
+}
+
+export interface DevMe extends ApiUser {
+  usage: UsageSummary
+  keys: ApiKey[]
+}
+
+export interface CreatedApiKey {
+  id: number
+  api_key: string
+  key_prefix: string
+  name?: string
+  warning: string
+}
+
 export interface Stats {
   total_companies: number
   hiring: number
@@ -162,6 +215,17 @@ export const apiClient = {
 
   // Filters
   getSources: () => api.get<{ sources: Source[] }>('/api/filters/sources'),
+
+  // Public API developer accounts + keys
+  devSignup: (email: string, password: string, company_name?: string) =>
+    devApi.post<{ token: string; user: ApiUser }>('/api/dev/signup', { email, password, company_name }),
+  devLogin: (email: string, password: string) =>
+    devApi.post<{ token: string; user: ApiUser }>('/api/dev/login', { email, password }),
+  devLogout: () => devApi.post('/api/dev/logout'),
+  devMe: () => devApi.get<DevMe>('/api/dev/me'),
+  createApiKey: (name?: string) => devApi.post<CreatedApiKey>('/api/dev/keys', { name }),
+  listApiKeys: () => devApi.get<{ keys: ApiKey[] }>('/api/dev/keys'),
+  revokeApiKey: (id: number) => devApi.post(`/api/dev/keys/${id}/revoke`),
   getBatches: () => api.get<{ batches: string[] }>('/api/filters/batches'),
   getIndustries: () => api.get<{ industries: string[] }>('/api/filters/industries'),
   getCountries: () => api.get<{ countries: string[] }>('/api/filters/countries'),

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -15,7 +15,8 @@ import {
   LogOut,
   Loader2,
   CheckCircle2,
-  AlertCircle
+  AlertCircle,
+  KeyRound
 } from 'lucide-react';
 import { HackerCard } from '../components/ui/hacker-card';
 import { Button } from '../components/ui/button';
@@ -814,8 +815,113 @@ export function AdminPage() {
               <p className="text-muted-foreground font-mono">Failed to load stats</p>
             </div>
           )}
+
+          {/* Public API consumers */}
+          <div className="mt-8">
+            <ApiConsumersSection />
+          </div>
         </div>
       </div>
     </>
+  );
+}
+
+function adminFetch(path: string, options: RequestInit = {}) {
+  const token = localStorage.getItem('admin_token');
+  return fetch(path, {
+    ...options,
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', ...(options.headers || {}) },
+  });
+}
+
+const API_PLANS = ['free', 'starter', 'pro', 'enterprise'];
+
+function ApiConsumersSection() {
+  const queryClient = useQueryClient();
+  const { data: users } = useQuery({
+    queryKey: ['admin-api-users'],
+    queryFn: async () => (await adminFetch('/api/admin/api-users')).json(),
+  });
+  const { data: keys } = useQuery({
+    queryKey: ['admin-api-keys'],
+    queryFn: async () => (await adminFetch('/api/admin/api-keys')).json(),
+  });
+  const inval = () => {
+    queryClient.invalidateQueries({ queryKey: ['admin-api-users'] });
+    queryClient.invalidateQueries({ queryKey: ['admin-api-keys'] });
+  };
+  const revoke = useMutation({
+    mutationFn: (id: number) => adminFetch(`/api/admin/api-keys/${id}/revoke`, { method: 'POST' }),
+    onSuccess: inval,
+  });
+  const setPlan = useMutation({
+    mutationFn: ({ id, plan }: { id: number; plan: string }) =>
+      adminFetch(`/api/admin/api-users/${id}/plan`, { method: 'POST', body: JSON.stringify({ plan }) }),
+    onSuccess: inval,
+  });
+  const setStatus = useMutation({
+    mutationFn: ({ id, status }: { id: number; status: string }) =>
+      adminFetch(`/api/admin/api-users/${id}/status`, { method: 'POST', body: JSON.stringify({ status }) }),
+    onSuccess: inval,
+  });
+
+  return (
+    <HackerCard glowColor="orange" className="p-6">
+      <h2 className="text-xl font-bold font-mono mb-4 flex items-center gap-2">
+        <KeyRound className="h-5 w-5 text-[#FB651E]" /> Public API — Users &amp; Keys
+      </h2>
+
+      <div className="overflow-x-auto mb-6">
+        <table className="w-full font-mono text-sm">
+          <thead className="border-b border-border text-left text-muted-foreground">
+            <tr><th className="pb-2">Email</th><th className="pb-2">Company</th><th className="pb-2">Plan</th><th className="pb-2">Keys</th><th className="pb-2">Status</th></tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {(users?.users || []).map((u: any) => (
+              <tr key={u.id}>
+                <td className="py-2">{u.email}</td>
+                <td className="py-2 text-muted-foreground">{u.company_name || '—'}</td>
+                <td className="py-2">
+                  <select value={u.plan} onChange={(e) => setPlan.mutate({ id: u.id, plan: e.target.value })}
+                          className="bg-background border border-border rounded px-1 py-0.5 text-xs">
+                    {API_PLANS.map((p) => <option key={p} value={p}>{p}</option>)}
+                  </select>
+                </td>
+                <td className="py-2 text-muted-foreground">{u.active_keys}</td>
+                <td className="py-2">
+                  <button onClick={() => setStatus.mutate({ id: u.id, status: u.status === 'active' ? 'suspended' : 'active' })}
+                          className={`text-xs ${u.status === 'active' ? 'text-emerald-500' : 'text-red-500'}`}>
+                    {u.status}
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {!users?.users?.length && <tr><td colSpan={5} className="py-4 text-center text-muted-foreground">No API users yet</td></tr>}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full font-mono text-sm">
+          <thead className="border-b border-border text-left text-muted-foreground">
+            <tr><th className="pb-2">Key</th><th className="pb-2">Owner</th><th className="pb-2">Active</th><th className="pb-2">Last used</th><th className="pb-2" /></tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {(keys?.keys || []).map((k: any) => (
+              <tr key={k.id}>
+                <td className="py-2">{k.key_prefix}…{k.name ? ` (${k.name})` : ''}</td>
+                <td className="py-2 text-muted-foreground">{k.email}</td>
+                <td className="py-2">{k.is_active ? <span className="text-emerald-500">yes</span> : <span className="text-red-500">revoked</span>}</td>
+                <td className="py-2 text-muted-foreground">{k.last_used_at ? new Date(k.last_used_at).toLocaleDateString() : 'never'}</td>
+                <td className="py-2 text-right">{k.is_active && (
+                  <button onClick={() => revoke.mutate(k.id)} className="text-xs text-red-500 hover:text-red-600">Revoke</button>
+                )}</td>
+              </tr>
+            ))}
+            {!keys?.keys?.length && <tr><td colSpan={5} className="py-4 text-center text-muted-foreground">No API keys yet</td></tr>}
+          </tbody>
+        </table>
+      </div>
+    </HackerCard>
   );
 }

--- a/frontend/src/pages/ApiDocsPage.tsx
+++ b/frontend/src/pages/ApiDocsPage.tsx
@@ -1,0 +1,151 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
+import { Terminal, Copy, Check, BookOpen, KeyRound, Gauge, ExternalLink } from 'lucide-react'
+import { HackerCard } from '../components/ui/hacker-card'
+import { Button } from '../components/ui/button'
+import { useDevAuth } from '../contexts/DevAuthContext'
+
+const API_BASE = 'https://api.exploreyc.com/api/v1'
+
+const ENDPOINTS: { method: string; path: string; desc: string; params?: string }[] = [
+  { method: 'GET', path: '/companies', desc: 'List / filter companies (YC + a16z).', params: 'limit≤100, offset, source (yc|a16z|all), batch, industry, country, is_hiring, top_company, search' },
+  { method: 'GET', path: '/companies/{id}', desc: 'A single company by id.' },
+  { method: 'GET', path: '/companies/slug/{slug}', desc: 'A single company by slug.' },
+  { method: 'GET', path: '/search', desc: 'Full-text company search.', params: 'q (required), limit≤100, offset, source' },
+  { method: 'GET', path: '/stats', desc: 'Portfolio stats (counts by batch, industry, country).' },
+  { method: 'GET', path: '/sources', desc: 'Available sources (incubators / VCs) with counts.' },
+  { method: 'GET', path: '/batches', desc: 'Distinct YC batches.' },
+  { method: 'GET', path: '/industries', desc: 'Distinct industries.' },
+  { method: 'GET', path: '/countries', desc: 'Distinct countries.' },
+  { method: 'GET', path: '/map', desc: 'Geo-located companies (lat/lng).', params: 'batch, is_hiring' },
+  { method: 'GET', path: '/batch/{name}/wrapped', desc: 'Batch "wrapped" analytics.' },
+]
+
+const PLANS = [
+  { name: 'Free', limit: '5 / day', price: '$0' },
+  { name: 'Starter', limit: '500 / day', price: '$29/mo' },
+  { name: 'Pro', limit: '5,000 / day', price: '$99/mo' },
+  { name: 'Enterprise', limit: 'Custom', price: 'Contact us' },
+]
+
+function CodeBlock({ code, label }: { code: string; label?: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <div className="relative group">
+      {label && <div className="text-[10px] uppercase tracking-wide font-mono text-muted-foreground mb-1">{label}</div>}
+      <pre className="rounded-md border border-border bg-muted/50 p-3 pr-12 overflow-x-auto text-xs font-mono leading-relaxed">
+        <code>{code}</code>
+      </pre>
+      <button
+        onClick={() => { navigator.clipboard.writeText(code); setCopied(true); setTimeout(() => setCopied(false), 1500) }}
+        className="absolute top-2 right-2 inline-flex items-center gap-1 text-xs font-mono text-muted-foreground hover:text-[#FB651E]"
+      >
+        {copied ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : <Copy className="h-3.5 w-3.5" />}
+      </button>
+    </div>
+  )
+}
+
+export function ApiDocsPage() {
+  const { user } = useDevAuth()
+
+  const curl = `curl -H "Authorization: Bearer YOUR_API_KEY" \\\n  "${API_BASE}/companies?source=all&limit=20"`
+  const js = `const res = await fetch("${API_BASE}/companies?source=all&limit=20", {\n  headers: { Authorization: "Bearer YOUR_API_KEY" },\n});\nconst data = await res.json();`
+  const py = `import requests\nr = requests.get(\n    "${API_BASE}/companies",\n    headers={"Authorization": "Bearer YOUR_API_KEY"},\n    params={"source": "all", "limit": 20},\n)\nprint(r.json())`
+
+  return (
+    <>
+      <Helmet><title>API Docs | ExploreYC</title></Helmet>
+      <div className="min-h-screen bg-background p-4 md:p-8">
+        <div className="max-w-4xl mx-auto">
+          {/* Header */}
+          <div className="mb-8">
+            <div className="flex items-center gap-2 mb-2 font-mono text-sm text-muted-foreground">
+              <Terminal className="h-4 w-4 text-[#FB651E]" />
+              <span>$ curl api.exploreyc.com/api/v1</span>
+            </div>
+            <h1 className="text-3xl font-bold font-mono">
+              <span className="text-[#FB651E]">&gt;</span> ExploreYC API
+            </h1>
+            <p className="text-muted-foreground font-mono text-sm mt-2 max-w-2xl">
+              Read-only programmatic access to Y Combinator and a16z portfolio companies —
+              funding, stage, exits, and more.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {user ? (
+                <Link to="/dashboard"><Button className="bg-[#FB651E] hover:bg-[#E65C00] font-mono"><KeyRound className="h-4 w-4 mr-2" />Your keys</Button></Link>
+              ) : (
+                <Link to="/signup"><Button className="bg-[#FB651E] hover:bg-[#E65C00] font-mono"><KeyRound className="h-4 w-4 mr-2" />Get an API key</Button></Link>
+              )}
+              <a href={`${API_BASE}/docs`} target="_blank" rel="noopener noreferrer">
+                <Button variant="outline" className="font-mono"><BookOpen className="h-4 w-4 mr-2" />Interactive docs<ExternalLink className="h-3 w-3 ml-2" /></Button>
+              </a>
+            </div>
+          </div>
+
+          {/* Auth */}
+          <HackerCard glowColor="orange" className="p-6 mb-6">
+            <h2 className="text-lg font-bold font-mono mb-3 flex items-center gap-2"><KeyRound className="h-5 w-5 text-[#FB651E]" />Authentication</h2>
+            <p className="text-sm text-muted-foreground mb-3">
+              Send your key on every request as a bearer token (or the <code className="bg-muted px-1 rounded">X-API-Key</code> header).
+              {user
+                ? <> You're logged in — grab your key from the <Link to="/dashboard" className="text-[#FB651E] hover:underline">dashboard</Link>.</>
+                : <> <Link to="/signup" className="text-[#FB651E] hover:underline">Sign up</Link> to get one.</>}
+            </p>
+            <CodeBlock label="Base URL" code={API_BASE} />
+          </HackerCard>
+
+          {/* Quick start */}
+          <HackerCard glowColor="green" className="p-6 mb-6">
+            <h2 className="text-lg font-bold font-mono mb-3">Quick start</h2>
+            <div className="space-y-3">
+              <CodeBlock label="curl" code={curl} />
+              <CodeBlock label="JavaScript" code={js} />
+              <CodeBlock label="Python" code={py} />
+            </div>
+          </HackerCard>
+
+          {/* Rate limits */}
+          <HackerCard glowColor="blue" className="p-6 mb-6">
+            <h2 className="text-lg font-bold font-mono mb-3 flex items-center gap-2"><Gauge className="h-5 w-5 text-blue-500" />Rate limits</h2>
+            <p className="text-sm text-muted-foreground mb-3">
+              Per key, rolling 24h. Every response includes <code className="bg-muted px-1 rounded">X-RateLimit-Limit</code>,
+              <code className="bg-muted px-1 rounded ml-1">X-RateLimit-Remaining</code>, and
+              <code className="bg-muted px-1 rounded ml-1">X-RateLimit-Reset</code>; a 429 adds <code className="bg-muted px-1 rounded">Retry-After</code>.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm font-mono">
+                <thead className="text-left text-muted-foreground border-b border-border">
+                  <tr><th className="pb-2">Plan</th><th className="pb-2">Limit</th><th className="pb-2">Price</th></tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {PLANS.map((p) => (
+                    <tr key={p.name}><td className="py-2 font-medium">{p.name}</td><td className="py-2">{p.limit}</td><td className="py-2 text-muted-foreground">{p.price}</td></tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </HackerCard>
+
+          {/* Endpoints */}
+          <HackerCard glowColor="purple" className="p-6">
+            <h2 className="text-lg font-bold font-mono mb-3">Endpoints</h2>
+            <div className="divide-y divide-border">
+              {ENDPOINTS.map((e) => (
+                <div key={e.path} className="py-3">
+                  <div className="flex items-center gap-2 font-mono text-sm">
+                    <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-emerald-500/10 text-emerald-500">{e.method}</span>
+                    <code className="text-foreground">{e.path}</code>
+                  </div>
+                  <p className="text-sm text-muted-foreground mt-1">{e.desc}</p>
+                  {e.params && <p className="text-xs text-muted-foreground/80 font-mono mt-1">params: {e.params}</p>}
+                </div>
+              ))}
+            </div>
+          </HackerCard>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/DevLoginPage.tsx
+++ b/frontend/src/pages/DevLoginPage.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { Helmet } from 'react-helmet-async'
+import { KeyRound, AlertCircle, Loader2 } from 'lucide-react'
+import { HackerCard } from '../components/ui/hacker-card'
+import { Button } from '../components/ui/button'
+import { Input } from '../components/ui/input'
+import { useDevAuth } from '../contexts/DevAuthContext'
+
+export function DevLoginPage() {
+  const navigate = useNavigate()
+  const { login } = useDevAuth()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+    try {
+      await login(email, password)
+      navigate('/dashboard')
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || 'Login failed. Check your credentials.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <Helmet><title>Log in | ExploreYC API</title></Helmet>
+      <div className="min-h-screen flex items-center justify-center bg-background p-4">
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="w-full max-w-md">
+          <HackerCard glowColor="orange" className="p-8">
+            <div className="text-center mb-8">
+              <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-[#FB651E]/10 mb-4">
+                <KeyRound className="h-8 w-8 text-[#FB651E]" />
+              </div>
+              <h1 className="text-2xl font-bold font-mono mb-2">Developer login</h1>
+              <p className="text-sm text-muted-foreground font-mono">Access your API keys and usage.</p>
+            </div>
+
+            <form onSubmit={submit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium font-mono mb-2">Email</label>
+                <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)}
+                       className="font-mono" placeholder="you@company.com" required />
+              </div>
+              <div>
+                <label className="block text-sm font-medium font-mono mb-2">Password</label>
+                <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)}
+                       className="font-mono" placeholder="••••••••" required />
+              </div>
+
+              {error && (
+                <div className="flex items-center gap-2 text-sm text-red-500 font-mono">
+                  <AlertCircle className="h-4 w-4" />{error}
+                </div>
+              )}
+
+              <Button type="submit" className="w-full bg-[#FB651E] hover:bg-[#E65C00]" disabled={loading}>
+                {loading ? (<><Loader2 className="h-4 w-4 mr-2 animate-spin" />Logging in…</>) : 'Log in'}
+              </Button>
+            </form>
+
+            <p className="mt-6 pt-6 border-t border-border text-xs text-muted-foreground font-mono text-center">
+              No account? <Link to="/signup" className="text-[#FB651E] hover:underline">Sign up</Link>
+              {'  ·  '}
+              <Link to="/api-docs" className="text-[#FB651E] hover:underline">Read the docs</Link>
+            </p>
+          </HackerCard>
+        </motion.div>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/DeveloperDashboard.tsx
+++ b/frontend/src/pages/DeveloperDashboard.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react'
+import { Navigate, Link } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  KeyRound, Copy, Check, Trash2, Plus, LogOut, Loader2, BookOpen, AlertCircle, Terminal,
+} from 'lucide-react'
+import { HackerCard } from '../components/ui/hacker-card'
+import { Button } from '../components/ui/button'
+import { Input } from '../components/ui/input'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '../components/ui/dialog'
+import { useDevAuth } from '../contexts/DevAuthContext'
+import { apiClient, type DevMe, type CreatedApiKey } from '../lib/api'
+
+function CopyButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <button
+      onClick={() => { navigator.clipboard.writeText(value); setCopied(true); setTimeout(() => setCopied(false), 1500) }}
+      className="inline-flex items-center gap-1 text-xs font-mono text-muted-foreground hover:text-[#FB651E] transition-colors"
+    >
+      {copied ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : <Copy className="h-3.5 w-3.5" />}
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  )
+}
+
+export function DeveloperDashboard() {
+  const { user, loading, logout } = useDevAuth()
+  const queryClient = useQueryClient()
+  const [newKey, setNewKey] = useState<CreatedApiKey | null>(null)
+  const [keyName, setKeyName] = useState('')
+
+  const { data: me, isLoading } = useQuery<DevMe>({
+    queryKey: ['dev-me'],
+    queryFn: () => apiClient.devMe().then((r) => r.data),
+    enabled: !!user,
+  })
+
+  const createKey = useMutation({
+    mutationFn: () => apiClient.createApiKey(keyName || undefined).then((r) => r.data),
+    onSuccess: (data) => {
+      setNewKey(data)
+      setKeyName('')
+      queryClient.invalidateQueries({ queryKey: ['dev-me'] })
+    },
+  })
+
+  const revokeKey = useMutation({
+    mutationFn: (id: number) => apiClient.revokeApiKey(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['dev-me'] }),
+  })
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <Loader2 className="h-8 w-8 animate-spin text-[#FB651E]" />
+      </div>
+    )
+  }
+  if (!user) return <Navigate to="/login" replace />
+
+  const usage = me?.usage
+  const pct = usage && usage.limit > 0 ? Math.min(100, Math.round((usage.used_24h / usage.limit) * 100)) : 0
+
+  return (
+    <>
+      <Helmet><title>Developer Dashboard | ExploreYC API</title></Helmet>
+      <div className="min-h-screen bg-background p-4 md:p-8">
+        <div className="max-w-4xl mx-auto">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-8">
+            <div>
+              <div className="flex items-center gap-2 mb-2 font-mono text-sm text-muted-foreground">
+                <Terminal className="h-4 w-4 text-[#FB651E]" />
+                <span>$ exploreyc --api</span>
+              </div>
+              <h1 className="text-3xl font-bold font-mono">
+                <span className="text-[#FB651E]">&gt;</span> Developer Dashboard
+              </h1>
+              <p className="text-sm text-muted-foreground font-mono mt-1">{user.email}</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Link to="/api-docs"><Button variant="outline" className="font-mono"><BookOpen className="h-4 w-4 mr-2" />Docs</Button></Link>
+              <Button variant="outline" className="font-mono" onClick={logout}><LogOut className="h-4 w-4 mr-2" />Logout</Button>
+            </div>
+          </div>
+
+          {/* Plan + usage */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+            <HackerCard glowColor="orange" className="p-6">
+              <div className="text-sm font-mono text-muted-foreground mb-1">PLAN</div>
+              <div className="text-2xl font-bold font-mono capitalize">{me?.plan_name || user.plan}</div>
+              <p className="text-xs text-muted-foreground font-mono mt-2">
+                {usage?.limit ?? user.daily_limit} requests / day
+              </p>
+              <a href="mailto:konstantin.borimechkov14@gmail.com?subject=ExploreYC%20API%20upgrade"
+                 className="inline-block mt-3 text-xs text-[#FB651E] hover:underline font-mono">
+                Need more? Contact us to upgrade →
+              </a>
+            </HackerCard>
+
+            <HackerCard glowColor="green" className="p-6">
+              <div className="text-sm font-mono text-muted-foreground mb-1">USAGE (LAST 24H)</div>
+              <div className="text-2xl font-bold font-mono">
+                {usage?.used_24h ?? 0}<span className="text-sm text-muted-foreground"> / {usage?.limit ?? user.daily_limit}</span>
+              </div>
+              <div className="mt-3 h-2 w-full rounded-full bg-muted overflow-hidden">
+                <div className={`h-full ${pct >= 100 ? 'bg-red-500' : 'bg-emerald-500'}`} style={{ width: `${pct}%` }} />
+              </div>
+              <p className="text-xs text-muted-foreground font-mono mt-2">{usage?.remaining ?? '—'} remaining</p>
+            </HackerCard>
+          </div>
+
+          {/* API keys */}
+          <HackerCard glowColor="orange" className="p-6">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+              <h2 className="text-xl font-bold font-mono flex items-center gap-2">
+                <KeyRound className="h-5 w-5 text-[#FB651E]" /> API Keys
+              </h2>
+              <div className="flex items-center gap-2">
+                <Input value={keyName} onChange={(e) => setKeyName(e.target.value)}
+                       placeholder="Key name (optional)" className="font-mono h-9 w-48" />
+                <Button className="bg-[#FB651E] hover:bg-[#E65C00]" disabled={createKey.isPending}
+                        onClick={() => createKey.mutate()}>
+                  {createKey.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <><Plus className="h-4 w-4 mr-1" />New key</>}
+                </Button>
+              </div>
+            </div>
+
+            {isLoading ? (
+              <div className="py-8 text-center"><Loader2 className="h-6 w-6 animate-spin mx-auto text-[#FB651E]" /></div>
+            ) : me && me.keys.length > 0 ? (
+              <div className="divide-y divide-border">
+                {me.keys.map((k) => (
+                  <div key={k.id} className="flex items-center justify-between py-3 gap-3">
+                    <div className="min-w-0">
+                      <div className="font-mono text-sm truncate">
+                        {k.key_prefix}<span className="text-muted-foreground">…</span>
+                        {k.name && <span className="ml-2 text-muted-foreground">({k.name})</span>}
+                        {!k.is_active && <span className="ml-2 text-xs text-red-500">revoked</span>}
+                      </div>
+                      <div className="text-xs text-muted-foreground font-mono">
+                        Created {new Date(k.created_at).toLocaleDateString()} ·{' '}
+                        {k.last_used_at ? `last used ${new Date(k.last_used_at).toLocaleDateString()}` : 'never used'}
+                      </div>
+                    </div>
+                    {k.is_active && (
+                      <button onClick={() => revokeKey.mutate(k.id)} disabled={revokeKey.isPending}
+                              className="inline-flex items-center gap-1 text-xs font-mono text-red-500 hover:text-red-600 transition-colors">
+                        <Trash2 className="h-3.5 w-3.5" /> Revoke
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="py-8 text-center text-sm text-muted-foreground font-mono">
+                No keys yet. Create one to start calling the API.
+              </p>
+            )}
+          </HackerCard>
+        </div>
+      </div>
+
+      {/* One-time key reveal */}
+      <Dialog open={!!newKey} onOpenChange={(open) => !open && setNewKey(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2"><KeyRound className="h-5 w-5 text-[#FB651E]" /> Your new API key</DialogTitle>
+            <DialogDescription>
+              Copy it now — for security we only store a hash and <strong>won't show it again</strong>.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-2 rounded-md border border-border bg-muted/50 p-3 font-mono text-sm break-all">
+            {newKey?.api_key}
+          </div>
+          <div className="mt-3 flex items-center justify-between">
+            <div className="flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400 font-mono">
+              <AlertCircle className="h-4 w-4" /> Store it in a secret manager.
+            </div>
+            {newKey && <CopyButton value={newKey.api_key} />}
+          </div>
+          <Button className="mt-4 w-full bg-[#FB651E] hover:bg-[#E65C00]" onClick={() => setNewKey(null)}>
+            I've saved my key
+          </Button>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { Helmet } from 'react-helmet-async'
+import { KeyRound, AlertCircle, Loader2 } from 'lucide-react'
+import { HackerCard } from '../components/ui/hacker-card'
+import { Button } from '../components/ui/button'
+import { Input } from '../components/ui/input'
+import { useDevAuth } from '../contexts/DevAuthContext'
+
+export function SignupPage() {
+  const navigate = useNavigate()
+  const { signup } = useDevAuth()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [company, setCompany] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+    try {
+      await signup(email, password, company)
+      navigate('/dashboard')
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || 'Signup failed. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <Helmet><title>Create a developer account | ExploreYC API</title></Helmet>
+      <div className="min-h-screen flex items-center justify-center bg-background p-4">
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="w-full max-w-md">
+          <HackerCard glowColor="orange" className="p-8">
+            <div className="text-center mb-8">
+              <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-[#FB651E]/10 mb-4">
+                <KeyRound className="h-8 w-8 text-[#FB651E]" />
+              </div>
+              <h1 className="text-2xl font-bold font-mono mb-2">Get API access</h1>
+              <p className="text-sm text-muted-foreground font-mono">
+                Free tier: 5 requests/day. Create an account to get your API key.
+              </p>
+            </div>
+
+            <form onSubmit={submit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium font-mono mb-2">Work email</label>
+                <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)}
+                       className="font-mono" placeholder="you@company.com" required />
+              </div>
+              <div>
+                <label className="block text-sm font-medium font-mono mb-2">Company</label>
+                <Input type="text" value={company} onChange={(e) => setCompany(e.target.value)}
+                       className="font-mono" placeholder="Acme Inc." />
+              </div>
+              <div>
+                <label className="block text-sm font-medium font-mono mb-2">Password</label>
+                <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)}
+                       className="font-mono" placeholder="At least 8 characters" minLength={8} required />
+              </div>
+
+              {error && (
+                <div className="flex items-center gap-2 text-sm text-red-500 font-mono">
+                  <AlertCircle className="h-4 w-4" />{error}
+                </div>
+              )}
+
+              <Button type="submit" className="w-full bg-[#FB651E] hover:bg-[#E65C00]" disabled={loading}>
+                {loading ? (<><Loader2 className="h-4 w-4 mr-2 animate-spin" />Creating account…</>) : 'Create account'}
+              </Button>
+            </form>
+
+            <p className="mt-6 pt-6 border-t border-border text-xs text-muted-foreground font-mono text-center">
+              Already have an account? <Link to="/login" className="text-[#FB651E] hover:underline">Log in</Link>
+              {'  ·  '}
+              <Link to="/api-docs" className="text-[#FB651E] hover:underline">Read the docs</Link>
+            </p>
+          </HackerCard>
+        </motion.div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
Phase 2 of the paywalled public API — the developer-facing UI for the backend in **#32**. (Merge/deploy #32 first; until then the `/api/dev/*` endpoints 404 and signup won't work, but the pages render.)

## What's included
- **`DevAuthContext`** — localStorage `dev_token` + `/api/dev/me` hydration, wrapping the app. New **`devApi`** axios instance auto-injects the bearer token; typed `api.ts` methods (`devSignup/devLogin/devLogout/devMe/createApiKey/listApiKeys/revokeApiKey`) + interfaces (`ApiUser`, `ApiKey`, `DevMe`, `CreatedApiKey`, `UsageSummary`).
- **Routes**: `/signup` (email + password + company), `/login`, `/dashboard` (protected → redirects to `/login`), `/api-docs` (public).
- **`DeveloperDashboard`**: plan card + **rolling-24h usage meter**, **create key** (plaintext shown **once** in a copy dialog with a "won't be shown again" warning), key list by prefix + last-used, **revoke**.
- **`ApiDocsPage`**: base URL, auth, **rate-limit / pricing table**, **curl / JS / Python** samples with copy buttons, endpoint reference, and a link to the interactive `/api/v1/docs`. (We only store a key *hash*, so samples use a `YOUR_API_KEY` placeholder and point logged-in users to their dashboard.)
- **`AdminPage`**: new **"Public API — Users & Keys"** section to **revoke keys**, change **plans**, and **suspend/reactivate** users — reusing the existing admin Bearer pattern.

## Verification
- `npm run build` (tsc -b && vite build) passes clean; **no new dependencies**.
- Client method/response shapes match the #32 backend, which was verified end-to-end (signup/keys/rate-limit/revoke).

## Note
Runtime-depends on #32 being deployed. Recommended order: deploy #32 backend (apply migration, set `ENV=production`) → merge this → Vercel redeploys the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)