### PR TITLE
Add Docker Compose setup for one-command local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,10 @@ FRONTEND_URL=http://localhost:5173
 
 # Shared secret required as a Bearer token on /api/cron/* endpoints.
 CRON_SECRET=generate-a-long-random-string
+
+# =============================================================================
+# Docker Compose
+# =============================================================================
+# DATABASE_URL is set automatically by docker-compose.yml — don't set it here
+# for the Docker workflow. Override other vars by adding them to a .env file.
+VITE_API_BASE_URL=http://backend:8000

--- a/README.md
+++ b/README.md
@@ -83,6 +83,33 @@ The Vite dev server proxies `/api` and `/ws` to `localhost:8000`, so the fronten
 
 **Minimum viable local setup:** leave `DATABASE_URL` unset (falls back to SQLite) and provide just an `OPENAI_API_KEY` for the idea-validator features. Every other integration degrades gracefully if its key is missing — see [`.env.example`](.env.example) for the full list.
 
+---
+
+### 🐳 Docker quick start (alternative)
+
+No Python or Node required - just [Docker](https://docs.docker.com/get-docker/).
+
+```bash
+git clone https://github.com/KonstantinMB/exploreyc.git
+cd exploreyc
+cp .env.example .env   # add OPENAI_API_KEY etc. if you want - DATABASE_URL is set automatically
+docker compose up
+```
+
+| Service  | URL                   |
+|----------|-----------------------|
+| Frontend | http://localhost:5173 |
+| Backend  | http://localhost:8000 |
+| Postgres | localhost:5432        |
+
+On first start `docker/init-db.sh` runs all Postgres-compatible migrations automatically. Data persists in a named volume across restarts; `docker compose down -v` wipes it.
+
+If you add a new migration, append it to `docker/init-db.sh` and run `docker compose down -v && docker compose up`.
+
+> For production deployment see [`DEPLOYMENT.md`](DEPLOYMENT.md).
+
+
+
 ### Seeding local data
 
 The local SQLite database starts empty. To populate it, scrape YC company data from the public Algolia API (no API keys needed):

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,43 @@
+# backend/.dockerignore
+# Excludes files that should not be sent to the Docker build daemon.
+# Keeping the build context small means faster builds and no accidental
+# secrets or host-specific artifacts inside the image.
+
+# Virtual environments — packages are re-installed inside the container
+venv/
+.venv/
+env/
+ENV/
+
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+*.pyo
+.pytest_cache/
+.mypy_cache/
+
+# Local database files
+*.db
+*.sqlite
+*.sqlite3
+
+# Environment / secrets
+.env
+.env.*
+
+# Logs
+*.log
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Git
+.git/
+.gitignore
+
+# OS artefacts
+.DS_Store
+Thumbs.db

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install Chromium and its deps (used by scraper_service and og_image_generator)
+RUN playwright install chromium --with-deps
+
+COPY . .
+
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,67 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: exploreyc
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./supabase/migrations:/migrations:ro
+      - ./docker/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh:ro
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d exploreyc"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/exploreyc
+      DIRECT_DATABASE_URL: postgresql://postgres:postgres@postgres:5432/exploreyc
+      FRONTEND_URL: http://localhost:5173
+      ENV: development
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      PERPLEXITY_API_KEY: ${PERPLEXITY_API_KEY:-}
+      CORESIGNAL_API_KEY: ${CORESIGNAL_API_KEY:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      CRON_SECRET: ${CRON_SECRET:-local-dev-cron-secret}
+      ADMIN_USERNAME: ${ADMIN_USERNAME:-admin}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin}
+      SUPABASE_URL: ${SUPABASE_URL:-}
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:-}
+      SUPABASE_KEY: ${SUPABASE_KEY:-}
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+      - /app/venv
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    depends_on:
+      - backend
+    environment:
+      VITE_API_BASE_URL: http://backend:8000
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+
+volumes:
+  postgres_data:

--- a/docker/init-db.sh
+++ b/docker/init-db.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+MIGRATIONS_DIR="/migrations"
+DB="exploreyc"
+USER="postgres"
+
+run_migration() {
+    local file="$1"
+    echo "Applying: $file"
+    psql -v ON_ERROR_STOP=1 --username "$USER" --dbname "$DB" -f "$MIGRATIONS_DIR/$file"
+}
+
+# Stub auth.role() — used in RLS policies but not available in vanilla Postgres
+psql -v ON_ERROR_STOP=1 --username "$USER" --dbname "$DB" <<'SQL'
+CREATE SCHEMA IF NOT EXISTS auth;
+CREATE OR REPLACE FUNCTION auth.role()
+  RETURNS text LANGUAGE sql STABLE AS $$ SELECT 'authenticated'::text; $$;
+SQL
+
+run_migration "20250315000000_initial_schema.sql"
+run_migration "20250316000000_email_features.sql"
+run_migration "20250321000000_add_hiring_board.sql"
+run_migration "20250322_add_logo_path.sql"
+run_migration "20260316000000_add_idea_validator.sql"
+run_migration "20260322_add_salary_currency.sql"
+# 20260324_add_predictions_sqlite.sql skipped — SQLite-only syntax
+run_migration "20260324_add_predictions_table.sql"
+run_migration "20260327_add_research_cache.sql"
+run_migration "20260706000000_add_company_sources.sql"
+run_migration "20260707000000_add_public_api.sql"
+run_migration "20260707120000_add_api_user_avatar.sql"
+
+echo "All migrations applied."

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,38 @@
+# frontend/.dockerignore
+# Excludes files that should not be sent to the Docker build daemon.
+# Keeping the build context small means faster builds and no accidental
+# secrets or host-specific artefacts inside the image.
+
+# Dependencies — re-installed inside the container via npm ci
+node_modules/
+
+# Build output — not needed for the dev server image
+dist/
+build/
+
+# Environment / secrets
+.env
+.env.*
+!.env.example
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Git
+.git/
+.gitignore
+
+# OS artefacts
+.DS_Store
+Thumbs.db

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,17 +1,20 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const backendUrl = process.env.VITE_API_BASE_URL ?? 'http://localhost:8000'
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: true,
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: backendUrl,
         changeOrigin: true,
       },
       '/ws': {
-        target: 'http://localhost:8000',
+        target: backendUrl,
         ws: true,
       }
     }


### PR DESCRIPTION
Fixes #6

Sets up a full local dev environment with a single command: `docker compose up`
  
 **What's included:**
    - `docker-compose.yml` postgres, backend, frontend wired together
    - `backend/Dockerfile` Python 3.11 slim, uvicorn
    - `frontend/Dockerfile` Node 20 alpine, Vite dev server bound to 0.0.0.0
    - `docker/init-db.sh` runs all Postgres migrations on first start, skips the SQLite-only file
  
One non-obvious thing: the migrations reference `auth.role()` which is Supabase-specific.
Added a stub function so they apply cleanly on vanilla Postgres.
  
Tested: all migrations applied, frontend at :5173, backend at :8000



https://github.com/user-attachments/assets/3aab729f-9260-4a77-ba86-c4ce94781a54

