### PR TITLE
Reposition as multi-source (YC + a16z); neutral brand mark + shared PageHeader

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -66,7 +66,7 @@ export function Header({ onThemeToggle, isDark = false, onCommandPalette }: Head
             <YCLogo className="h-8 w-8 sm:h-10 sm:w-10 flex-shrink-0" />
             <div className="min-w-0">
               <h1 className="text-base sm:text-xl font-bold bg-gradient-to-r from-[#FB651E] to-[#FF8833] bg-clip-text text-transparent truncate">
-                YC Company Explorer
+                ExploreYC
               </h1>
               <p className="text-xs text-muted-foreground font-mono hidden sm:block">
                 {(stats?.total_companies ?? 0).toLocaleString()} companies indexed

--- a/frontend/src/components/LoadingScreen.tsx
+++ b/frontend/src/components/LoadingScreen.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { Logo } from './ui/Logo';
 
 const LOADING_TIPS = [
-  'Discovering startups from every YC batch...',
+  'Discovering startups across YC & a16z...',
   'Mapping companies across the globe...',
   'Indexing industries and hiring status...',
   'Building your explorer view...',
@@ -47,20 +48,20 @@ export function LoadingScreen({ message, progress = 0, total = 0 }: LoadingScree
           animate={{ scale: 1, opacity: 1, y: 0 }}
           transition={{ duration: 0.6, type: 'spring', stiffness: 120 }}
         >
-          <motion.img
-            src="/yc-logo.png"
-            alt="YC"
-            className="h-20 w-20 object-contain drop-shadow-lg"
+          <motion.div
+            className="drop-shadow-lg"
             animate={{ y: [0, -4, 0] }}
             transition={{ duration: 2, repeat: Infinity, ease: 'easeInOut' }}
-          />
+          >
+            <Logo size={80} />
+          </motion.div>
           <motion.p
             className="mt-4 font-mono text-sm text-muted-foreground tracking-wider"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.3 }}
           >
-            YC Company Explorer
+            ExploreYC
           </motion.p>
         </motion.div>
 

--- a/frontend/src/components/MobileBottomNav.tsx
+++ b/frontend/src/components/MobileBottomNav.tsx
@@ -8,6 +8,7 @@ import {
 import { useApp } from '../contexts/AppContext';
 import { useDevAuth } from '../contexts/DevAuthContext';
 import { Avatar } from './ui/Avatar';
+import { Logo } from './ui/Logo';
 
 type Item = { label: string; icon: React.ComponentType<{ className?: string }>; path: string };
 
@@ -58,10 +59,8 @@ export function MobileBottomNav() {
       >
         <div className="flex h-full items-center justify-between px-4">
           <Link to="/" onClick={close} className="flex items-center gap-2 min-w-0">
-            <div className="w-8 h-8 bg-[#FB651E] flex items-center justify-center flex-shrink-0">
-              <span className="text-base font-bold text-white">Y</span>
-            </div>
-            <span className="text-sm font-bold truncate">YC Explorer</span>
+            <Logo size={32} />
+            <span className="text-sm font-bold truncate">ExploreYC</span>
           </Link>
           <button
             onClick={() => setOpen((o) => !o)}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -7,6 +7,7 @@ import {
 import { useApp } from '../contexts/AppContext';
 import { useDevAuth } from '../contexts/DevAuthContext';
 import { Avatar } from './ui/Avatar';
+import { Logo } from './ui/Logo';
 
 interface NavTab {
   id: string;
@@ -55,12 +56,10 @@ export function Navbar() {
         <div className="flex h-14 items-center justify-between gap-2">
           {/* Logo */}
           <Link to="/" className="flex items-center gap-2 sm:gap-3 group min-w-0 flex-shrink-0">
-            <div className="w-9 h-9 bg-[#FB651E] flex items-center justify-center group-hover:shadow-[0_0_16px_rgba(251,101,30,0.4)] transition-shadow flex-shrink-0">
-              <span className="text-lg font-bold text-white">Y</span>
-            </div>
+            <Logo size={36} className="group-hover:shadow-[0_0_16px_rgba(251,101,30,0.4)] transition-shadow" />
             <div className="hidden lg:block min-w-0">
-              <div className="text-sm font-bold whitespace-nowrap truncate">YC Explorer</div>
-              <div className="text-xs text-muted-foreground whitespace-nowrap truncate">$ company-db</div>
+              <div className="text-sm font-bold whitespace-nowrap truncate">ExploreYC</div>
+              <div className="text-xs text-muted-foreground whitespace-nowrap truncate">$ startup-db</div>
             </div>
           </Link>
 

--- a/frontend/src/components/PageTitleManager.tsx
+++ b/frontend/src/components/PageTitleManager.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 
 const BRAND = 'ExploreYC';
-const DEFAULT_TITLE = `${BRAND} — explore the Y Combinator portfolio`;
+const DEFAULT_TITLE = `${BRAND} — startup data from YC, a16z & more`;
 
 const EXACT: Record<string, string> = {
   '/': DEFAULT_TITLE,

--- a/frontend/src/components/share/ShareCard.tsx
+++ b/frontend/src/components/share/ShareCard.tsx
@@ -51,7 +51,7 @@ export const ShareCard = forwardRef<HTMLDivElement, ShareCardProps>(
         {/* Watermark */}
         {watermark && (
           <div className="absolute bottom-6 right-6 flex items-center gap-2 text-white/60">
-            <span className="text-sm font-mono">YC Explorer</span>
+            <span className="text-sm font-mono">ExploreYC</span>
             <svg
               className="w-4 h-4"
               fill="currentColor"

--- a/frontend/src/components/share/TradingCard.tsx
+++ b/frontend/src/components/share/TradingCard.tsx
@@ -275,7 +275,7 @@ export const TradingCard = forwardRef<HTMLDivElement, TradingCardProps>(({ compa
           style={{ marginTop: 24, fontSize: 14, color: '#71717a', flexShrink: 0 }}
         >
           <span>Powered by</span>
-          <span className="font-bold" style={{ color: '#FB651E' }}>YC Explorer</span>
+          <span className="font-bold" style={{ color: '#FB651E' }}>ExploreYC</span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/ui/Logo.tsx
+++ b/frontend/src/components/ui/Logo.tsx
@@ -1,0 +1,43 @@
+/**
+ * Source-neutral brand mark for ExploreYC.
+ * An orange terminal-prompt glyph (`>`) instead of the YC "Y" — reads as a
+ * multi-source startup-data platform, not a YC-only tool. Keeps the brand color.
+ */
+export function Logo({ size = 36, className = '' }: { size?: number; className?: string }) {
+  return (
+    <div
+      style={{ width: size, height: size }}
+      className={`bg-[#FB651E] flex items-center justify-center flex-shrink-0 ${className}`}
+      aria-hidden
+    >
+      <span style={{ fontSize: Math.round(size * 0.52) }} className="font-mono font-bold text-white leading-none">
+        &gt;
+      </span>
+    </div>
+  )
+}
+
+/** Logo + "ExploreYC" wordmark (+ optional terminal subtitle). */
+export function Brand({
+  size = 36,
+  subtitle = '$ startup-db',
+  showText = true,
+  className = '',
+}: {
+  size?: number
+  subtitle?: string | null
+  showText?: boolean
+  className?: string
+}) {
+  return (
+    <div className={`flex items-center gap-2 sm:gap-3 min-w-0 ${className}`}>
+      <Logo size={size} className="group-hover:shadow-[0_0_16px_rgba(251,101,30,0.4)] transition-shadow" />
+      {showText && (
+        <div className="min-w-0">
+          <div className="text-sm font-bold whitespace-nowrap truncate">ExploreYC</div>
+          {subtitle && <div className="text-xs text-muted-foreground whitespace-nowrap truncate">{subtitle}</div>}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -1,0 +1,39 @@
+import { Terminal } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+/**
+ * Standardized page header used across the platform: a terminal `$ command`
+ * line, a `> Title`, an optional subtitle, and optional right-aligned actions.
+ * Consolidates the copy/paste header pattern that had drifted per-page.
+ */
+export function PageHeader({
+  command,
+  title,
+  subtitle,
+  actions,
+  className = '',
+}: {
+  command: string
+  title: ReactNode
+  subtitle?: ReactNode
+  actions?: ReactNode
+  className?: string
+}) {
+  return (
+    <div className={`mb-6 ${className}`}>
+      <div className="flex items-center gap-2 mb-2 font-mono text-sm text-muted-foreground">
+        <Terminal className="h-4 w-4 text-[#FB651E]" />
+        <span className="truncate">{command}</span>
+      </div>
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="text-2xl md:text-3xl font-bold mb-1">
+            <span className="text-[#FB651E]">&gt;</span> {title}
+          </h1>
+          {subtitle && <p className="text-muted-foreground font-mono text-sm">{subtitle}</p>}
+        </div>
+        {actions && <div className="flex-shrink-0">{actions}</div>}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -229,7 +229,7 @@ export function AdminPage() {
     return (
       <>
         <Helmet>
-          <title>Admin Login - YC Company Explorer</title>
+          <title>Admin Login - ExploreYC</title>
         </Helmet>
         <div className="min-h-screen flex items-center justify-center bg-background p-4">
           <motion.div
@@ -322,7 +322,7 @@ export function AdminPage() {
   return (
     <>
       <Helmet>
-        <title>Admin Dashboard - YC Company Explorer</title>
+        <title>Admin Dashboard - ExploreYC</title>
       </Helmet>
 
       <div className="min-h-screen bg-background p-4 md:p-8">

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -2,10 +2,11 @@ import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { AdvancedAnalytics } from '../components/AdvancedAnalytics';
 import { useApp } from '../contexts/AppContext';
-import { TrendingUp, Building2, Globe2, Calendar, ArrowRight, Sparkles, Terminal, Briefcase, Target } from 'lucide-react';
+import { TrendingUp, Building2, Globe2, Calendar, ArrowRight, Sparkles, Briefcase, Target } from 'lucide-react';
 import { HackerCard } from '../components/ui/hacker-card';
 import { DotPattern } from '../components/ui/dot-pattern';
 import { GridPattern } from '../components/ui/grid-pattern';
+import { PageHeader } from '../components/ui/PageHeader';
 
 const container = {
   hidden: { opacity: 0 },
@@ -78,19 +79,11 @@ export function AnalyticsPage() {
           transition={{ duration: 0.5 }}
           className="mb-8"
         >
-          <div className="flex items-center gap-2 mb-4 font-mono text-sm text-muted-foreground">
-            <Terminal className="h-4 w-4 text-[#FB651E]" />
-            <span>$ analyze --data yc-portfolio</span>
-          </div>
-          <h1 className="text-3xl md:text-4xl font-bold mb-2">
-            <span className="text-[#FB651E]">&gt;</span>{' '}
-            <span className="bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text text-transparent">
-              Analytics Dashboard
-            </span>
-          </h1>
-          <p className="text-muted-foreground font-mono">
-            Insights and trends from Y Combinator's portfolio
-          </p>
+          <PageHeader
+            command="$ analyze --data yc-portfolio"
+            title="YC Portfolio Analytics"
+            subtitle="Insights and trends across the Y Combinator portfolio"
+          />
         </motion.div>
 
         {/* Quick Stats Grid */}

--- a/frontend/src/pages/BatchWrappedPage.tsx
+++ b/frontend/src/pages/BatchWrappedPage.tsx
@@ -146,14 +146,14 @@ export function BatchWrappedPage() {
     <>
       {/* Dynamic meta tags for SEO and social sharing */}
       <Helmet>
-        <title>{stats.batch} Wrapped - YC Company Explorer</title>
+        <title>{stats.batch} Wrapped - ExploreYC</title>
         <meta
           name="description"
           content={`Explore ${stats.batch} batch wrapped: ${stats.total_companies} companies, ${stats.hiring_percentage}% hiring, top industry ${stats.top_industries[0]?.name}`}
         />
 
         {/* Open Graph tags */}
-        <meta property="og:title" content={`${stats.batch} Wrapped - YC Company Explorer`} />
+        <meta property="og:title" content={`${stats.batch} Wrapped - ExploreYC`} />
         <meta
           property="og:description"
           content={`${stats.total_companies} companies launched in ${stats.batch}. Top industry: ${stats.top_industries[0]?.name}. ${stats.hiring_percentage}% are hiring!`}

--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -14,7 +14,6 @@ import {
 } from '@tanstack/react-table';
 import {
   Database,
-  Terminal,
   Download,
   ExternalLink,
   ArrowUpDown,
@@ -39,6 +38,7 @@ import {
 } from 'lucide-react';
 import { apiClient, type Company, type CompanyFilter } from '../lib/api';
 import { SourceBadge, sourceLabel } from '../components/ui/SourceBadge';
+import { PageHeader } from '../components/ui/PageHeader';
 import { useApp } from '../contexts/AppContext';
 import { HackerCard } from '../components/ui/hacker-card';
 import { DotPattern } from '../components/ui/dot-pattern';
@@ -822,29 +822,21 @@ export function DatabasePage() {
 
       <div className="container relative mx-auto px-4 py-8 max-w-[1600px]">
         {/* Header */}
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }} className="mb-6">
-          <div className="flex items-center gap-2 mb-3 font-mono text-sm text-muted-foreground">
-            <Terminal className="h-4 w-4 text-[#FB651E]" />
-            <span>$ yc --database --all --export</span>
-          </div>
-          <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
-            <div>
-              <h1 className="text-2xl md:text-3xl font-bold mb-1">
-                <span className="text-[#FB651E]">&gt;</span>{' '}
-                <span>{sourceHeading}</span>
-              </h1>
-              <p className="text-muted-foreground font-mono text-sm">
-                {sourceSubtitle}
-              </p>
-            </div>
-            <button
-              onClick={() => setExportOpen(true)}
-              className="flex items-center gap-2 px-4 py-2.5 bg-[#FB651E] hover:bg-[#E65C00] text-white text-sm font-semibold font-mono transition-colors rounded-sm flex-shrink-0"
-            >
-              <Download className="w-4 h-4" />
-              Export Data
-            </button>
-          </div>
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }}>
+          <PageHeader
+            command="$ db --companies --export"
+            title={sourceHeading}
+            subtitle={sourceSubtitle}
+            actions={
+              <button
+                onClick={() => setExportOpen(true)}
+                className="flex items-center gap-2 px-4 py-2.5 bg-[#FB651E] hover:bg-[#E65C00] text-white text-sm font-semibold font-mono transition-colors rounded-sm flex-shrink-0"
+              >
+                <Download className="w-4 h-4" />
+                Export Data
+              </button>
+            }
+          />
         </motion.div>
 
         {/* Stats row */}

--- a/frontend/src/pages/EnhancedDashboard.tsx
+++ b/frontend/src/pages/EnhancedDashboard.tsx
@@ -322,7 +322,7 @@ export function EnhancedDashboard() {
             <div>
               <h3 className="font-bold mb-3 flex items-center gap-2">
                 <img src="/yc-logo.png" alt="YC" className="h-6 w-6 object-contain" />
-                YC Company Explorer
+                ExploreYC
               </h3>
               <p className="text-sm text-muted-foreground">
                 Explore and analyze Y Combinator startups with interactive maps, advanced analytics, and real-time data.

--- a/frontend/src/pages/FundingPage.tsx
+++ b/frontend/src/pages/FundingPage.tsx
@@ -159,7 +159,7 @@ export function FundingPage() {
           'datePublished': '2024-01-01',
           'creator': {
             '@type': 'Organization',
-            'name': 'YC Explorer'
+            'name': 'ExploreYC'
           },
           'distribution': {
             '@type': 'DataDownload',
@@ -207,7 +207,7 @@ export function FundingPage() {
         {/* Primary Meta Tags */}
         <title>
           {filteredNetwork?.companies.length
-            ? `Top ${filteredNetwork.companies.length} YC Companies by Funding (2025) | YC Explorer`
+            ? `Top ${filteredNetwork.companies.length} YC Companies by Funding (2025) | ExploreYC`
             : 'YC Startup Funding Leaderboard 2025 | Y Combinator Companies Ranked'
           }
         </title>
@@ -265,7 +265,7 @@ export function FundingPage() {
         <meta name="twitter:image" content="https://yc-explorer.com/og-funding.png" />
 
         {/* Additional SEO */}
-        <meta name="author" content="YC Explorer" />
+        <meta name="author" content="ExploreYC" />
         <meta name="robots" content="index, follow, max-image-preview:large" />
         <meta name="googlebot" content="index, follow" />
 

--- a/frontend/src/pages/HiringBoardPage.tsx
+++ b/frontend/src/pages/HiringBoardPage.tsx
@@ -150,7 +150,7 @@ export function HiringBoardPage() {
   return (
     <>
       <Helmet>
-        <title>Live YC Hiring Board - 1,425+ Jobs | YC Explorer</title>
+        <title>Live YC Hiring Board - 1,425+ Jobs | ExploreYC</title>
         <meta
           name="description"
           content={`Browse ${filteredAndSortedJobs.length || '1,425+'} live job openings from Y Combinator companies. Filter by role, batch, location, salary. One-click apply.`}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -54,11 +54,11 @@ export function HomePage() {
           <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-4">
             <span className="text-[#FB651E]">&gt;</span>{' '}
             <span className="bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text text-transparent">
-              Explore YC Companies
+              Explore YC &amp; a16z startups
             </span>
           </h1>
           <p className="text-lg text-muted-foreground font-mono max-w-2xl mb-8">
-            Search, analyze, and discover insights from Y Combinator's portfolio. {totalCompanies.toLocaleString()}+ companies, {totalCountries}+ countries.
+            Search, analyze, and build on startup data from Y Combinator, a16z &amp; more — {totalCompanies.toLocaleString()}+ companies in one place, now with a free, open-source API.
           </p>
 
           {/* Live Stats - inline terminal style */}
@@ -120,7 +120,7 @@ export function HomePage() {
             >
               <img
                 src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1140202&theme=light&t=1778138682064"
-                alt="ExploreYC - YC Company Explorer - Your data layer for Y Combinator's startup ecosystem | Product Hunt"
+                alt="ExploreYC — startup data API for YC & a16z | Product Hunt"
                 width="250"
                 height="54"
               />

--- a/frontend/src/pages/ShareHub.tsx
+++ b/frontend/src/pages/ShareHub.tsx
@@ -180,7 +180,7 @@ export function ShareHub() {
               { step: '1', text: 'Choose your content type (wrapped, leaderboard, map, or company card)' },
               { step: '2', text: 'Customize filters and options to create your perfect share' },
               { step: '3', text: 'Download high-quality PNG or share directly to Twitter/LinkedIn' },
-              { step: '4', text: 'Drive traffic back to YC Explorer and grow your audience' },
+              { step: '4', text: 'Drive traffic back to ExploreYC and grow your audience' },
             ].map((item, index) => (
               <motion.div
                 key={index}


### PR DESCRIPTION
Makes the platform read as a **multi-source startup-data platform** (YC + a16z, more to come) instead of a YC-only tool — while keeping accurate "YC" labels on the genuinely YC-scoped tools. Per the agreed direction: **reposition (keep ExploreYC) · neutralize the mark · include a design-system pass.**

## Brand
- **Neutral mark**: new `<Logo>` — an orange terminal **`>`** glyph replacing the YC "Y" square (keeps the brand color). Applied to navbar, mobile burger, and the loading screen. New `<Brand>` lockup too.
- Wordmark: **"YC Explorer / $ company-db" → "ExploreYC / $ startup-db"**.
- Normalized **"YC (Company) Explorer" → "ExploreYC"** across pages/meta/share cards.

## Positioning copy
- `PageTitleManager` default: *"explore the Y Combinator portfolio"* → **"startup data from YC, a16z & more"**.
- **Home hero**: *"Explore YC Companies"* → **"Explore YC & a16z startups"**; subtitle now reflects multi-source + the open-source API.

## Design system
- New shared **`<PageHeader>`** (terminal `$ command` + `> Title` + subtitle + right-aligned actions) consolidating the per-page header pattern that had drifted.
- Applied to **DatabasePage** (keeps its source-aware title) and **AnalyticsPage** (labeled "YC Portfolio Analytics").

## Deliberately kept as "YC"
Analytics / Funding / Hiring / idea-validator stay YC-labeled — a16z has no funding/batch/hiring data, so those tools are genuinely YC-scoped and relabeling them would be inaccurate.

Frontend-only; `npm run build` passes; no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)