### PR TITLE
Fix 500 on /api/v1 company endpoints (datetime serialization on Postgres)

### DIFF
--- a/backend/public_api.py
+++ b/backend/public_api.py
@@ -75,8 +75,9 @@ class PublicCompany(BaseModel):
     valuation_usd: Optional[float] = None
     employee_count: Optional[int] = None
     employee_growth_6m: Optional[float] = None
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
+    # Postgres returns datetime objects (SQLite returns strings) — accept both, serialize to ISO
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
     class Config:
         extra = "ignore"  # cache dicts carry internal fields (raw_json, …) — dropped from the public shape


### PR DESCRIPTION
**Hotfix** for a production 500 on `GET /api/v1/companies` (and `/companies/{id}`, `/companies/slug/{slug}`, `/search`).

`PublicCompany.created_at`/`updated_at` were typed `Optional[str]`. That passed on SQLite (timestamps are strings) but on **Postgres** `RealDictCursor` returns `datetime` objects → Pydantic `ResponseValidationError` → 500.

Fix: type them `Optional[datetime]` — accepts both SQLite strings and Postgres datetimes, serializes to ISO 8601. Verified against a Postgres-shaped row (datetime + Decimal); `raw_json` still stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)