### PR TITLE
Fix daily digest emails silently sending 0 (undefined render_section)

### DIFF
--- a/backend/email_service.py
+++ b/backend/email_service.py
@@ -410,8 +410,6 @@ class EmailService:
 
         sections = []
 
-        # Stats banner — a compact one-line summary right under the header.
-        stats_parts = []
         if new_companies:
             cards = "\n".join(self._render_company_card(c) for c in new_companies[:20])
             sections.append(self._render_section(
@@ -426,11 +424,6 @@ class EmailService:
                 cards,
             ))
 
-        sections = []
-        if new_companies:
-            sections.append(render_section("🆕", len(new_companies), "New Companies", new_companies[:20], new_accent))
-        if newly_hiring:
-            sections.append(render_section("💼", len(newly_hiring), "Now Hiring", newly_hiring[:20], hiring_accent))
         if batch_changes:
             cards = "\n".join(self._render_batch_change_card(c) for c in batch_changes[:10])
             sections.append(self._render_section(

--- a/test_digest_render.py
+++ b/test_digest_render.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Unit test for the daily digest HTML renderer.
+
+Regression guard for the bug where `_render_daily_digest` referenced an
+undefined bare `render_section(...)` (instead of `self._render_section`),
+raising NameError. Because `send_daily_digest` swallows render exceptions and
+returns False, every scheduled digest silently sent 0 emails for weeks.
+
+Run: python -m pytest test_digest_render.py   (or: python test_digest_render.py)
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "backend"))
+
+from email_service import EmailService  # noqa: E402
+
+
+def _service():
+    svc = EmailService()
+    # __init__ returns early (and skips these) when RESEND_API_KEY is unset;
+    # set them directly so we can exercise pure rendering without credentials.
+    svc.from_email = "ExploreYC <digest@exploreyc.com>"
+    svc.frontend_url = "https://exploreyc.com"
+    return svc
+
+
+NEW_COMPANIES = [
+    {
+        "id": 1,
+        "name": "Litmus",
+        "batch": "Summer 2026",
+        "one_liner": "Run an async work trial on every engineer you interview.",
+        "website": "https://litmushiring.com/",
+        "slug": "litmus-build",
+        "logo": "",
+    }
+]
+
+NEWLY_HIRING = [
+    {
+        "id": 2,
+        "name": "Soren",
+        "batch": "Fall 2025",
+        "one_liner": "AI Transformation for Regulated Institutions",
+        "website": "https://usesoren.com",
+        "slug": "soren",
+        "logo": "",
+        "is_hiring": True,
+    }
+]
+
+BATCH_CHANGES = [
+    {"id": 3, "name": "Acme", "old_batch": "Winter 2025", "new_batch": "Summer 2026", "slug": "acme"}
+]
+
+
+def test_render_daily_digest_does_not_raise():
+    """The renderer must produce HTML for real change data without raising."""
+    svc = _service()
+    html = svc._render_daily_digest(
+        new_companies=NEW_COMPANIES,
+        newly_hiring=NEWLY_HIRING,
+        batch_changes=BATCH_CHANGES,
+        unsubscribe_link="https://exploreyc.com/unsubscribe?token=abc",
+    )
+    assert isinstance(html, str) and html
+    # Each section's data must actually appear in the output.
+    assert "Litmus" in html
+    assert "Soren" in html
+    assert "new companies (1)" in html
+    assert "now hiring (1)" in html
+    assert "batch updates (1)" in html
+
+
+if __name__ == "__main__":
+    test_render_daily_digest_does_not_raise()
+    print("PASS: digest renders without error")


### PR DESCRIPTION
## Problem

Scheduled **daily digest emails have silently sent 0 emails for ~5 weeks**, despite having changes to report and 24 verified subscribers.

## Root cause

`_render_daily_digest()` in `backend/email_service.py` had a leftover botched-refactor block. After correctly building `sections` with `self._render_section(...)`, it reset `sections = []` and rebuilt them by calling a **bare, undefined `render_section(...)`** with undefined `new_accent`/`hiring_accent` variables:

```python
sections = []
if new_companies:
    sections.append(render_section("🆕", ..., new_accent))  # NameError
```

Every digest render raised `NameError: name 'render_section' is not defined`. `send_daily_digest()` wraps rendering in `try/except` and returns `False` on any exception, so **all sends failed before ever reaching Resend** — `emails_sent` was `0` on every run. Verification/confirmation emails use different render functions and were unaffected.

Introduced in the `7eb1740` template redesign; the `6f782a7` refactor added the correct block above but never removed the broken duplicate.

## Why it went unnoticed

The GitHub Actions cron `curl` has no `--fail` flag, so the job stayed green even though the endpoint returned `{"emails_sent":0}`.

## Evidence

- Live `/api/admin/change-log-status` → `subscriber_count: 24`, changes present.
- Digest run responses → `{"success":true,"emails_sent":0,"changes":{"new_companies":6,"newly_hiring":4}}`.
- `/api/admin/digest-preview?format=html` → **HTTP 500: `name 'render_section' is not defined`** (JSON format worked).

## Fix

Remove the duplicate broken block (and dead `stats_parts` leftover), keeping the correct `self._render_section` path for new / hiring / batch sections. Add `test_digest_render.py` as a regression guard.

- Before: `NameError: name 'render_section' is not defined`
- After: renders full HTML with all sections ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)