### PR TITLE
Dev portal in-platform (navbar) + account profile with avatar

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -235,10 +235,14 @@ class Database:
                     email_verified BOOLEAN NOT NULL DEFAULT 0,
                     verification_token TEXT,
                     stripe_customer_id TEXT,
+                    avatar_url TEXT,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
             ''')
+            # Existing local DBs: add avatar_url if missing
+            if 'avatar_url' not in {r[1] for r in cursor.execute("PRAGMA table_info(api_users)").fetchall()}:
+                cursor.execute('ALTER TABLE api_users ADD COLUMN avatar_url TEXT')
             cursor.execute('''
                 CREATE TABLE IF NOT EXISTS api_keys (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -398,6 +402,20 @@ class Database:
             cur = conn.cursor()
             cur.execute('UPDATE api_users SET stripe_customer_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
                         (customer_id, user_id))
+            return cur.rowcount > 0
+
+    def update_api_user_profile(self, user_id, company_name=None, avatar_url=None) -> bool:
+        sets, params = [], []
+        if company_name is not None:
+            sets.append('company_name = ?'); params.append(company_name)
+        if avatar_url is not None:
+            sets.append('avatar_url = ?'); params.append(avatar_url)
+        if not sets:
+            return False
+        params.append(user_id)
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(f"UPDATE api_users SET {', '.join(sets)}, updated_at = CURRENT_TIMESTAMP WHERE id = ?", params)
             return cur.rowcount > 0
 
     def list_api_users(self) -> List[Dict]:

--- a/backend/database_postgres.py
+++ b/backend/database_postgres.py
@@ -1973,6 +1973,20 @@ class DatabasePostgres:
                             (customer_id, user_id))
                 return cur.rowcount > 0
 
+    def update_api_user_profile(self, user_id, company_name=None, avatar_url=None) -> bool:
+        sets, params = [], []
+        if company_name is not None:
+            sets.append('company_name = %s'); params.append(company_name)
+        if avatar_url is not None:
+            sets.append('avatar_url = %s'); params.append(avatar_url)
+        if not sets:
+            return False
+        params.append(user_id)
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"UPDATE api_users SET {', '.join(sets)}, updated_at = NOW() WHERE id = %s", params)
+                return cur.rowcount > 0
+
     def list_api_users(self) -> List[Dict]:
         with self.get_connection() as conn:
             with conn.cursor(cursor_factory=RealDictCursor) as cur:

--- a/backend/main.py
+++ b/backend/main.py
@@ -3105,6 +3105,11 @@ class SetStatusRequest(BaseModel):
     status: str
 
 
+class ProfileUpdate(BaseModel):
+    company_name: Optional[str] = None
+    avatar_url: Optional[str] = None  # small base64 data URL (client-resized)
+
+
 def _dev_user_public(user: dict) -> dict:
     limit = plan_limit(user.get("plan"))
     return {
@@ -3112,6 +3117,7 @@ def _dev_user_public(user: dict) -> dict:
         "plan": user.get("plan", "free"),
         "plan_name": PLAN_META.get(user.get("plan", "free"), {}).get("name"),
         "status": user.get("status", "active"), "email_verified": bool(user.get("email_verified")),
+        "avatar_url": user.get("avatar_url"),
         "daily_limit": limit,
     }
 
@@ -3213,6 +3219,18 @@ async def dev_usage(days: int = 7, session: dict = Depends(verify_dev_session)):
         "total": sum(s["count"] for s in series),
         "by_endpoint": [{"endpoint": r["endpoint"], "count": int(r["count"])} for r in by_endpoint],
     }
+
+
+@app.post("/api/dev/profile")
+async def dev_update_profile(req: ProfileUpdate, session: dict = Depends(verify_dev_session)):
+    avatar = req.avatar_url
+    if avatar:
+        if not avatar.startswith("data:image/"):
+            raise HTTPException(status_code=400, detail="avatar_url must be a data:image/* URL")
+        if len(avatar) > 400_000:
+            raise HTTPException(status_code=400, detail="Image too large (max ~300KB). Please crop or shrink it.")
+    db.update_api_user_profile(session["user_id"], company_name=req.company_name, avatar_url=avatar)
+    return _dev_user_public(db.get_api_user_by_id(session["user_id"]))
 
 
 @app.post("/api/dev/keys")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -85,6 +85,11 @@ function ScrollToTop() {
 // Layout component for pages with navigation (AppProvider wraps entire app so context persists on nav)
 function LayoutContent() {
   const { commandPaletteOpen, setCommandPaletteOpen, contactFormOpen, setContactFormOpen, loading, stats, companies, error, refreshData, loadingProgress, loadingTotal } = useApp();
+  const location = useLocation();
+
+  // Developer-portal pages get the platform chrome (navbar) but don't need the company
+  // dataset, so they skip the initial loading/error gate and render immediately.
+  const chromeOnly = ['/api-docs', '/dashboard', '/signup', '/login'].some((p) => location.pathname.startsWith(p));
 
   // Global keyboard shortcut for command palette (⌘K / Ctrl+K)
   React.useEffect(() => {
@@ -100,7 +105,7 @@ function LayoutContent() {
 
   // Show loading screen while initial data is loading
   // Keep loading screen visible until BOTH stats AND companies are loaded
-  if ((loading && !stats) || (loading && companies.length === 0)) {
+  if (!chromeOnly && ((loading && !stats) || (loading && companies.length === 0))) {
     return (
       <AnimatePresence>
         <LoadingScreen
@@ -112,7 +117,7 @@ function LayoutContent() {
   }
 
   // Show error screen if data failed to load
-  if (error && !stats) {
+  if (!chromeOnly && error && !stats) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center p-4">
         <div className="text-center max-w-md">
@@ -175,11 +180,6 @@ function AnimatedRoutes() {
       <Route path="/research-hub" element={<ResearchHubPage />} />
       <Route path="/batch/:batch/wrapped" element={<BatchWrappedPage />} />
       <Route path="/admin" element={<AdminPage />} />
-      {/* Public API developer portal */}
-      <Route path="/signup" element={<SignupPage />} />
-      <Route path="/login" element={<DevLoginPage />} />
-      <Route path="/dashboard" element={<DeveloperDashboard />} />
-      <Route path="/api-docs" element={<ApiDocsPage />} />
       <Route path="/company/:slug" element={<CompanyPage />} />
       <Route path="/share/company/:slug" element={<CompanyCardPage />} />
       <Route path="/share/company" element={<CompanyCardPage />} />
@@ -198,6 +198,11 @@ function AnimatedRoutes() {
         <Route path="founders" element={<FoundersPage />} />
         <Route path="roadmap" element={<RoadmapPage />} />
         <Route path="share" element={<ShareHub />} />
+        {/* Public API developer portal — in-platform (navbar, burger, ⌘K) */}
+        <Route path="api-docs" element={<ApiDocsPage />} />
+        <Route path="signup" element={<SignupPage />} />
+        <Route path="login" element={<DevLoginPage />} />
+        <Route path="dashboard" element={<DeveloperDashboard />} />
       </Route>
     </Routes>
   );

--- a/frontend/src/components/MobileBottomNav.tsx
+++ b/frontend/src/components/MobileBottomNav.tsx
@@ -3,10 +3,11 @@ import { Link, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Home, BarChart3, Wrench, BookOpen, Map as MapIcon, DollarSign, Share2, Briefcase,
-  Mail, Database, Terminal, Menu, X, Moon, Sun, Command,
+  Mail, Database, Terminal, Menu, X, Moon, Sun, Command, LogOut, LayoutDashboard,
 } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
 import { useDevAuth } from '../contexts/DevAuthContext';
+import { Avatar } from './ui/Avatar';
 
 type Item = { label: string; icon: React.ComponentType<{ className?: string }>; path: string };
 
@@ -37,7 +38,7 @@ const groups: { title: string; items: Item[] }[] = [
 export function MobileBottomNav() {
   const location = useLocation();
   const { darkMode, setDarkMode, setCommandPaletteOpen, setContactFormOpen } = useApp();
-  const { user } = useDevAuth();
+  const { user, logout } = useDevAuth();
   const [open, setOpen] = useState(false);
 
   const hideOnPaths = ['/batch/', '/validator'];
@@ -93,6 +94,30 @@ export function MobileBottomNav() {
             </div>
 
             <div className="p-4 space-y-6">
+              {/* Account */}
+              {user ? (
+                <div className="border border-border p-3 flex items-center gap-3">
+                  <Avatar src={user.avatar_url} name={user.company_name || user.email} size={40} />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-semibold truncate">{user.company_name || 'Developer'}</div>
+                    <div className="text-xs text-muted-foreground truncate">{user.email}</div>
+                  </div>
+                  <button onClick={() => { close(); logout(); }} aria-label="Log out"
+                          className="w-9 h-9 flex items-center justify-center border border-border text-red-500">
+                    <LogOut className="w-4 h-4" />
+                  </button>
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-2">
+                  <Link to="/login" onClick={close} className="flex items-center justify-center gap-2 px-3 py-3 border border-border text-sm">
+                    Log in
+                  </Link>
+                  <Link to="/signup" onClick={close} className="flex items-center justify-center gap-2 px-3 py-3 bg-[#FB651E] text-white text-sm font-semibold">
+                    Get API key
+                  </Link>
+                </div>
+              )}
+
               {groups.map((group) => (
                 <div key={group.title}>
                   <div className="text-[10px] uppercase tracking-widest text-muted-foreground/70 mb-2">{group.title}</div>
@@ -130,7 +155,7 @@ export function MobileBottomNav() {
                   </Link>
                   <Link to={user ? '/dashboard' : '/signup'} onClick={close}
                         className="flex items-center gap-2 px-3 py-3 border border-[#FB651E]/40 bg-[#FB651E]/10 text-[#FB651E]">
-                    <Terminal className="w-4 h-4" /> <span className="text-sm">{user ? 'Dashboard' : 'Get a key'}</span>
+                    <LayoutDashboard className="w-4 h-4" /> <span className="text-sm">{user ? 'Dashboard' : 'Get a key'}</span>
                   </Link>
                 </div>
               </div>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -2,9 +2,11 @@ import { Link, useLocation } from 'react-router-dom';
 import {
   Home, BarChart3, Wrench, BookOpen, Map as MapIcon, DollarSign, Share2,
   Moon, Sun, Command, Briefcase, Mail, Database, Terminal, ChevronDown,
+  LayoutDashboard, LogOut, KeyRound,
 } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
 import { useDevAuth } from '../contexts/DevAuthContext';
+import { Avatar } from './ui/Avatar';
 
 interface NavTab {
   id: string;
@@ -33,7 +35,7 @@ const moreTabs: NavTab[] = [
 export function Navbar() {
   const location = useLocation();
   const { darkMode, setDarkMode, setCommandPaletteOpen, setContactFormOpen } = useApp();
-  const { user } = useDevAuth();
+  const { user, logout } = useDevAuth();
 
   const isActive = (path: string) =>
     path === '/' ? location.pathname === '/' : location.pathname.startsWith(path);
@@ -132,6 +134,41 @@ export function Navbar() {
             >
               {darkMode ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
             </button>
+
+            {/* Account */}
+            {user ? (
+              <div className="relative group">
+                <button className="flex items-center gap-1.5 pl-1 pr-1.5 h-8 border border-border hover:border-[#FB651E]/50 transition-colors" aria-label="Account">
+                  <Avatar src={user.avatar_url} name={user.company_name || user.email} size={24} />
+                  <ChevronDown className="w-3.5 h-3.5 text-muted-foreground transition-transform group-hover:rotate-180" />
+                </button>
+                <div className="absolute right-0 top-full pt-1 hidden group-hover:block z-50">
+                  <div className="min-w-[200px] border border-border bg-background/98 backdrop-blur shadow-[0_8px_24px_rgba(0,0,0,0.25)] py-1">
+                    <div className="px-3 py-2 border-b border-border">
+                      <div className="text-xs font-semibold truncate">{user.company_name || 'Developer'}</div>
+                      <div className="text-[11px] text-muted-foreground truncate">{user.email}</div>
+                      <div className="text-[10px] text-[#FB651E] mt-0.5 uppercase">{user.plan_name || user.plan} plan</div>
+                    </div>
+                    <Link to="/dashboard" className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50">
+                      <LayoutDashboard className="w-4 h-4" /> Dashboard
+                    </Link>
+                    <Link to="/api-docs" className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50">
+                      <Terminal className="w-4 h-4" /> API Docs
+                    </Link>
+                    <button onClick={logout} className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-500 hover:bg-red-500/5">
+                      <LogOut className="w-4 h-4" /> Log out
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <Link
+                to="/signup"
+                className="flex items-center gap-1.5 h-8 px-3 text-xs font-semibold bg-[#FB651E] hover:bg-[#E65C00] text-white transition-colors"
+              >
+                <KeyRound className="w-3.5 h-3.5" /> <span className="hidden lg:inline">Get API key</span>
+              </Link>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/components/ui/Avatar.tsx
+++ b/frontend/src/components/ui/Avatar.tsx
@@ -1,0 +1,26 @@
+/** Round avatar: shows the image if present, else an initial on an orange chip. */
+export function Avatar({
+  src,
+  name,
+  size = 32,
+  className = '',
+}: {
+  src?: string | null
+  name?: string
+  size?: number
+  className?: string
+}) {
+  const initial = (name || '?').trim().charAt(0).toUpperCase() || '?'
+  const style = { width: size, height: size }
+  if (src) {
+    return <img src={src} alt="" style={style} className={`rounded-full object-cover border border-border ${className}`} draggable={false} />
+  }
+  return (
+    <div
+      style={style}
+      className={`rounded-full bg-[#FB651E]/15 text-[#FB651E] flex items-center justify-center font-bold select-none ${className}`}
+    >
+      <span style={{ fontSize: Math.round(size * 0.45) }}>{initial}</span>
+    </div>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -113,6 +113,7 @@ export interface ApiUser {
   plan_name?: string
   status: string
   email_verified: boolean
+  avatar_url?: string | null
   daily_limit: number
 }
 
@@ -234,6 +235,8 @@ export const apiClient = {
   listApiKeys: () => devApi.get<{ keys: ApiKey[] }>('/api/dev/keys'),
   revokeApiKey: (id: number) => devApi.post(`/api/dev/keys/${id}/revoke`),
   devUsage: (days = 7) => devApi.get<UsageStats>(`/api/dev/usage?days=${days}`),
+  updateProfile: (data: { company_name?: string; avatar_url?: string }) =>
+    devApi.post<ApiUser>('/api/dev/profile', data),
   getBatches: () => api.get<{ batches: string[] }>('/api/filters/batches'),
   getIndustries: () => api.get<{ industries: string[] }>('/api/filters/industries'),
   getCountries: () => api.get<{ countries: string[] }>('/api/filters/countries'),

--- a/frontend/src/pages/ApiDocsPage.tsx
+++ b/frontend/src/pages/ApiDocsPage.tsx
@@ -313,11 +313,10 @@ export function ApiDocsPage() {
 
             {/* Sticky sidebar */}
             <aside className="hidden lg:block">
-              <div className="sticky top-6 font-mono text-sm space-y-4">
-                <Link to="/" className="flex items-center gap-2 group">
-                  <div className="w-8 h-8 bg-[#FB651E] flex items-center justify-center"><span className="text-white font-bold">Y</span></div>
-                  <span className="font-bold">API Reference</span>
-                </Link>
+              <div className="sticky top-20 font-mono text-sm space-y-4">
+                <div className="text-base font-bold flex items-center gap-2">
+                  <span className="text-[#FB651E]">&gt;</span> API Reference
+                </div>
                 <div className="space-y-0.5">
                   {nav.map((n) => (
                     <a key={n.id} href={`#${n.id}`} className="block px-2 py-1 text-muted-foreground hover:text-[#FB651E] transition-colors">{n.label}</a>

--- a/frontend/src/pages/DeveloperDashboard.tsx
+++ b/frontend/src/pages/DeveloperDashboard.tsx
@@ -1,17 +1,44 @@
-import { useState } from 'react'
+import { useState, type ChangeEvent } from 'react'
 import { Navigate, Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
-  KeyRound, Copy, Check, Trash2, Plus, LogOut, Loader2, BookOpen, AlertCircle, Terminal, Activity,
+  KeyRound, Copy, Check, Trash2, Plus, LogOut, Loader2, BookOpen, AlertCircle, Terminal, Activity, Camera,
 } from 'lucide-react'
 import { BarChart, Bar, XAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
 import { HackerCard } from '../components/ui/hacker-card'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '../components/ui/dialog'
+import { Avatar } from '../components/ui/Avatar'
 import { useDevAuth } from '../contexts/DevAuthContext'
 import { apiClient, type DevMe, type CreatedApiKey, type UsageStats } from '../lib/api'
+
+/** Resize an uploaded image to a small square jpeg data URL (avoids file storage). */
+function resizeToDataUrl(file: File, size = 160): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onerror = reject
+    reader.onload = () => {
+      const img = new Image()
+      img.onerror = reject
+      img.onload = () => {
+        const canvas = document.createElement('canvas')
+        canvas.width = size
+        canvas.height = size
+        const ctx = canvas.getContext('2d')
+        if (!ctx) return reject(new Error('no canvas'))
+        const scale = Math.max(size / img.width, size / img.height)
+        const w = img.width * scale
+        const h = img.height * scale
+        ctx.drawImage(img, (size - w) / 2, (size - h) / 2, w, h)
+        resolve(canvas.toDataURL('image/jpeg', 0.85))
+      }
+      img.src = reader.result as string
+    }
+    reader.readAsDataURL(file)
+  })
+}
 
 function CopyButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false)
@@ -27,10 +54,12 @@ function CopyButton({ value }: { value: string }) {
 }
 
 export function DeveloperDashboard() {
-  const { user, loading, logout } = useDevAuth()
+  const { user, loading, logout, refresh } = useDevAuth()
   const queryClient = useQueryClient()
   const [newKey, setNewKey] = useState<CreatedApiKey | null>(null)
   const [keyName, setKeyName] = useState('')
+  const [company, setCompany] = useState<string | null>(null)
+  const [avatarError, setAvatarError] = useState('')
 
   const { data: me, isLoading } = useQuery<DevMe>({
     queryKey: ['dev-me'],
@@ -57,6 +86,24 @@ export function DeveloperDashboard() {
     mutationFn: (id: number) => apiClient.revokeApiKey(id),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['dev-me'] }),
   })
+
+  const profile = useMutation({
+    mutationFn: (data: { company_name?: string; avatar_url?: string }) => apiClient.updateProfile(data),
+    onSuccess: () => { refresh(); queryClient.invalidateQueries({ queryKey: ['dev-me'] }) },
+  })
+
+  const onPickAvatar = async (e: ChangeEvent<HTMLInputElement>) => {
+    setAvatarError('')
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+    try {
+      const avatar_url = await resizeToDataUrl(file)
+      profile.mutate({ avatar_url })
+    } catch {
+      setAvatarError('Could not process that image.')
+    }
+  }
 
   if (loading) {
     return (
@@ -92,6 +139,47 @@ export function DeveloperDashboard() {
               <Button variant="outline" className="font-mono" onClick={logout}><LogOut className="h-4 w-4 mr-2" />Logout</Button>
             </div>
           </div>
+
+          {/* Profile */}
+          <HackerCard glowColor="orange" className="p-6 mb-6">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+              <div className="relative flex-shrink-0">
+                <Avatar src={me?.avatar_url ?? user.avatar_url} name={(me?.company_name || user.company_name) ?? user.email} size={64} />
+                <label className="absolute -bottom-1 -right-1 w-6 h-6 bg-[#FB651E] hover:bg-[#E65C00] rounded-full flex items-center justify-center cursor-pointer border-2 border-background"
+                       title="Upload a picture">
+                  {profile.isPending ? <Loader2 className="w-3.5 h-3.5 text-white animate-spin" /> : <Camera className="w-3.5 h-3.5 text-white" />}
+                  <input type="file" accept="image/*" className="hidden" onChange={onPickAvatar} />
+                </label>
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-mono text-muted-foreground mb-2 truncate">{user.email}</div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Input
+                    value={company ?? (me?.company_name ?? user.company_name ?? '')}
+                    onChange={(e) => setCompany(e.target.value)}
+                    placeholder="Company name"
+                    className="h-9 font-mono max-w-xs"
+                  />
+                  <Button
+                    className="bg-[#FB651E] hover:bg-[#E65C00] h-9"
+                    disabled={profile.isPending || company === null}
+                    onClick={() => profile.mutate({ company_name: company ?? '' })}
+                  >
+                    Save
+                  </Button>
+                  {(me?.avatar_url ?? user.avatar_url) && (
+                    <button
+                      onClick={() => profile.mutate({ avatar_url: '' })}
+                      className="text-xs font-mono text-muted-foreground hover:text-red-500"
+                    >
+                      Remove photo
+                    </button>
+                  )}
+                </div>
+                {avatarError && <p className="text-xs text-red-500 mt-1">{avatarError}</p>}
+              </div>
+            </div>
+          </HackerCard>
 
           {/* Plan + usage */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">

--- a/supabase/migrations/20260707120000_add_api_user_avatar.sql
+++ b/supabase/migrations/20260707120000_add_api_user_avatar.sql
@@ -1,0 +1,2 @@
+-- Developer profile picture (stored as a small base64 data URL, client-resized).
+ALTER TABLE api_users ADD COLUMN IF NOT EXISTS avatar_url TEXT;


### PR DESCRIPTION
Makes the developer portal feel in-platform, and adds account/profile with a picture.

## In-platform (navbar everywhere)
- Moved `/api-docs`, `/dashboard`, `/signup`, `/login` **into the platform `Layout`** so they get the navbar, mobile **burger**, command palette, and banner — no longer floating full-screen.
- `Layout` **skips the company-dataset loading gate** for these chrome-only routes, so docs/dashboard render instantly (they don't need the YC dataset).
- API docs sidebar drops below the sticky navbar.

## Navbar reflects the account
- **Logged in** → avatar/initials **dropdown** (email, plan, Dashboard, API Docs, Log out).
- **Logged out** → a **"Get API key"** CTA.
- The mobile burger shows the same account block (avatar + email + log out, or log in / get key).

## Profile + picture
- New **`api_users.avatar_url`** (Postgres migration `20260707120000_add_api_user_avatar.sql` + SQLite in-code migrator).
- Pictures are stored as a **small client-resized base64 data URL** (160px jpeg) — **no S3/Storage infra needed**.
- **`POST /api/dev/profile`** updates `company_name` + `avatar_url` (validates `data:image/*`, caps ~300KB); `avatar_url` flows through `/me` and login/signup payloads.
- **Dashboard profile card**: avatar with an upload button, editable company name, "remove photo".
- New reusable `<Avatar>` (image or initial chip) used in navbar + burger + dashboard.

## Verify
- Backend compiles; frontend `npm run build` clean; **no new deps / lockfile churn**.
- Profile flow verified end-to-end on SQLite (set/clear avatar, company edit, data-url + size validation); `avatar_url` migration verified on fresh **and** pre-existing SQLite DBs.

## Deploy note
Apply the migration `supabase/migrations/20260707120000_add_api_user_avatar.sql` to Supabase (one `ALTER TABLE api_users ADD COLUMN IF NOT EXISTS avatar_url TEXT;`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)