### PR TITLE
Fix Railway $PORT crash after Docker build switch

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,4 +16,7 @@ RUN playwright install chromium --with-deps
 COPY . .
 
 EXPOSE 8000
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Shell form (via sh -c) so $PORT is expanded when a platform injects it
+# (e.g. Railway); falls back to 8000 for docker-compose / local. `exec`
+# makes uvicorn PID 1 so it receives SIGTERM for graceful shutdown.
+CMD ["sh", "-c", "exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn main:app --host 0.0.0.0 --port $PORT
+web: sh -c "exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"


### PR DESCRIPTION
## Problem

Production backend on Railway is crash-looping:

```
Error: Invalid value for '--port': '$PORT' is not a valid integer.
```

## Root cause

PR #41 ("Add Docker Compose setup") added `backend/Dockerfile`. Railway auto-detected it and switched the backend from a **Nixpacks** build to a **Docker** build.

- Nixpacks ran the `Procfile` start command through a **shell**, so `$PORT` (injected by Railway) expanded.
- In Docker mode, Railway **execs the start command without a shell**, so `uvicorn main:app --host 0.0.0.0 --port $PORT` passed the literal string `$PORT` → uvicorn rejects it → crash loop → API down → site shows UI but no data.

## Fix

Wrap the start command in `sh -c "exec ... ${PORT:-8000}"` in both `backend/Procfile` and the `backend/Dockerfile` CMD:

- `$PORT` is expanded whether the platform uses a shell (Nixpacks/Render) or execs directly (Railway Docker).
- Falls back to `8000` for docker-compose / local dev.
- `exec` keeps uvicorn as PID 1 for graceful SIGTERM shutdown.

Verified expansion locally: `PORT=8080` → `--port 8080`; unset → `--port 8000`.

## Note
If Railway has an explicit **Custom Start Command** set in the dashboard, that overrides both the Procfile and the Docker CMD — in that case clear it (to use the Procfile) or set it to `sh -c "uvicorn main:app --host 0.0.0.0 --port \$PORT"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)