### PR TITLE
Force correct Railway start command via config-as-code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ wheels/
 !frontend/tsconfig*.json
 !vercel.json
 !frontend/vercel.json
+!backend/railway.json
 
 # Environment variables
 .env

--- a/backend/railway.json
+++ b/backend/railway.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "startCommand": "sh -c 'exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}'"
+  }
+}


### PR DESCRIPTION
## Problem

After merging #43 (which fixed `backend/Procfile` and the `backend/Dockerfile` CMD), the Railway backend **still** crash-loops with the same error:

```
Error: Invalid value for '--port': '$PORT' is not a valid integer.
```

## Why #43 wasn't enough

The failing command is byte-for-byte identical to before, even though the repo's Procfile and Docker CMD are now correct on `master`. That means Railway is running a start command that comes from **neither** — a **Custom Start Command configured in the Railway dashboard** (`uvicorn main:app --host 0.0.0.0 --port $PORT`), which overrides both the Procfile and the Docker CMD. Railway execs it without a shell, so `$PORT` stays literal.

## Fix

Per Railway's docs, **config-as-code overrides the dashboard**:
- [Config as Code reference](https://docs.railway.com/config-as-code/reference)
- [Set a Start Command](https://docs.railway.com/guides/start-command)

Adds `backend/railway.json`:

```json
{
  "$schema": "https://railway.com/railway.schema.json",
  "deploy": {
    "startCommand": "sh -c 'exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}'"
  }
}
```

Railway lexes this to `['sh','-c','exec uvicorn … --port ${PORT:-8000}']` and execs it; `sh` expands `$PORT` (→ injected port on Railway, → `8000` for local/compose). `exec` keeps uvicorn as PID 1 for graceful shutdown. Verified locally by simulating Railway's shlex→exec: `PORT=8080` → `--port 8080`; unset → `--port 8000`.

Also whitelists `backend/railway.json` in `.gitignore` (which otherwise ignores all `*.json`).

> Assumes the Railway service's **Root Directory is `backend/`** (where the Procfile/Dockerfile already live). If it's the repo root, move this file to the repo root.

## Alternative (no code change)
Clear the **Custom Start Command** in Railway → Service → Settings → Deploy → it then falls back to the (now-fixed) Docker CMD from #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)