### PR TITLE
Add feature-interest capture for the paused DB export

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -278,6 +278,19 @@ class Database:
                 )
             ''')
 
+            # Interest in currently-unavailable features (e.g. data export).
+            # Deduped per (feature, user_identifier) so one browser counts once.
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS feature_requests (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    feature TEXT NOT NULL,
+                    user_identifier TEXT,
+                    email TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE (feature, user_identifier)
+                )
+            ''')
+
             # Bring existing databases up to the multi-source schema before indexing
             self._migrate_schema(cursor)
 
@@ -589,6 +602,42 @@ class Database:
                 json.dumps(company)
             ))
             return cursor.lastrowid
+
+    def record_feature_interest(self, feature: str, user_identifier: Optional[str] = None,
+                                email: Optional[str] = None) -> Dict:
+        """Record interest in a currently-unavailable feature.
+
+        Deduped per (feature, user_identifier). Returns {"created": bool, "count": int}.
+        """
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                '''INSERT OR IGNORE INTO feature_requests (feature, user_identifier, email)
+                   VALUES (?, ?, ?)''',
+                (feature, user_identifier, email),
+            )
+            created = cursor.rowcount > 0
+            # Keep the email fresh if the same browser re-submits with one
+            if not created and email is not None and user_identifier is not None:
+                cursor.execute(
+                    '''UPDATE feature_requests SET email = ?
+                       WHERE feature = ? AND user_identifier = ?''',
+                    (email, feature, user_identifier),
+                )
+            cursor.execute(
+                'SELECT COUNT(*) FROM feature_requests WHERE feature = ?', (feature,)
+            )
+            count = cursor.fetchone()[0]
+            return {"created": created, "count": count}
+
+    def get_feature_interest_count(self, feature: str) -> int:
+        """Return the number of distinct interest registrations for a feature."""
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                'SELECT COUNT(*) FROM feature_requests WHERE feature = ?', (feature,)
+            )
+            return cursor.fetchone()[0] or 0
 
     def get_companies(self,
                      limit: int = 100,

--- a/backend/database_postgres.py
+++ b/backend/database_postgres.py
@@ -754,6 +754,57 @@ class DatabasePostgres:
                 )
                 return cur.fetchone() is not None
 
+    # ========== FEATURE INTEREST METHODS ==========
+
+    def record_feature_interest(self, feature: str, user_identifier: Optional[str] = None,
+                                email: Optional[str] = None) -> Dict:
+        """Record interest in a currently-unavailable feature.
+
+        Deduped per (feature, user_identifier). Returns {"created": bool, "count": int}.
+        The CREATE TABLE is defensive so the endpoint works even if the Supabase
+        migration hasn't been applied yet (idempotent, cheap).
+        """
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS feature_requests (
+                        id BIGSERIAL PRIMARY KEY,
+                        feature TEXT NOT NULL,
+                        user_identifier TEXT,
+                        email TEXT,
+                        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                        UNIQUE (feature, user_identifier)
+                    )
+                    """
+                )
+                cur.execute(
+                    """
+                    INSERT INTO feature_requests (feature, user_identifier, email)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (feature, user_identifier)
+                    DO UPDATE SET email = COALESCE(EXCLUDED.email, feature_requests.email)
+                    RETURNING (xmax = 0) AS inserted
+                    """,
+                    (feature, user_identifier, email),
+                )
+                row = cur.fetchone()
+                created = bool(row[0]) if row else False
+                cur.execute(
+                    "SELECT COUNT(*) FROM feature_requests WHERE feature = %s", (feature,)
+                )
+                count = cur.fetchone()[0]
+                return {"created": created, "count": count}
+
+    def get_feature_interest_count(self, feature: str) -> int:
+        """Return the number of distinct interest registrations for a feature."""
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT COUNT(*) FROM feature_requests WHERE feature = %s", (feature,)
+                )
+                return cur.fetchone()[0] or 0
+
     # ========== STARTUP IDEA VALIDATOR METHODS ==========
 
     def get_yc_company_count(self) -> int:

--- a/backend/main.py
+++ b/backend/main.py
@@ -695,88 +695,22 @@ async def get_countries():
     return {"countries": countries}
 
 
+# Data export (CSV/JSON) is currently disabled. The endpoints are kept so direct
+# callers get a clear 503 instead of a 404. Users can register interest for the
+# feature via POST /api/feature-interest (see below).
+_EXPORT_DISABLED_DETAIL = "Data export is temporarily unavailable."
+
+
 @app.get("/api/export/json")
-async def export_json(
-    batch: Optional[str] = None,
-    is_hiring: Optional[bool] = None,
-    industry: Optional[str] = None,
-    country: Optional[str] = None,
-    search: Optional[str] = None,
-    top_company: Optional[bool] = None,
-    source: Optional[str] = None,
-):
-    """Export companies to JSON"""
-    companies = company_cache.get_companies(
-        limit=10000,
-        batch=batch,
-        is_hiring=is_hiring,
-        industry=industry,
-        country=country,
-        search=search,
-        top_company=top_company,
-        source=source,
-    )
-
-    # Create JSON file
-    json_str = json.dumps(companies, indent=2, default=str)
-
-    return StreamingResponse(
-        io.BytesIO(json_str.encode()),
-        media_type="application/json",
-        headers={
-            "Content-Disposition": f"attachment; filename=yc_companies_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
-        }
-    )
+async def export_json():
+    """Disabled — data export is temporarily unavailable."""
+    raise HTTPException(status_code=503, detail=_EXPORT_DISABLED_DETAIL)
 
 
 @app.get("/api/export/csv")
-async def export_csv(
-    batch: Optional[str] = None,
-    is_hiring: Optional[bool] = None,
-    industry: Optional[str] = None,
-    country: Optional[str] = None,
-    search: Optional[str] = None,
-    top_company: Optional[bool] = None,
-    source: Optional[str] = None,
-):
-    """Export companies to CSV"""
-    companies = company_cache.get_companies(
-        limit=10000,
-        batch=batch,
-        is_hiring=is_hiring,
-        industry=industry,
-        country=country,
-        search=search,
-        top_company=top_company,
-        source=source,
-    )
-
-    if not companies:
-        raise HTTPException(status_code=404, detail="No companies found")
-
-    # Create CSV
-    output = io.StringIO()
-
-    # Get fieldnames from first company (exclude raw_json)
-    fieldnames = [k for k in companies[0].keys() if k != 'raw_json']
-
-    writer = csv.DictWriter(output, fieldnames=fieldnames)
-    writer.writeheader()
-
-    for company in companies:
-        # Remove raw_json field
-        company_data = {k: v for k, v in company.items() if k != 'raw_json'}
-        writer.writerow(company_data)
-
-    csv_str = output.getvalue()
-
-    return StreamingResponse(
-        io.BytesIO(csv_str.encode()),
-        media_type="text/csv",
-        headers={
-            "Content-Disposition": f"attachment; filename=yc_companies_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"
-        }
-    )
+async def export_csv():
+    """Disabled — data export is temporarily unavailable."""
+    raise HTTPException(status_code=503, detail=_EXPORT_DISABLED_DETAIL)
 
 
 @app.websocket("/ws/scrape")
@@ -1688,6 +1622,38 @@ async def get_user_votes(user_identifier: str):
     except Exception as e:
         logger.error(f"Get user votes error: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+class FeatureInterestRequest(BaseModel):
+    feature: str = "db-export"          # which paused feature the interest is for
+    email: Optional[str] = None         # optional — for "notify me when it's back"
+    user_identifier: Optional[str] = None  # stable per-browser id to dedupe clicks
+
+
+@app.post("/api/feature-interest")
+async def register_feature_interest(request: FeatureInterestRequest):
+    """Record that a user wants a currently-unavailable feature (e.g. data export).
+
+    Deduplicated per (feature, user_identifier) so one browser counts once.
+    Returns the running interest count so the UI can show demand.
+    """
+    feature = (request.feature or "").strip() or "db-export"
+    email = (request.email or "").strip() or None
+    try:
+        result = db.record_feature_interest(
+            feature=feature,
+            user_identifier=(request.user_identifier or "").strip() or None,
+            email=email,
+        )
+        return {
+            "success": True,
+            "feature": feature,
+            "already_registered": not result["created"],
+            "count": result["count"],
+        }
+    except Exception as e:
+        logger.error(f"Feature interest error: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 # ============================================================================

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -241,32 +241,12 @@ export const apiClient = {
   getIndustries: () => api.get<{ industries: string[] }>('/api/filters/industries'),
   getCountries: () => api.get<{ countries: string[] }>('/api/filters/countries'),
 
-  // Export
-  exportJSON: (filters: Partial<CompanyFilter>) => {
-    const params = new URLSearchParams()
-    if (filters.batch) params.append('batch', filters.batch)
-    if (filters.is_hiring !== undefined) params.append('is_hiring', String(filters.is_hiring))
-    if (filters.industry) params.append('industry', filters.industry)
-    if (filters.country) params.append('country', filters.country)
-    if (filters.search) params.append('search', filters.search)
-    if (filters.top_company !== undefined) params.append('top_company', String(filters.top_company))
-    if (filters.source) params.append('source', filters.source)
-
-    window.open(`${API_BASE_URL}/api/export/json?${params.toString()}`, '_blank')
-  },
-
-  exportCSV: (filters: Partial<CompanyFilter>) => {
-    const params = new URLSearchParams()
-    if (filters.batch) params.append('batch', filters.batch)
-    if (filters.is_hiring !== undefined) params.append('is_hiring', String(filters.is_hiring))
-    if (filters.industry) params.append('industry', filters.industry)
-    if (filters.country) params.append('country', filters.country)
-    if (filters.search) params.append('search', filters.search)
-    if (filters.top_company !== undefined) params.append('top_company', String(filters.top_company))
-    if (filters.source) params.append('source', filters.source)
-
-    window.open(`${API_BASE_URL}/api/export/csv?${params.toString()}`, '_blank')
-  },
+  // Feature interest — data export is currently unavailable; users register demand here.
+  submitFeatureInterest: (payload: { feature?: string; email?: string; user_identifier?: string }) =>
+    api.post<{ success: boolean; feature: string; already_registered: boolean; count: number }>(
+      '/api/feature-interest',
+      payload,
+    ),
 
   // Startup Idea Validator
   validateIdea: (idea: string, maxSimilar: number = 10) =>

--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { Helmet } from 'react-helmet-async';
 import { useQuery } from '@tanstack/react-query';
@@ -28,13 +28,11 @@ import {
   TrendingUp,
   Layers,
   CheckCircle2,
-  Github,
-  FileJson,
-  FileText,
   Filter,
   SlidersHorizontal,
-  Lock,
   Loader2,
+  Send,
+  Mail,
 } from 'lucide-react';
 import { apiClient, type Company, type CompanyFilter } from '../lib/api';
 import { SourceBadge, sourceLabel } from '../components/ui/SourceBadge';
@@ -58,9 +56,6 @@ const mobileHiddenColumns = new Set([
   'nonprofit', 'funding_last_round_name', 'employee_count',
   'employee_growth_6m', 'website', 'founders', 'exit', 'year_founded',
 ]);
-
-const GITHUB_REPO = 'konstantinmb/exploreyc';
-const GITHUB_URL = `https://github.com/${GITHUB_REPO}`;
 
 function formatFunding(v?: number | null): string {
   if (!v) return '—';
@@ -406,103 +401,57 @@ function getColumns(source: string): ColumnDef<Company, any>[] {
   return columns;
 }
 
-const LS_KEY = 'yc_gh_star_verified';
-const POLL_INTERVAL_MS = 5000;
-const POLL_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const FEATURE_KEY = 'db-export';
+const FEATURE_INTEREST_LS_KEY = 'yc_feature_interest_db-export';
 
-async function fetchStarCount(): Promise<number> {
-  const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}`, {
-    headers: { Accept: 'application/vnd.github.v3+json' },
-  });
-  if (!res.ok) throw new Error('GitHub API error');
-  const data = await res.json();
-  return data.stargazers_count as number;
+// Stable per-browser id so one browser's interest counts once (shared with roadmap votes).
+function getClientId(): string {
+  let id = localStorage.getItem('roadmap-user-id');
+  if (!id) {
+    id = `user-${Math.random().toString(36).slice(2, 11)}`;
+    localStorage.setItem('roadmap-user-id', id);
+  }
+  return id;
 }
 
-function ExportModal({
+// Data export is currently paused. Instead of downloading, users register interest
+// ("I want this feature") which is persisted server-side so we can measure demand.
+function FeatureInterestModal({
   open,
   onClose,
-  filters,
 }: {
   open: boolean;
   onClose: () => void;
-  filters: CompanyFilter;
 }) {
-  const [baselineCount, setBaselineCount] = useState<number | null>(null);
-  const [liveCount, setLiveCount] = useState<number | null>(null);
-  const [isPolling, setIsPolling] = useState(false);
-  const [starVerified, setStarVerified] = useState(false);
-  const [pollFailed, setPollFailed] = useState(false);
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'done' | 'error'>('idle');
+  const [count, setCount] = useState<number | null>(null);
 
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const stopPolling = useCallback(() => {
-    if (intervalRef.current) { clearInterval(intervalRef.current); intervalRef.current = null; }
-    if (timeoutRef.current) { clearTimeout(timeoutRef.current); timeoutRef.current = null; }
-  }, []);
-
-  // On modal open: check localStorage, fetch baseline count
+  // If this browser already registered interest, show the thank-you state on open.
   useEffect(() => {
     if (!open) return;
-    if (localStorage.getItem(LS_KEY) === 'true') {
-      setStarVerified(true);
-      return;
+    if (localStorage.getItem(FEATURE_INTEREST_LS_KEY) === 'true') {
+      setStatus('done');
     }
-    fetchStarCount()
-      .then((count) => { setBaselineCount(count); setLiveCount(count); })
-      .catch(() => { /* non-fatal: gate stays locked */ });
   }, [open]);
 
-  // Start polling when user clicks the star button
-  useEffect(() => {
-    if (!isPolling || starVerified) return;
-
-    intervalRef.current = setInterval(async () => {
-      try {
-        const count = await fetchStarCount();
-        setLiveCount(count);
-        if (baselineCount !== null && count > baselineCount) {
-          setStarVerified(true);
-          localStorage.setItem(LS_KEY, 'true');
-          stopPolling();
-        }
-      } catch {
-        // keep polling silently on transient errors
-      }
-    }, POLL_INTERVAL_MS);
-
-    timeoutRef.current = setTimeout(() => {
-      stopPolling();
-      setIsPolling(false);
-      setPollFailed(true);
-    }, POLL_TIMEOUT_MS);
-
-    return stopPolling;
-  }, [isPolling, starVerified, baselineCount, stopPolling]);
-
-  // Clean up on modal close
-  useEffect(() => {
-    if (!open) {
-      stopPolling();
-      setIsPolling(false);
-      setPollFailed(false);
+  const handleSubmit = async () => {
+    setStatus('submitting');
+    try {
+      const { data } = await apiClient.submitFeatureInterest({
+        feature: FEATURE_KEY,
+        email: email.trim() || undefined,
+        user_identifier: getClientId(),
+      });
+      setCount(data.count ?? null);
+      localStorage.setItem(FEATURE_INTEREST_LS_KEY, 'true');
+      setStatus('done');
+    } catch {
+      setStatus('error');
     }
-  }, [open, stopPolling]);
-
-  const handleStarClick = () => {
-    window.open(GITHUB_URL, '_blank', 'noopener,noreferrer');
-    setIsPolling(true);
-    setPollFailed(false);
   };
 
-  const handleDownload = (type: 'csv' | 'json') => {
-    if (!starVerified) return;
-    if (type === 'csv') apiClient.exportCSV(filters);
-    else apiClient.exportJSON(filters);
-  };
-
-  const displayCount = liveCount ?? baselineCount;
+  const done = status === 'done';
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
@@ -510,153 +459,76 @@ function ExportModal({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-base">
             <Download className="w-4 h-4 text-[#FB651E]" />
-            Export YC Company Data
+            Data export
           </DialogTitle>
           <DialogDescription className="text-xs text-muted-foreground mt-1">
-            This is an open-source project. Export is free — all we ask is a GitHub star to help others discover it.
+            Export is paused while we rebuild it. Want it back? Let us know and we'll
+            prioritise it.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 pt-2">
-          {/* GitHub star section */}
-          <HackerCard glowColor={starVerified ? 'green' : 'orange'} className="p-4">
-            <div className="flex items-center justify-between mb-3">
+          {done ? (
+            <HackerCard glowColor="green" className="p-4">
               <div className="flex items-center gap-2">
-                <Github className="w-4 h-4 text-foreground" />
-                <span className="text-sm font-semibold">exploreyc</span>
-              </div>
-              {displayCount !== null && (
-                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                  <Star className="w-3.5 h-3.5 text-yellow-500 fill-yellow-500" />
-                  <span className="font-mono tabular-nums">{displayCount.toLocaleString()}</span>
-                </div>
-              )}
-            </div>
-
-            {starVerified ? (
-              <div className="flex items-center gap-2 px-4 py-2.5 bg-emerald-500/10 border border-emerald-500/30 rounded-sm">
                 <CheckCircle2 className="w-4 h-4 text-emerald-500 flex-shrink-0" />
-                <span className="text-sm text-emerald-500 font-semibold">Star confirmed — thank you!</span>
+                <span className="text-sm text-emerald-500 font-semibold">
+                  Thanks — we've noted your interest!
+                </span>
               </div>
-            ) : (
-              <>
-                <p className="text-xs text-muted-foreground mb-3 leading-relaxed">
-                  ExploreYC is open source. Star the repo to unlock the download — it helps more founders discover the tool.
+              {count !== null && (
+                <p className="text-xs text-muted-foreground mt-2">
+                  You're one of{' '}
+                  <span className="text-foreground font-semibold tabular-nums">
+                    {count.toLocaleString()}
+                  </span>{' '}
+                  {count === 1 ? 'person' : 'people'} who want this feature back.
                 </p>
-                <button
-                  onClick={handleStarClick}
-                  disabled={isPolling}
-                  className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-[#FB651E] hover:bg-[#E65C00] disabled:opacity-70 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors rounded-sm"
-                >
-                  <Star className="w-4 h-4 fill-white" />
-                  {isPolling ? 'Waiting for your star…' : 'Star on GitHub'}
-                </button>
+              )}
+            </HackerCard>
+          ) : (
+            <HackerCard glowColor="orange" className="p-4">
+              <p className="text-xs text-muted-foreground mb-3 leading-relaxed">
+                Click below to tell us you want CSV / JSON export. Leave an email if you'd
+                like us to notify you when it's back — totally optional.
+              </p>
 
-                {/* Polling status */}
-                {isPolling && !pollFailed && (
-                  <div className="flex items-center gap-2 mt-2 text-xs text-muted-foreground">
-                    <Loader2 className="w-3.5 h-3.5 animate-spin flex-shrink-0" />
-                    <span>Checking for your star every 5 s…</span>
-                  </div>
+              <div className="flex items-center gap-2 mb-3 px-3 py-2 border border-border rounded-sm bg-background/50 focus-within:border-[#FB651E]/50 transition-colors">
+                <Mail className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@example.com (optional)"
+                  className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground/60"
+                />
+              </div>
+
+              <button
+                onClick={handleSubmit}
+                disabled={status === 'submitting'}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-[#FB651E] hover:bg-[#E65C00] disabled:opacity-70 disabled:cursor-not-allowed text-white text-sm font-semibold transition-colors rounded-sm"
+              >
+                {status === 'submitting' ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Sending…
+                  </>
+                ) : (
+                  <>
+                    <Send className="w-4 h-4" />
+                    I want this feature
+                  </>
                 )}
+              </button>
 
-                {/* Timeout fallback */}
-                {pollFailed && (
-                  <div className="mt-2 text-xs text-muted-foreground leading-relaxed">
-                    Couldn't detect your star automatically.{' '}
-                    <a
-                      href={GITHUB_URL}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-[#FB651E] hover:underline"
-                    >
-                      Verify on GitHub
-                    </a>
-                    {' '}then{' '}
-                    <button
-                      className="text-[#FB651E] hover:underline"
-                      onClick={() => {
-                        setPollFailed(false);
-                        setIsPolling(true);
-                      }}
-                    >
-                      try again
-                    </button>
-                    .
-                  </div>
-                )}
-              </>
-            )}
-          </HackerCard>
-
-          {/* Divider */}
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-border" />
-            </div>
-            <div className="relative flex justify-center">
-              <span className="bg-background px-3 text-xs text-muted-foreground">
-                {starVerified ? 'Download your data' : 'Star to unlock download'}
-              </span>
-            </div>
-          </div>
-
-          {/* Active filters summary */}
-          {(filters.batch || filters.industry || filters.country || filters.search || filters.is_hiring || filters.top_company) && (
-            <div className="text-xs text-muted-foreground bg-muted/50 px-3 py-2 rounded-sm border border-border">
-              <span className="text-foreground font-medium">Exporting filtered data:</span>{' '}
-              {[
-                filters.search && `search="${filters.search}"`,
-                filters.batch && `batch=${filters.batch}`,
-                filters.industry && `industry=${filters.industry}`,
-                filters.country && `country=${filters.country}`,
-                filters.is_hiring && 'hiring=true',
-                filters.top_company && 'top_company=true',
-              ]
-                .filter(Boolean)
-                .join(', ')}
-            </div>
+              {status === 'error' && (
+                <p className="text-xs text-red-500 mt-2">
+                  Something went wrong — please try again.
+                </p>
+              )}
+            </HackerCard>
           )}
-
-          {/* Download buttons — locked until star verified */}
-          <div className="grid grid-cols-2 gap-3">
-            <button
-              onClick={() => handleDownload('csv')}
-              disabled={!starVerified}
-              className={`flex items-center justify-center gap-2 px-4 py-3 border rounded-sm text-sm font-medium transition-colors group ${
-                starVerified
-                  ? 'border-border hover:border-emerald-500/50 hover:bg-emerald-500/5 cursor-pointer'
-                  : 'border-border opacity-40 cursor-not-allowed'
-              }`}
-            >
-              {starVerified ? (
-                <FileText className="w-4 h-4 text-emerald-500" />
-              ) : (
-                <Lock className="w-4 h-4 text-muted-foreground" />
-              )}
-              <span className={starVerified ? 'group-hover:text-emerald-500 transition-colors' : ''}>CSV</span>
-            </button>
-            <button
-              onClick={() => handleDownload('json')}
-              disabled={!starVerified}
-              className={`flex items-center justify-center gap-2 px-4 py-3 border rounded-sm text-sm font-medium transition-colors group ${
-                starVerified
-                  ? 'border-border hover:border-blue-500/50 hover:bg-blue-500/5 cursor-pointer'
-                  : 'border-border opacity-40 cursor-not-allowed'
-              }`}
-            >
-              {starVerified ? (
-                <FileJson className="w-4 h-4 text-blue-500" />
-              ) : (
-                <Lock className="w-4 h-4 text-muted-foreground" />
-              )}
-              <span className={starVerified ? 'group-hover:text-blue-500 transition-colors' : ''}>JSON</span>
-            </button>
-          </div>
-
-          <p className="text-[10px] text-muted-foreground/60 text-center">
-            Export respects your active filters · Up to 10,000 companies
-          </p>
         </div>
       </DialogContent>
     </Dialog>
@@ -724,20 +596,6 @@ export function DatabasePage() {
       ...(source !== 'yc' && { source }),
     }),
     [currentPage, debouncedSearch, batch, industry, country, isHiring, topOnly, source],
-  );
-
-  // Export filters (without pagination)
-  const exportFilters: CompanyFilter = useMemo(
-    () => ({
-      ...(debouncedSearch && { search: debouncedSearch }),
-      ...(batch && { batch }),
-      ...(industry && { industry }),
-      ...(country && { country }),
-      ...(isHiring && { is_hiring: true }),
-      ...(topOnly && { top_company: true }),
-      ...(source !== 'yc' && { source }),
-    }),
-    [debouncedSearch, batch, industry, country, isHiring, topOnly, source],
   );
 
   const { data, isLoading, isFetching } = useQuery({
@@ -833,7 +691,7 @@ export function DatabasePage() {
                 className="flex items-center gap-2 px-4 py-2.5 bg-[#FB651E] hover:bg-[#E65C00] text-white text-sm font-semibold font-mono transition-colors rounded-sm flex-shrink-0"
               >
                 <Download className="w-4 h-4" />
-                Export Data
+                I want export
               </button>
             }
           />
@@ -1155,23 +1013,20 @@ export function DatabasePage() {
           className="mt-6 text-center"
         >
           <p className="text-xs text-muted-foreground font-mono">
-            Want the full dataset?{' '}
+            Data export (CSV / JSON) is paused while we rebuild it.{' '}
             <button
               onClick={() => setExportOpen(true)}
               className="text-[#FB651E] hover:underline"
             >
-              Export as CSV or JSON
+              I want this feature
             </button>
-            {' '}— just star us on GitHub first{' '}
-            <Star className="w-3 h-3 inline-block text-yellow-500 fill-yellow-500" />
           </p>
         </motion.div>
       </div>
 
-      <ExportModal
+      <FeatureInterestModal
         open={exportOpen}
         onClose={() => setExportOpen(false)}
-        filters={exportFilters}
       />
     </div>
   );

--- a/supabase/migrations/20260709000000_add_feature_requests.sql
+++ b/supabase/migrations/20260709000000_add_feature_requests.sql
@@ -1,0 +1,15 @@
+-- Feature interest: records when a user clicks "I want this feature" for a
+-- currently-unavailable feature (e.g. the paused data export). Deduped per
+-- (feature, user_identifier) so one browser counts once. Optional email lets us
+-- notify people when the feature ships.
+
+CREATE TABLE IF NOT EXISTS feature_requests (
+    id BIGSERIAL PRIMARY KEY,
+    feature TEXT NOT NULL,                 -- e.g. 'db-export'
+    user_identifier TEXT,                  -- stable per-browser id from the client
+    email TEXT,                            -- optional 'notify me when it's back'
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (feature, user_identifier)
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_requests_feature ON feature_requests(feature);


### PR DESCRIPTION
## What

Replaces the (currently disabled) CSV/JSON data-export on the Database page with a lightweight **"I want this feature"** interest-capture flow, so we can measure demand before rebuilding export.

- **New `feature_requests` table** — deduped per `(feature, user_identifier)` so one browser counts once; optional `email` for "notify me when it's back". Migration: `supabase/migrations/20260709000000_add_feature_requests.sql`.
- **Backend** — `POST /api/feature-interest` records interest and returns the running count; `record_feature_interest()` added to both the SQLite (`database.py`) and Postgres (`database_postgres.py`) layers. The old `/api/export/{json,csv}` endpoints now return a clear **503** instead of 404 so direct callers get a sensible signal.
- **Frontend** — `DatabasePage.tsx` swaps the old export UI for the one-click interest flow; `api.ts` updated to match.

## Notes

- Branched off current `master` and rebased so it layers **on top of** #45 and #46 — no merged work is reverted (verified `hero_service`/#46 intact).
- Verified: backend files compile, frontend type-checks clean, migration is valid SQL. No in-tree test suite exists to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)