### PR TITLE
Fix 'Page not found' tab title on /api-docs, /dashboard, /login, /signup

### DIFF
--- a/frontend/src/components/PageTitleManager.tsx
+++ b/frontend/src/components/PageTitleManager.tsx
@@ -22,6 +22,10 @@ const EXACT: Record<string, string> = {
   '/admin': 'Admin',
   '/verify-email': 'Verify your email',
   '/explore': DEFAULT_TITLE,
+  '/api-docs': 'API Reference',
+  '/dashboard': 'Developer Dashboard',
+  '/login': 'Developer Login',
+  '/signup': 'Get API Access',
 };
 
 function titleForPath(pathname: string): string {


### PR DESCRIPTION
The developer-portal routes showed **"Page not found — ExploreYC"** in the browser tab even though the page rendered fine.

Cause: `PageTitleManager`'s `EXACT` route→title map didn't include `/api-docs`, `/dashboard`, `/login`, `/signup`, so `titleForPath` fell through to the `Page not found` default, and its `useEffect` set `document.title` — overriding each page's own `<Helmet>` title.

Fix: added the four routes to the map (API Reference / Developer Dashboard / Developer Login / Get API Access). Build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)