### PR TITLE
Fix navbar: click dropdowns (opaque) + burger up to lg (mobile/tablet)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -147,7 +147,7 @@ function LayoutContent() {
       <ScrollToTop />
       <Navbar />
       <MobileBottomNav />
-      <main className="pt-[84px] md:pt-0">
+      <main className="pt-[84px] lg:pt-0">
         <AnimatedOutlet />
       </main>
       <CommandPalette

--- a/frontend/src/components/MobileBottomNav.tsx
+++ b/frontend/src/components/MobileBottomNav.tsx
@@ -54,7 +54,7 @@ export function MobileBottomNav() {
     <>
       {/* Top bar with burger */}
       <nav
-        className="fixed left-0 right-0 z-40 md:hidden h-14 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 font-mono"
+        className="fixed left-0 right-0 z-40 lg:hidden h-14 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 font-mono"
         style={{ top: '28px' }}
       >
         <div className="flex h-full items-center justify-between px-4">
@@ -80,7 +80,7 @@ export function MobileBottomNav() {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.15 }}
-            className="fixed inset-0 z-50 md:hidden bg-background font-mono overflow-y-auto"
+            className="fixed inset-0 z-50 lg:hidden bg-background font-mono overflow-y-auto"
           >
             {/* Overlay header */}
             <div className="flex items-center justify-between px-4 h-14 border-b border-border" style={{ marginTop: '28px' }}>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
   Home, BarChart3, Wrench, BookOpen, Map as MapIcon, DollarSign, Share2,
@@ -37,6 +38,21 @@ export function Navbar() {
   const location = useLocation();
   const { darkMode, setDarkMode, setCommandPaletteOpen, setContactFormOpen } = useApp();
   const { user, logout } = useDevAuth();
+  const [openMenu, setOpenMenu] = useState<null | 'more' | 'account'>(null);
+  const navRef = useRef<HTMLDivElement>(null);
+
+  // Close menus on outside click, Escape, or route change
+  useEffect(() => {
+    if (!openMenu) return;
+    const onDown = (e: MouseEvent) => {
+      if (navRef.current && !navRef.current.contains(e.target as Node)) setOpenMenu(null);
+    };
+    const onEsc = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpenMenu(null); };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onEsc);
+    return () => { document.removeEventListener('mousedown', onDown); document.removeEventListener('keydown', onEsc); };
+  }, [openMenu]);
+  useEffect(() => { setOpenMenu(null); }, [location.pathname]);
 
   const isActive = (path: string) =>
     path === '/' ? location.pathname === '/' : location.pathname.startsWith(path);
@@ -50,21 +66,24 @@ export function Navbar() {
       active ? 'text-[#FB651E] border-[#FB651E]' : 'text-muted-foreground hover:text-foreground border-transparent hover:border-border'
     }`;
 
+  // Solid panel (no transparency so page content can't bleed through)
+  const panelClass = 'absolute right-0 top-full mt-1 z-50 border border-border bg-background shadow-[0_8px_24px_rgba(0,0,0,0.35)] py-1';
+
   return (
-    <nav className="hidden md:block sticky top-0 z-40 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 font-mono">
+    <nav className="hidden lg:block sticky top-0 z-40 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 font-mono">
       <div className="container mx-auto px-4">
-        <div className="flex h-14 items-center justify-between gap-2">
+        <div ref={navRef} className="flex h-14 items-center justify-between gap-2">
           {/* Logo */}
-          <Link to="/" className="flex items-center gap-2 sm:gap-3 group min-w-0 flex-shrink-0">
+          <Link to="/" className="flex items-center gap-2 xl:gap-3 group min-w-0 flex-shrink-0">
             <Logo size={36} className="group-hover:shadow-[0_0_16px_rgba(251,101,30,0.4)] transition-shadow" />
-            <div className="hidden lg:block min-w-0">
+            <div className="hidden xl:block min-w-0">
               <div className="text-sm font-bold whitespace-nowrap truncate">ExploreYC</div>
               <div className="text-xs text-muted-foreground whitespace-nowrap truncate">$ startup-db</div>
             </div>
           </Link>
 
           {/* Center nav */}
-          <div className="flex items-center gap-0.5">
+          <div className="flex items-center gap-0.5 min-w-0">
             {primaryTabs.map((tab) => {
               const Icon = tab.icon;
               return (
@@ -75,19 +94,23 @@ export function Navbar() {
               );
             })}
 
-            {/* API entry */}
             <Link to={apiPath} className={tabClass(apiActive)}>
               <Terminal className="w-4 h-4 flex-shrink-0" />
               <span className="truncate">API</span>
             </Link>
 
-            {/* More dropdown (hover) */}
-            <div className="relative group">
-              <button className={`${tabClass(moreActive)} cursor-default`} aria-haspopup="true">
-                More <ChevronDown className="w-3.5 h-3.5 transition-transform group-hover:rotate-180" />
+            {/* More (click) */}
+            <div className="relative">
+              <button
+                onClick={() => setOpenMenu((m) => (m === 'more' ? null : 'more'))}
+                className={tabClass(moreActive)}
+                aria-haspopup="true"
+                aria-expanded={openMenu === 'more'}
+              >
+                More <ChevronDown className={`w-3.5 h-3.5 transition-transform ${openMenu === 'more' ? 'rotate-180' : ''}`} />
               </button>
-              <div className="absolute right-0 top-full pt-1 hidden group-hover:block z-50">
-                <div className="min-w-[180px] border border-border bg-background/98 backdrop-blur shadow-[0_8px_24px_rgba(0,0,0,0.25)] py-1">
+              {openMenu === 'more' && (
+                <div className={`${panelClass} min-w-[180px]`}>
                   {moreTabs.map((tab) => {
                     const Icon = tab.icon;
                     return (
@@ -95,9 +118,7 @@ export function Navbar() {
                         key={tab.id}
                         to={tab.path}
                         className={`flex items-center gap-2 px-3 py-2 text-sm transition-colors ${
-                          isActive(tab.path)
-                            ? 'text-[#FB651E] bg-[#FB651E]/5'
-                            : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                          isActive(tab.path) ? 'text-[#FB651E] bg-[#FB651E]/5' : 'text-muted-foreground hover:text-foreground hover:bg-muted/60'
                         }`}
                       >
                         <Icon className="w-4 h-4" /> {tab.label}
@@ -105,26 +126,27 @@ export function Navbar() {
                     );
                   })}
                 </div>
-              </div>
+              )}
             </div>
           </div>
 
           {/* Right actions */}
-          <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="flex items-center gap-1.5 flex-shrink-0">
             <button
               onClick={() => setContactFormOpen(true)}
-              className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground hover:text-[#FB651E] hover:border-[#FB651E]/50 border border-border transition-colors"
+              className="flex items-center gap-2 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-[#FB651E] hover:border-[#FB651E]/50 border border-border transition-colors"
               title="Send feedback or bug report"
             >
               <Mail className="w-3 h-3" />
-              <span className="hidden lg:inline">Contact</span>
+              <span className="hidden xl:inline">Contact</span>
             </button>
             <button
               onClick={() => setCommandPaletteOpen(true)}
-              className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:border-[#FB651E]/50 border border-border transition-colors"
+              className="flex items-center gap-2 px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:border-[#FB651E]/50 border border-border transition-colors"
+              title="Command palette (⌘K)"
             >
               <Command className="w-3 h-3" />
-              <span className="hidden lg:inline">⌘K</span>
+              <span className="hidden xl:inline">⌘K</span>
             </button>
             <button
               onClick={() => setDarkMode(!darkMode)}
@@ -134,38 +156,43 @@ export function Navbar() {
               {darkMode ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
             </button>
 
-            {/* Account */}
+            {/* Account (click) */}
             {user ? (
-              <div className="relative group">
-                <button className="flex items-center gap-1.5 pl-1 pr-1.5 h-8 border border-border hover:border-[#FB651E]/50 transition-colors" aria-label="Account">
+              <div className="relative">
+                <button
+                  onClick={() => setOpenMenu((m) => (m === 'account' ? null : 'account'))}
+                  className="flex items-center gap-1.5 pl-1 pr-1.5 h-8 border border-border hover:border-[#FB651E]/50 transition-colors"
+                  aria-label="Account"
+                  aria-expanded={openMenu === 'account'}
+                >
                   <Avatar src={user.avatar_url} name={user.company_name || user.email} size={24} />
-                  <ChevronDown className="w-3.5 h-3.5 text-muted-foreground transition-transform group-hover:rotate-180" />
+                  <ChevronDown className={`w-3.5 h-3.5 text-muted-foreground transition-transform ${openMenu === 'account' ? 'rotate-180' : ''}`} />
                 </button>
-                <div className="absolute right-0 top-full pt-1 hidden group-hover:block z-50">
-                  <div className="min-w-[200px] border border-border bg-background/98 backdrop-blur shadow-[0_8px_24px_rgba(0,0,0,0.25)] py-1">
+                {openMenu === 'account' && (
+                  <div className={`${panelClass} min-w-[210px]`}>
                     <div className="px-3 py-2 border-b border-border">
                       <div className="text-xs font-semibold truncate">{user.company_name || 'Developer'}</div>
                       <div className="text-[11px] text-muted-foreground truncate">{user.email}</div>
                       <div className="text-[10px] text-[#FB651E] mt-0.5 uppercase">{user.plan_name || user.plan} plan</div>
                     </div>
-                    <Link to="/dashboard" className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50">
+                    <Link to="/dashboard" className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/60">
                       <LayoutDashboard className="w-4 h-4" /> Dashboard
                     </Link>
-                    <Link to="/api-docs" className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50">
+                    <Link to="/api-docs" className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/60">
                       <Terminal className="w-4 h-4" /> API Docs
                     </Link>
-                    <button onClick={logout} className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-500 hover:bg-red-500/5">
+                    <button onClick={() => { setOpenMenu(null); logout(); }} className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-500 hover:bg-red-500/5">
                       <LogOut className="w-4 h-4" /> Log out
                     </button>
                   </div>
-                </div>
+                )}
               </div>
             ) : (
               <Link
                 to="/signup"
                 className="flex items-center gap-1.5 h-8 px-3 text-xs font-semibold bg-[#FB651E] hover:bg-[#E65C00] text-white transition-colors"
               >
-                <KeyRound className="w-3.5 h-3.5" /> <span className="hidden lg:inline">Get API key</span>
+                <KeyRound className="w-3.5 h-3.5" /> <span className="hidden xl:inline">Get API key</span>
               </Link>
             )}
           </div>


### PR DESCRIPTION
Fixes the reported navbar bugs.

## Dropdowns "overflowed with the background page"
The **More** and **account** menus were **hover-based** and **semi-transparent** (`bg-background/98` + `backdrop-blur`), so page content bled through and clicks didn't open them reliably.
- Now **click-based** with proper open state.
- Close on **outside-click**, **Escape**, and **route change**.
- Panels are **fully opaque** (`bg-background` + shadow + border) — no bleed-through, correct z-index.

## Didn't scale on mobile/tablet
The full horizontal navbar showed from **`md` (768px)** and was too cramped with the new API tab + More + account.
- Desktop navbar now shows only at **`lg`+**.
- Tablets get the **mobile burger** (`MobileBottomNav` `md:hidden` → `lg:hidden`; main padding `md:pt-0` → `lg:pt-0` to keep content clear of the fixed bar).
- Tightened right-action spacing; the logo wordmark and Contact/⌘K labels reveal at `xl`.

Frontend-only; `npm run build` passes.

_Note: I couldn't visually verify (the Chrome extension wasn't connected during this session) — please give it a quick look after deploy; happy to iterate on spacing/behavior._

🤖 Generated with [Claude Code](https://claude.com/claude-code)