### PR TITLE
Navbar declutter + mobile burger, hacky API docs, dev usage analytics

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -502,6 +502,26 @@ class Database:
             cur.execute('DELETE FROM api_usage WHERE created_at < ?', (self._fmt_dt(older_than),))
             return cur.rowcount
 
+    def get_api_usage_timeseries(self, user_id, since) -> List[Dict]:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('''
+                SELECT DATE(u.created_at) AS day, COUNT(*) AS count
+                FROM api_usage u JOIN api_keys k ON k.id = u.api_key_id
+                WHERE k.user_id = ? AND u.created_at > ?
+                GROUP BY DATE(u.created_at) ORDER BY day''', (user_id, self._fmt_dt(since)))
+            return [dict(r) for r in cur.fetchall()]
+
+    def get_api_usage_by_endpoint(self, user_id, since, limit=10) -> List[Dict]:
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('''
+                SELECT u.endpoint AS endpoint, COUNT(*) AS count
+                FROM api_usage u JOIN api_keys k ON k.id = u.api_key_id
+                WHERE k.user_id = ? AND u.created_at > ?
+                GROUP BY u.endpoint ORDER BY count DESC LIMIT ?''', (user_id, self._fmt_dt(since), limit))
+            return [dict(r) for r in cur.fetchall()]
+
     def insert_company(self, company: Dict[str, Any]) -> int:
         """Insert or update a company"""
         with self.get_connection() as conn:

--- a/backend/database_postgres.py
+++ b/backend/database_postgres.py
@@ -2075,6 +2075,26 @@ class DatabasePostgres:
                 cur.execute('DELETE FROM api_usage WHERE created_at < %s', (older_than,))
                 return cur.rowcount
 
+    def get_api_usage_timeseries(self, user_id, since) -> List[Dict]:
+        with self.get_connection() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute('''
+                    SELECT to_char(u.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS day, COUNT(*) AS count
+                    FROM api_usage u JOIN api_keys k ON k.id = u.api_key_id
+                    WHERE k.user_id = %s AND u.created_at > %s
+                    GROUP BY 1 ORDER BY 1''', (user_id, since))
+                return [dict(r) for r in cur.fetchall()]
+
+    def get_api_usage_by_endpoint(self, user_id, since, limit=10) -> List[Dict]:
+        with self.get_connection() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute('''
+                    SELECT u.endpoint AS endpoint, COUNT(*) AS count
+                    FROM api_usage u JOIN api_keys k ON k.id = u.api_key_id
+                    WHERE k.user_id = %s AND u.created_at > %s
+                    GROUP BY u.endpoint ORDER BY count DESC LIMIT %s''', (user_id, since, limit))
+                return [dict(r) for r in cur.fetchall()]
+
     def get_research_stats(self) -> Dict:
         """Get research statistics"""
         with self.get_connection() as conn:

--- a/backend/main.py
+++ b/backend/main.py
@@ -3194,6 +3194,27 @@ async def dev_verify_email(token: str):
     return {"success": True}
 
 
+@app.get("/api/dev/usage")
+async def dev_usage(days: int = 7, session: dict = Depends(verify_dev_session)):
+    """Per-day request counts + top endpoints for the caller's keys (for the dashboard chart)."""
+    days = max(1, min(days, 90))
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    rows = db.get_api_usage_timeseries(session["user_id"], since)
+    by_endpoint = db.get_api_usage_by_endpoint(session["user_id"], since)
+    counts = {str(r["day"]): int(r["count"]) for r in rows}
+    today = datetime.now(timezone.utc).date()
+    series = []
+    for i in range(days - 1, -1, -1):
+        d = (today - timedelta(days=i)).isoformat()
+        series.append({"date": d, "count": counts.get(d, 0)})
+    return {
+        "days": days,
+        "series": series,
+        "total": sum(s["count"] for s in series),
+        "by_endpoint": [{"endpoint": r["endpoint"], "count": int(r["count"])} for r in by_endpoint],
+    }
+
+
 @app.post("/api/dev/keys")
 async def dev_create_key(req: CreateKeyRequest, session: dict = Depends(verify_dev_session)):
     raw = API_KEY_PREFIX + secrets.token_urlsafe(32)

--- a/frontend/src/components/MobileBottomNav.tsx
+++ b/frontend/src/components/MobileBottomNav.tsx
@@ -1,102 +1,159 @@
+import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Home, BarChart3, Wrench, Map as MapIcon, DollarSign, Share2, Briefcase, Mail, Database } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Home, BarChart3, Wrench, BookOpen, Map as MapIcon, DollarSign, Share2, Briefcase,
+  Mail, Database, Terminal, Menu, X, Moon, Sun, Command,
+} from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
+import { useDevAuth } from '../contexts/DevAuthContext';
 
-interface NavTab {
-  id: string;
-  label: string;
-  icon: React.ComponentType<{ className?: string }>;
-  path: string;
-}
-
-const allNavTabs: NavTab[] = [
-  { id: 'home', label: 'Home', icon: Home, path: '/' },
-  { id: 'analytics', label: 'Analytics', icon: BarChart3, path: '/analytics' },
-  { id: 'funding', label: 'Funding', icon: DollarSign, path: '/funding' },
-  { id: 'hiring', label: 'Hiring', icon: Briefcase, path: '/hiring' },
-  { id: 'database', label: 'Database', icon: Database, path: '/database' },
-  { id: 'tools', label: 'Tools', icon: Wrench, path: '/tools' },
-  { id: 'roadmap', label: 'Roadmap', icon: MapIcon, path: '/roadmap' },
-  { id: 'share', label: 'Share', icon: Share2, path: '/share' },
-];
+type Item = { label: string; icon: React.ComponentType<{ className?: string }>; path: string };
 
 const showShareNav = import.meta.env.VITE_SHOW_SHARE_NAV === 'true' || import.meta.env.VITE_SHOW_SHARE_NAV === '1';
-const navTabs = showShareNav ? allNavTabs : allNavTabs.filter((t) => t.id !== 'share');
+
+const groups: { title: string; items: Item[] }[] = [
+  {
+    title: 'Explore',
+    items: [
+      { label: 'Home', icon: Home, path: '/' },
+      { label: 'Database', icon: Database, path: '/database' },
+      { label: 'Analytics', icon: BarChart3, path: '/analytics' },
+      { label: 'Hiring', icon: Briefcase, path: '/hiring' },
+      { label: 'Funding', icon: DollarSign, path: '/funding' },
+    ],
+  },
+  {
+    title: 'More',
+    items: [
+      { label: 'Tools', icon: Wrench, path: '/tools' },
+      { label: 'Founders', icon: BookOpen, path: '/founders' },
+      { label: 'Roadmap', icon: MapIcon, path: '/roadmap' },
+      ...(showShareNav ? [{ label: 'Share', icon: Share2, path: '/share' }] : []),
+    ],
+  },
+];
 
 export function MobileBottomNav() {
   const location = useLocation();
-  const { setContactFormOpen } = useApp();
+  const { darkMode, setDarkMode, setCommandPaletteOpen, setContactFormOpen } = useApp();
+  const { user } = useDevAuth();
+  const [open, setOpen] = useState(false);
 
-  const isActiveTab = (path: string) => {
-    if (path === '/') {
-      return location.pathname === '/';
-    }
-    return location.pathname.startsWith(path);
-  };
-
-  // Don't show on certain full-screen pages
   const hideOnPaths = ['/batch/', '/validator'];
-  const shouldHide = hideOnPaths.some(path => location.pathname.includes(path));
+  if (hideOnPaths.some((p) => location.pathname.includes(p))) return null;
 
-  if (shouldHide) {
-    return null;
-  }
+  const isActive = (path: string) =>
+    path === '/' ? location.pathname === '/' : location.pathname.startsWith(path);
+
+  const close = () => setOpen(false);
 
   return (
-    <nav className="fixed left-0 right-0 z-40 md:hidden border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 overflow-x-hidden" style={{ top: '28px' }}>
-      <div className="flex items-center justify-around gap-0.5 px-1 pt-2 pb-3 h-14 min-w-0">
-        {navTabs.map((tab) => {
-          const Icon = tab.icon;
-          const isActive = isActiveTab(tab.path);
+    <>
+      {/* Top bar with burger */}
+      <nav
+        className="fixed left-0 right-0 z-40 md:hidden h-14 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 font-mono"
+        style={{ top: '28px' }}
+      >
+        <div className="flex h-full items-center justify-between px-4">
+          <Link to="/" onClick={close} className="flex items-center gap-2 min-w-0">
+            <div className="w-8 h-8 bg-[#FB651E] flex items-center justify-center flex-shrink-0">
+              <span className="text-base font-bold text-white">Y</span>
+            </div>
+            <span className="text-sm font-bold truncate">YC Explorer</span>
+          </Link>
+          <button
+            onClick={() => setOpen((o) => !o)}
+            aria-label="Menu"
+            className="w-9 h-9 flex items-center justify-center border border-border text-muted-foreground hover:text-[#FB651E] hover:border-[#FB651E]/50 transition-colors"
+          >
+            {open ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+          </button>
+        </div>
+      </nav>
 
-          return (
-            <Link
-              key={tab.id}
-              to={tab.path}
-              className="flex flex-col items-center justify-center flex-1 min-w-0 py-1 px-1 rounded-lg group gap-0.5"
-            >
-              <div
-                className={`
-                  flex items-center justify-center w-7 h-7 rounded-lg transition-all flex-shrink-0
-                  ${isActive
-                    ? 'bg-[#FB651E]/10'
-                    : 'group-hover:bg-muted/50'
-                  }
-                `}
-              >
-                <Icon
-                  className={`
-                    w-3.5 h-3.5 transition-colors
-                    ${isActive ? 'text-[#FB651E]' : 'text-muted-foreground group-hover:text-foreground'}
-                  `}
-                />
+      {/* Full-screen overlay menu */}
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="fixed inset-0 z-50 md:hidden bg-background font-mono overflow-y-auto"
+          >
+            {/* Overlay header */}
+            <div className="flex items-center justify-between px-4 h-14 border-b border-border" style={{ marginTop: '28px' }}>
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Terminal className="w-4 h-4 text-[#FB651E]" /> <span>$ navigate</span>
               </div>
-              <span
-                className={`
-                  text-[9px] font-medium transition-colors flex-shrink-0 leading-tight truncate max-w-full
-                  ${isActive ? 'text-[#FB651E]' : 'text-muted-foreground'}
-                `}
-              >
-                {tab.label}
-              </span>
-            </Link>
-          );
-        })}
+              <button onClick={close} aria-label="Close" className="w-9 h-9 flex items-center justify-center border border-border text-muted-foreground hover:text-[#FB651E]">
+                <X className="w-5 h-5" />
+              </button>
+            </div>
 
-        {/* Contact button */}
-        <button
-          onClick={() => setContactFormOpen(true)}
-          className="flex flex-col items-center justify-center flex-1 min-w-0 py-1 px-1 rounded-lg group gap-0.5 hover:bg-muted/50 transition-colors"
-          title="Send feedback or bug report"
-        >
-          <div className="flex items-center justify-center w-7 h-7 rounded-lg transition-all flex-shrink-0 group-hover:bg-muted/50">
-            <Mail className="w-3.5 h-3.5 transition-colors text-muted-foreground group-hover:text-foreground" />
-          </div>
-          <span className="text-[9px] font-medium transition-colors flex-shrink-0 leading-tight text-muted-foreground">
-            Contact
-          </span>
-        </button>
-      </div>
-    </nav>
+            <div className="p-4 space-y-6">
+              {groups.map((group) => (
+                <div key={group.title}>
+                  <div className="text-[10px] uppercase tracking-widest text-muted-foreground/70 mb-2">{group.title}</div>
+                  <div className="grid grid-cols-2 gap-2">
+                    {group.items.map((item) => {
+                      const Icon = item.icon;
+                      const active = isActive(item.path);
+                      return (
+                        <Link
+                          key={item.path}
+                          to={item.path}
+                          onClick={close}
+                          className={`flex items-center gap-2 px-3 py-3 border transition-colors ${
+                            active
+                              ? 'border-[#FB651E]/50 bg-[#FB651E]/10 text-[#FB651E]'
+                              : 'border-border text-foreground hover:border-[#FB651E]/30'
+                          }`}
+                        >
+                          <Icon className="w-4 h-4 flex-shrink-0" />
+                          <span className="text-sm truncate">{item.label}</span>
+                        </Link>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+
+              {/* Developers */}
+              <div>
+                <div className="text-[10px] uppercase tracking-widest text-muted-foreground/70 mb-2">Developers</div>
+                <div className="grid grid-cols-2 gap-2">
+                  <Link to="/api-docs" onClick={close}
+                        className="flex items-center gap-2 px-3 py-3 border border-border text-foreground hover:border-[#FB651E]/30">
+                    <Terminal className="w-4 h-4" /> <span className="text-sm">API Docs</span>
+                  </Link>
+                  <Link to={user ? '/dashboard' : '/signup'} onClick={close}
+                        className="flex items-center gap-2 px-3 py-3 border border-[#FB651E]/40 bg-[#FB651E]/10 text-[#FB651E]">
+                    <Terminal className="w-4 h-4" /> <span className="text-sm">{user ? 'Dashboard' : 'Get a key'}</span>
+                  </Link>
+                </div>
+              </div>
+
+              {/* Actions */}
+              <div className="flex items-center gap-2 pt-2 border-t border-border">
+                <button onClick={() => { close(); setContactFormOpen(true); }}
+                        className="flex-1 flex items-center justify-center gap-2 px-3 py-3 border border-border text-sm text-muted-foreground hover:text-[#FB651E]">
+                  <Mail className="w-4 h-4" /> Contact
+                </button>
+                <button onClick={() => { close(); setCommandPaletteOpen(true); }}
+                        className="flex-1 flex items-center justify-center gap-2 px-3 py-3 border border-border text-sm text-muted-foreground hover:text-foreground">
+                  <Command className="w-4 h-4" /> Search
+                </button>
+                <button onClick={() => setDarkMode(!darkMode)} aria-label="Toggle theme"
+                        className="w-12 flex items-center justify-center px-3 py-3 border border-border text-muted-foreground hover:text-foreground">
+                  {darkMode ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
   );
 }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,6 +1,10 @@
 import { Link, useLocation } from 'react-router-dom';
-import { Home, BarChart3, Wrench, BookOpen, Map as MapIcon, DollarSign, Share2, Moon, Sun, Command, Briefcase, Mail, Database } from 'lucide-react';
+import {
+  Home, BarChart3, Wrench, BookOpen, Map as MapIcon, DollarSign, Share2,
+  Moon, Sun, Command, Briefcase, Mail, Database, Terminal, ChevronDown,
+} from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
+import { useDevAuth } from '../contexts/DevAuthContext';
 
 interface NavTab {
   id: string;
@@ -9,88 +13,117 @@ interface NavTab {
   path: string;
 }
 
-const allNavTabs: NavTab[] = [
+const primaryTabs: NavTab[] = [
   { id: 'home', label: 'Home', icon: Home, path: '/' },
-  { id: 'analytics', label: 'Analytics', icon: BarChart3, path: '/analytics' },
-  { id: 'funding', label: 'Funding', icon: DollarSign, path: '/funding' },
-  { id: 'hiring', label: 'Hiring', icon: Briefcase, path: '/hiring' },
   { id: 'database', label: 'Database', icon: Database, path: '/database' },
-  { id: 'tools', label: 'Tools', icon: Wrench, path: '/tools' },
-  { id: 'founders', label: 'Founders', icon: BookOpen, path: '/founders' },
-  { id: 'roadmap', label: 'Roadmap', icon: MapIcon, path: '/roadmap' },
-  { id: 'share', label: 'Share', icon: Share2, path: '/share' },
+  { id: 'analytics', label: 'Analytics', icon: BarChart3, path: '/analytics' },
+  { id: 'hiring', label: 'Hiring', icon: Briefcase, path: '/hiring' },
 ];
 
 const showShareNav = import.meta.env.VITE_SHOW_SHARE_NAV === 'true' || import.meta.env.VITE_SHOW_SHARE_NAV === '1';
-const navTabs = showShareNav ? allNavTabs : allNavTabs.filter((t) => t.id !== 'share');
+
+const moreTabs: NavTab[] = [
+  { id: 'funding', label: 'Funding', icon: DollarSign, path: '/funding' },
+  { id: 'tools', label: 'Tools', icon: Wrench, path: '/tools' },
+  { id: 'founders', label: 'Founders', icon: BookOpen, path: '/founders' },
+  { id: 'roadmap', label: 'Roadmap', icon: MapIcon, path: '/roadmap' },
+  ...(showShareNav ? [{ id: 'share', label: 'Share', icon: Share2, path: '/share' }] : []),
+];
 
 export function Navbar() {
   const location = useLocation();
   const { darkMode, setDarkMode, setCommandPaletteOpen, setContactFormOpen } = useApp();
+  const { user } = useDevAuth();
 
-  const isActiveTab = (path: string) => {
-    if (path === '/') {
-      return location.pathname === '/';
-    }
-    return location.pathname.startsWith(path);
-  };
+  const isActive = (path: string) =>
+    path === '/' ? location.pathname === '/' : location.pathname.startsWith(path);
+
+  const apiPath = user ? '/dashboard' : '/api-docs';
+  const apiActive = ['/api-docs', '/dashboard', '/signup', '/login'].some((p) => location.pathname.startsWith(p));
+  const moreActive = moreTabs.some((t) => isActive(t.path));
+
+  const tabClass = (active: boolean) =>
+    `relative flex items-center gap-1.5 px-3 py-2 text-sm transition-colors border-b-2 -mb-[1px] whitespace-nowrap ${
+      active ? 'text-[#FB651E] border-[#FB651E]' : 'text-muted-foreground hover:text-foreground border-transparent hover:border-border'
+    }`;
 
   return (
     <nav className="hidden md:block sticky top-0 z-40 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 font-mono">
       <div className="container mx-auto px-4">
-        <div className="flex h-14 items-center justify-between">
-          {/* Left: Logo + Title - whitespace-nowrap to prevent bad wrapping on small desktop */}
+        <div className="flex h-14 items-center justify-between gap-2">
+          {/* Logo */}
           <Link to="/" className="flex items-center gap-2 sm:gap-3 group min-w-0 flex-shrink-0">
             <div className="w-9 h-9 bg-[#FB651E] flex items-center justify-center group-hover:shadow-[0_0_16px_rgba(251,101,30,0.4)] transition-shadow flex-shrink-0">
               <span className="text-lg font-bold text-white">Y</span>
             </div>
-            <div className="hidden sm:block min-w-0">
+            <div className="hidden lg:block min-w-0">
               <div className="text-sm font-bold whitespace-nowrap truncate">YC Explorer</div>
               <div className="text-xs text-muted-foreground whitespace-nowrap truncate">$ company-db</div>
             </div>
           </Link>
 
-          {/* Center: Navigation Tabs */}
-          <div className="flex items-center gap-0.5 min-w-0 overflow-x-auto">
-            {navTabs.map((tab) => {
+          {/* Center nav */}
+          <div className="flex items-center gap-0.5">
+            {primaryTabs.map((tab) => {
               const Icon = tab.icon;
-              const isActive = isActiveTab(tab.path);
-
               return (
-                <Link
-                  key={tab.id}
-                  to={tab.path}
-                  className={`
-                    relative flex items-center gap-1.5 sm:gap-2 px-2 sm:px-3 py-2 text-sm transition-colors border-b-2 -mb-[1px] whitespace-nowrap min-w-0
-                    ${isActive
-                      ? 'text-[#FB651E] border-[#FB651E]'
-                      : 'text-muted-foreground hover:text-foreground border-transparent hover:border-border'
-                    }
-                  `}
-                >
+                <Link key={tab.id} to={tab.path} className={tabClass(isActive(tab.path))}>
                   <Icon className="w-4 h-4 flex-shrink-0" />
-                  <span className="hidden md:inline truncate">{tab.label}</span>
+                  <span className="truncate">{tab.label}</span>
                 </Link>
               );
             })}
+
+            {/* API entry */}
+            <Link to={apiPath} className={tabClass(apiActive)}>
+              <Terminal className="w-4 h-4 flex-shrink-0" />
+              <span className="truncate">API</span>
+            </Link>
+
+            {/* More dropdown (hover) */}
+            <div className="relative group">
+              <button className={`${tabClass(moreActive)} cursor-default`} aria-haspopup="true">
+                More <ChevronDown className="w-3.5 h-3.5 transition-transform group-hover:rotate-180" />
+              </button>
+              <div className="absolute right-0 top-full pt-1 hidden group-hover:block z-50">
+                <div className="min-w-[180px] border border-border bg-background/98 backdrop-blur shadow-[0_8px_24px_rgba(0,0,0,0.25)] py-1">
+                  {moreTabs.map((tab) => {
+                    const Icon = tab.icon;
+                    return (
+                      <Link
+                        key={tab.id}
+                        to={tab.path}
+                        className={`flex items-center gap-2 px-3 py-2 text-sm transition-colors ${
+                          isActive(tab.path)
+                            ? 'text-[#FB651E] bg-[#FB651E]/5'
+                            : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                        }`}
+                      >
+                        <Icon className="w-4 h-4" /> {tab.label}
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
           </div>
 
-          {/* Right: Actions */}
-          <div className="flex items-center gap-2">
+          {/* Right actions */}
+          <div className="flex items-center gap-2 flex-shrink-0">
             <button
               onClick={() => setContactFormOpen(true)}
               className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground hover:text-[#FB651E] hover:border-[#FB651E]/50 border border-border transition-colors"
               title="Send feedback or bug report"
             >
               <Mail className="w-3 h-3" />
-              <span className="hidden sm:inline">Contact</span>
+              <span className="hidden lg:inline">Contact</span>
             </button>
             <button
               onClick={() => setCommandPaletteOpen(true)}
               className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:border-[#FB651E]/50 border border-border transition-colors"
             >
               <Command className="w-3 h-3" />
-              <span className="hidden sm:inline">⌘K</span>
+              <span className="hidden lg:inline">⌘K</span>
             </button>
             <button
               onClick={() => setDarkMode(!darkMode)}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -145,6 +145,13 @@ export interface CreatedApiKey {
   warning: string
 }
 
+export interface UsageStats {
+  days: number
+  total: number
+  series: { date: string; count: number }[]
+  by_endpoint: { endpoint: string; count: number }[]
+}
+
 export interface Stats {
   total_companies: number
   hiring: number
@@ -226,6 +233,7 @@ export const apiClient = {
   createApiKey: (name?: string) => devApi.post<CreatedApiKey>('/api/dev/keys', { name }),
   listApiKeys: () => devApi.get<{ keys: ApiKey[] }>('/api/dev/keys'),
   revokeApiKey: (id: number) => devApi.post(`/api/dev/keys/${id}/revoke`),
+  devUsage: (days = 7) => devApi.get<UsageStats>(`/api/dev/usage?days=${days}`),
   getBatches: () => api.get<{ batches: string[] }>('/api/filters/batches'),
   getIndustries: () => api.get<{ industries: string[] }>('/api/filters/industries'),
   getCountries: () => api.get<{ countries: string[] }>('/api/filters/countries'),

--- a/frontend/src/pages/ApiDocsPage.tsx
+++ b/frontend/src/pages/ApiDocsPage.tsx
@@ -1,9 +1,8 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
-import { Terminal, Copy, Check, BookOpen, KeyRound, Gauge, ExternalLink } from 'lucide-react'
-import { HackerCard } from '../components/ui/hacker-card'
-import { Button } from '../components/ui/button'
+import { Copy, Check, KeyRound, Gauge, ExternalLink, BookOpen } from 'lucide-react'
+import { DotPattern } from '../components/ui/dot-pattern'
 import { useDevAuth } from '../contexts/DevAuthContext'
 
 const API_BASE = 'https://api.exploreyc.com/api/v1'
@@ -29,121 +28,152 @@ const PLANS = [
   { name: 'Enterprise', limit: 'Custom', price: 'Contact us' },
 ]
 
-function CodeBlock({ code, label }: { code: string; label?: string }) {
+/** A terminal-window chrome wrapper. */
+function Terminal({ title, children, className = '' }: { title: string; children: ReactNode; className?: string }) {
+  return (
+    <div className={`border border-border bg-[#0b0b0d] rounded-md overflow-hidden shadow-[0_0_0_1px_rgba(251,101,30,0.08),0_12px_40px_-12px_rgba(0,0,0,0.5)] ${className}`}>
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-white/10 bg-white/[0.03]">
+        <span className="w-3 h-3 rounded-full bg-[#ff5f57]" />
+        <span className="w-3 h-3 rounded-full bg-[#febc2e]" />
+        <span className="w-3 h-3 rounded-full bg-[#28c840]" />
+        <span className="ml-2 text-[11px] font-mono text-white/40 truncate">{title}</span>
+      </div>
+      <div className="p-4 font-mono text-sm text-white/90">{children}</div>
+    </div>
+  )
+}
+
+function CodeBlock({ code, label }: { code: string; label: string }) {
   const [copied, setCopied] = useState(false)
   return (
-    <div className="relative group">
-      {label && <div className="text-[10px] uppercase tracking-wide font-mono text-muted-foreground mb-1">{label}</div>}
-      <pre className="rounded-md border border-border bg-muted/50 p-3 pr-12 overflow-x-auto text-xs font-mono leading-relaxed">
-        <code>{code}</code>
-      </pre>
-      <button
-        onClick={() => { navigator.clipboard.writeText(code); setCopied(true); setTimeout(() => setCopied(false), 1500) }}
-        className="absolute top-2 right-2 inline-flex items-center gap-1 text-xs font-mono text-muted-foreground hover:text-[#FB651E]"
-      >
-        {copied ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : <Copy className="h-3.5 w-3.5" />}
-      </button>
-    </div>
+    <Terminal title={`${label} — bash`}>
+      <div className="relative">
+        <pre className="overflow-x-auto pr-10 text-[13px] leading-relaxed text-emerald-300/90"><code>{code}</code></pre>
+        <button
+          onClick={() => { navigator.clipboard.writeText(code); setCopied(true); setTimeout(() => setCopied(false), 1500) }}
+          className="absolute top-0 right-0 inline-flex items-center gap-1 text-xs text-white/50 hover:text-[#FB651E]"
+        >
+          {copied ? <Check className="h-3.5 w-3.5 text-emerald-400" /> : <Copy className="h-3.5 w-3.5" />}
+        </button>
+      </div>
+    </Terminal>
   )
 }
 
 export function ApiDocsPage() {
   const { user } = useDevAuth()
 
-  const curl = `curl -H "Authorization: Bearer YOUR_API_KEY" \\\n  "${API_BASE}/companies?source=all&limit=20"`
-  const js = `const res = await fetch("${API_BASE}/companies?source=all&limit=20", {\n  headers: { Authorization: "Bearer YOUR_API_KEY" },\n});\nconst data = await res.json();`
+  const curl = `$ curl -H "Authorization: Bearer YOUR_API_KEY" \\\n    "${API_BASE}/companies?source=all&limit=20"`
+  const js = `const res = await fetch(\n  "${API_BASE}/companies?source=all&limit=20",\n  { headers: { Authorization: "Bearer YOUR_API_KEY" } }\n);\nconst data = await res.json();`
   const py = `import requests\nr = requests.get(\n    "${API_BASE}/companies",\n    headers={"Authorization": "Bearer YOUR_API_KEY"},\n    params={"source": "all", "limit": 20},\n)\nprint(r.json())`
 
   return (
     <>
       <Helmet><title>API Docs | ExploreYC</title></Helmet>
-      <div className="min-h-screen bg-background p-4 md:p-8">
-        <div className="max-w-4xl mx-auto">
-          {/* Header */}
-          <div className="mb-8">
-            <div className="flex items-center gap-2 mb-2 font-mono text-sm text-muted-foreground">
-              <Terminal className="h-4 w-4 text-[#FB651E]" />
-              <span>$ curl api.exploreyc.com/api/v1</span>
+      <div className="relative min-h-screen bg-background overflow-x-hidden">
+        <DotPattern color="hsl(var(--primary) / 0.12)" size={26} radius={0.5} />
+        <div className="container relative mx-auto px-4 py-10 max-w-4xl">
+
+          {/* Hero terminal */}
+          <Terminal title="guest@exploreyc: ~/api" className="mb-8">
+            <div className="space-y-1.5">
+              <p><span className="text-[#FB651E]">$</span> <span className="text-white/60">whoami</span></p>
+              <p className="text-white/90">exploreyc — programmatic access to YC &amp; a16z portfolio companies</p>
+              <p className="mt-3"><span className="text-[#FB651E]">$</span> <span className="text-white/60">cat api.md</span></p>
+              <p className="text-white/70 leading-relaxed">
+                Read-only REST API. Funding, stage, exits, founders, and more.
+                Free tier = <span className="text-emerald-300">5 requests/day</span>. Bring your API key.
+              </p>
+              <p className="mt-3 flex items-center gap-1"><span className="text-[#FB651E]">$</span> <span className="text-emerald-300 animate-pulse">▋</span></p>
             </div>
-            <h1 className="text-3xl font-bold font-mono">
-              <span className="text-[#FB651E]">&gt;</span> ExploreYC API
-            </h1>
-            <p className="text-muted-foreground font-mono text-sm mt-2 max-w-2xl">
-              Read-only programmatic access to Y Combinator and a16z portfolio companies —
-              funding, stage, exits, and more.
-            </p>
-            <div className="mt-4 flex flex-wrap gap-2">
-              {user ? (
-                <Link to="/dashboard"><Button className="bg-[#FB651E] hover:bg-[#E65C00] font-mono"><KeyRound className="h-4 w-4 mr-2" />Your keys</Button></Link>
-              ) : (
-                <Link to="/signup"><Button className="bg-[#FB651E] hover:bg-[#E65C00] font-mono"><KeyRound className="h-4 w-4 mr-2" />Get an API key</Button></Link>
-              )}
-              <a href={`${API_BASE}/docs`} target="_blank" rel="noopener noreferrer">
-                <Button variant="outline" className="font-mono"><BookOpen className="h-4 w-4 mr-2" />Interactive docs<ExternalLink className="h-3 w-3 ml-2" /></Button>
+            <div className="mt-5 flex flex-wrap gap-2">
+              <Link
+                to={user ? '/dashboard' : '/signup'}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-[#FB651E] hover:bg-[#E65C00] text-white text-sm font-semibold rounded-sm transition-colors"
+              >
+                <KeyRound className="h-4 w-4" /> {user ? 'Your keys' : 'Get an API key'}
+              </Link>
+              <a
+                href={`${API_BASE}/docs`} target="_blank" rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-4 py-2 border border-white/15 text-white/80 hover:text-white hover:border-[#FB651E]/50 text-sm rounded-sm transition-colors"
+              >
+                <BookOpen className="h-4 w-4" /> Interactive docs <ExternalLink className="h-3 w-3" />
               </a>
             </div>
-          </div>
+          </Terminal>
 
           {/* Auth */}
-          <HackerCard glowColor="orange" className="p-6 mb-6">
-            <h2 className="text-lg font-bold font-mono mb-3 flex items-center gap-2"><KeyRound className="h-5 w-5 text-[#FB651E]" />Authentication</h2>
-            <p className="text-sm text-muted-foreground mb-3">
-              Send your key on every request as a bearer token (or the <code className="bg-muted px-1 rounded">X-API-Key</code> header).
+          <section className="mb-8">
+            <h2 className="font-mono text-lg font-bold mb-3 flex items-center gap-2">
+              <span className="text-[#FB651E]">#</span> Authentication
+            </h2>
+            <p className="text-sm text-muted-foreground font-mono mb-3">
+              Send your key as a bearer token (or the <code className="text-[#FB651E]">X-API-Key</code> header).{' '}
               {user
-                ? <> You're logged in — grab your key from the <Link to="/dashboard" className="text-[#FB651E] hover:underline">dashboard</Link>.</>
-                : <> <Link to="/signup" className="text-[#FB651E] hover:underline">Sign up</Link> to get one.</>}
+                ? <>You're logged in — grab your key from the <Link to="/dashboard" className="text-[#FB651E] hover:underline">dashboard</Link>.</>
+                : <><Link to="/signup" className="text-[#FB651E] hover:underline">Sign up</Link> to get one.</>}
             </p>
-            <CodeBlock label="Base URL" code={API_BASE} />
-          </HackerCard>
+            <Terminal title="base url">
+              <span className="text-emerald-300">{API_BASE}</span>
+            </Terminal>
+          </section>
 
           {/* Quick start */}
-          <HackerCard glowColor="green" className="p-6 mb-6">
-            <h2 className="text-lg font-bold font-mono mb-3">Quick start</h2>
+          <section className="mb-8">
+            <h2 className="font-mono text-lg font-bold mb-3 flex items-center gap-2">
+              <span className="text-[#FB651E]">#</span> Quick start
+            </h2>
             <div className="space-y-3">
               <CodeBlock label="curl" code={curl} />
-              <CodeBlock label="JavaScript" code={js} />
-              <CodeBlock label="Python" code={py} />
+              <CodeBlock label="node" code={js} />
+              <CodeBlock label="python" code={py} />
             </div>
-          </HackerCard>
+          </section>
 
           {/* Rate limits */}
-          <HackerCard glowColor="blue" className="p-6 mb-6">
-            <h2 className="text-lg font-bold font-mono mb-3 flex items-center gap-2"><Gauge className="h-5 w-5 text-blue-500" />Rate limits</h2>
-            <p className="text-sm text-muted-foreground mb-3">
-              Per key, rolling 24h. Every response includes <code className="bg-muted px-1 rounded">X-RateLimit-Limit</code>,
-              <code className="bg-muted px-1 rounded ml-1">X-RateLimit-Remaining</code>, and
-              <code className="bg-muted px-1 rounded ml-1">X-RateLimit-Reset</code>; a 429 adds <code className="bg-muted px-1 rounded">Retry-After</code>.
+          <section className="mb-8">
+            <h2 className="font-mono text-lg font-bold mb-3 flex items-center gap-2">
+              <Gauge className="h-5 w-5 text-[#FB651E]" /> Rate limits
+            </h2>
+            <p className="text-sm text-muted-foreground font-mono mb-3">
+              Per key, rolling 24h. Every response carries <code className="text-[#FB651E]">X-RateLimit-*</code>; a 429 adds <code className="text-[#FB651E]">Retry-After</code>.
             </p>
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm font-mono">
-                <thead className="text-left text-muted-foreground border-b border-border">
-                  <tr><th className="pb-2">Plan</th><th className="pb-2">Limit</th><th className="pb-2">Price</th></tr>
+            <div className="border border-border rounded-md overflow-hidden">
+              <table className="w-full font-mono text-sm">
+                <thead className="bg-muted/50 text-left text-muted-foreground">
+                  <tr><th className="px-3 py-2">Plan</th><th className="px-3 py-2">Limit</th><th className="px-3 py-2">Price</th></tr>
                 </thead>
                 <tbody className="divide-y divide-border">
                   {PLANS.map((p) => (
-                    <tr key={p.name}><td className="py-2 font-medium">{p.name}</td><td className="py-2">{p.limit}</td><td className="py-2 text-muted-foreground">{p.price}</td></tr>
+                    <tr key={p.name}>
+                      <td className="px-3 py-2 font-medium">{p.name}</td>
+                      <td className="px-3 py-2 text-[#FB651E]">{p.limit}</td>
+                      <td className="px-3 py-2 text-muted-foreground">{p.price}</td>
+                    </tr>
                   ))}
                 </tbody>
               </table>
             </div>
-          </HackerCard>
+          </section>
 
           {/* Endpoints */}
-          <HackerCard glowColor="purple" className="p-6">
-            <h2 className="text-lg font-bold font-mono mb-3">Endpoints</h2>
-            <div className="divide-y divide-border">
+          <section>
+            <h2 className="font-mono text-lg font-bold mb-3 flex items-center gap-2">
+              <span className="text-[#FB651E]">#</span> Endpoints
+            </h2>
+            <div className="border border-border rounded-md divide-y divide-border">
               {ENDPOINTS.map((e) => (
-                <div key={e.path} className="py-3">
+                <div key={e.path} className="p-3 hover:bg-muted/30 transition-colors">
                   <div className="flex items-center gap-2 font-mono text-sm">
                     <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-emerald-500/10 text-emerald-500">{e.method}</span>
                     <code className="text-foreground">{e.path}</code>
                   </div>
                   <p className="text-sm text-muted-foreground mt-1">{e.desc}</p>
-                  {e.params && <p className="text-xs text-muted-foreground/80 font-mono mt-1">params: {e.params}</p>}
+                  {e.params && <p className="text-xs text-muted-foreground/70 font-mono mt-1">params: {e.params}</p>}
                 </div>
               ))}
             </div>
-          </HackerCard>
+          </section>
         </div>
       </div>
     </>

--- a/frontend/src/pages/DeveloperDashboard.tsx
+++ b/frontend/src/pages/DeveloperDashboard.tsx
@@ -3,14 +3,15 @@ import { Navigate, Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
-  KeyRound, Copy, Check, Trash2, Plus, LogOut, Loader2, BookOpen, AlertCircle, Terminal,
+  KeyRound, Copy, Check, Trash2, Plus, LogOut, Loader2, BookOpen, AlertCircle, Terminal, Activity,
 } from 'lucide-react'
+import { BarChart, Bar, XAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
 import { HackerCard } from '../components/ui/hacker-card'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '../components/ui/dialog'
 import { useDevAuth } from '../contexts/DevAuthContext'
-import { apiClient, type DevMe, type CreatedApiKey } from '../lib/api'
+import { apiClient, type DevMe, type CreatedApiKey, type UsageStats } from '../lib/api'
 
 function CopyButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false)
@@ -34,6 +35,12 @@ export function DeveloperDashboard() {
   const { data: me, isLoading } = useQuery<DevMe>({
     queryKey: ['dev-me'],
     queryFn: () => apiClient.devMe().then((r) => r.data),
+    enabled: !!user,
+  })
+
+  const { data: usageStats } = useQuery<UsageStats>({
+    queryKey: ['dev-usage'],
+    queryFn: () => apiClient.devUsage(7).then((r) => r.data),
     enabled: !!user,
   })
 
@@ -111,6 +118,60 @@ export function DeveloperDashboard() {
               <p className="text-xs text-muted-foreground font-mono mt-2">{usage?.remaining ?? '—'} remaining</p>
             </HackerCard>
           </div>
+
+          {/* Usage — last 7 days */}
+          <HackerCard glowColor="blue" className="p-6 mb-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-xl font-bold font-mono flex items-center gap-2">
+                <Activity className="h-5 w-5 text-blue-500" /> Usage — last 7 days
+              </h2>
+              <span className="text-sm font-mono text-muted-foreground">{usageStats?.total ?? 0} requests</span>
+            </div>
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              <div className="lg:col-span-2 h-48">
+                {usageStats && usageStats.series.length > 0 ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={usageStats.series} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
+                      <XAxis
+                        dataKey="date"
+                        tickFormatter={(d) => new Date(d).toLocaleDateString(undefined, { weekday: 'short' })}
+                        tick={{ fontSize: 11, fontFamily: 'monospace' }}
+                        stroke="hsl(var(--muted-foreground))"
+                      />
+                      <Tooltip
+                        cursor={{ fill: 'rgba(251,101,30,0.08)' }}
+                        contentStyle={{ fontFamily: 'monospace', fontSize: 12, background: 'hsl(var(--background))', border: '1px solid hsl(var(--border))' }}
+                        labelFormatter={(d) => new Date(d as string).toLocaleDateString()}
+                        formatter={(v) => [`${v} requests`, '']}
+                      />
+                      <Bar dataKey="count" radius={[2, 2, 0, 0]}>
+                        {usageStats.series.map((_, i) => <Cell key={i} fill="#FB651E" />)}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="h-full flex items-center justify-center text-sm text-muted-foreground font-mono">
+                    No requests yet — make your first call to see usage here.
+                  </div>
+                )}
+              </div>
+              <div>
+                <div className="text-[10px] uppercase tracking-widest text-muted-foreground/70 mb-2">Top endpoints</div>
+                {usageStats && usageStats.by_endpoint.length > 0 ? (
+                  <div className="space-y-1.5">
+                    {usageStats.by_endpoint.slice(0, 6).map((e) => (
+                      <div key={e.endpoint} className="flex items-center justify-between gap-2 text-xs font-mono">
+                        <span className="truncate text-muted-foreground" title={e.endpoint}>{e.endpoint}</span>
+                        <span className="text-foreground tabular-nums">{e.count}</span>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-xs text-muted-foreground font-mono">—</div>
+                )}
+              </div>
+            </div>
+          </HackerCard>
 
           {/* API keys */}
           <HackerCard glowColor="orange" className="p-6">


### PR DESCRIPTION
UX pass on the platform + the developer portal.

## Navbar (desktop) — decluttered
9 flat tabs → **primary** (Home · Database · Analytics · Hiring · **API**) + a **"More ▾"** dropdown (Funding, Tools, Founders, Roadmap, Share). The **API** entry routes to `/dashboard` when a dev is logged in, else `/api-docs`.

## Mobile — real burger menu
Replaced the cramped 9-icon strip (9px labels) with a proper **☰ burger**: compact top bar → full-screen overlay grouped **Explore / More / Developers**, big tap targets, theme + contact + search, closes on nav.

## API docs (`/api-docs`) — hacky redesign
Rewritten as a **terminal UI**: mac window chrome (traffic lights), `guest@exploreyc:~/api` prompt, `DotPattern` background, orange accents, copyable **curl / node / python** blocks styled as terminals. Same content, on-theme with the rest of the site.

## Developer usage analytics
- **Backend**: new `GET /api/dev/usage?days=7` → per-day request counts + top endpoints, aggregated from `api_usage` (new DB methods in **both** SQLite + Postgres layers, UTC-bucketed).
- **Dashboard**: a **7-day requests bar chart** (Recharts) + **top-endpoints** breakdown, alongside the existing rolling-24h meter.

## Verification
- `npm run build` (tsc -b && vite build) passes; no new deps, no lockfile churn.
- `/api/dev/usage` verified end-to-end on SQLite: 7-day series, `total`, and per-endpoint counts all correct.

Backend-only addition is additive (new endpoint + methods); no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)