### PR TITLE
Hero redesign (centered agentic search) + resilient answer cache

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1046,10 +1046,17 @@ async def hero_answer(req: HeroAnswerRequest, request: Request):
 
     key = hashlib.sha1(idea.lower().encode()).hexdigest()
 
-    # Return cached result if available
-    cached = db.get_idea_answer_cache(key) if hasattr(db, "get_idea_answer_cache") else None
-    if cached:
-        return {**cached, "cached": True}
+    # Return cached result if available. Cache read is non-fatal: if the
+    # idea_answer_cache table doesn't exist yet (migration not applied), or any
+    # transient DB issue occurs, degrade to computing a fresh answer rather than
+    # 500-ing the search.
+    if hasattr(db, "get_idea_answer_cache"):
+        try:
+            cached = db.get_idea_answer_cache(key)
+            if cached:
+                return {**cached, "cached": True}
+        except Exception as e:
+            logger.warning(f"hero cache read failed (non-fatal): {e}")
 
     # Guard: require embeddings to be present
     if not hasattr(db, "count_companies_with_embeddings"):

--- a/frontend/src/components/HeroAnswerBox.tsx
+++ b/frontend/src/components/HeroAnswerBox.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Search, ArrowRight } from 'lucide-react'
+import { Sparkles, ArrowRight, CornerDownLeft, Loader2, TrendingUp } from 'lucide-react'
 import { apiClient, type HeroAnswer } from '../lib/api'
 
 const EXAMPLES = [
@@ -11,11 +11,81 @@ const EXAMPLES = [
   'AI agents for customer support',
 ]
 
-const METER: Record<HeroAnswer['meter'], { label: string; cls: string }> = {
-  open: { label: 'OPEN FIELD', cls: 'text-emerald-500 border-emerald-500/40' },
-  emerging: { label: 'EMERGING', cls: 'text-[#FB651E] border-[#FB651E]/40' },
-  competitive: { label: 'COMPETITIVE', cls: 'text-amber-500 border-amber-500/40' },
-  crowded: { label: 'CROWDED', cls: 'text-red-500 border-red-500/40' },
+const METER: Record<
+  HeroAnswer['meter'],
+  { label: string; text: string; ring: string; glow: string; dot: string }
+> = {
+  open: {
+    label: 'OPEN FIELD',
+    text: 'text-emerald-500',
+    ring: 'border-emerald-500/40',
+    glow: 'shadow-[0_0_18px_-2px_rgba(16,185,129,0.5)]',
+    dot: 'bg-emerald-500',
+  },
+  emerging: {
+    label: 'EMERGING',
+    text: 'text-[#FB651E]',
+    ring: 'border-[#FB651E]/40',
+    glow: 'shadow-[0_0_18px_-2px_rgba(251,101,30,0.5)]',
+    dot: 'bg-[#FB651E]',
+  },
+  competitive: {
+    label: 'COMPETITIVE',
+    text: 'text-amber-500',
+    ring: 'border-amber-500/40',
+    glow: 'shadow-[0_0_18px_-2px_rgba(245,158,11,0.5)]',
+    dot: 'bg-amber-500',
+  },
+  crowded: {
+    label: 'CROWDED',
+    text: 'text-red-500',
+    ring: 'border-red-500/40',
+    glow: 'shadow-[0_0_18px_-2px_rgba(239,68,68,0.5)]',
+    dot: 'bg-red-500',
+  },
+}
+
+/** Typewriter that cycles the example prompts as the placeholder. */
+function useTypewriter(words: string[]) {
+  const [text, setText] = useState('')
+  useEffect(() => {
+    let mounted = true
+    let wordIdx = 0
+    let charIdx = 0
+    let deleting = false
+    let timer: ReturnType<typeof setTimeout>
+
+    const tick = () => {
+      if (!mounted) return
+      const word = words[wordIdx]
+      if (!deleting) {
+        charIdx++
+        setText(word.slice(0, charIdx))
+        if (charIdx === word.length) {
+          deleting = true
+          timer = setTimeout(tick, 1900)
+          return
+        }
+        timer = setTimeout(tick, 45)
+      } else {
+        charIdx--
+        setText(word.slice(0, charIdx))
+        if (charIdx === 0) {
+          deleting = false
+          wordIdx = (wordIdx + 1) % words.length
+          timer = setTimeout(tick, 350)
+          return
+        }
+        timer = setTimeout(tick, 22)
+      }
+    }
+    timer = setTimeout(tick, 700)
+    return () => {
+      mounted = false
+      clearTimeout(timer)
+    }
+  }, [words])
+  return text
 }
 
 export function HeroAnswerBox() {
@@ -23,10 +93,13 @@ export function HeroAnswerBox() {
   const [loading, setLoading] = useState(false)
   const [answer, setAnswer] = useState<HeroAnswer | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [focused, setFocused] = useState(false)
+  const taRef = useRef<HTMLTextAreaElement>(null)
+  const typed = useTypewriter(EXAMPLES)
 
   async function ask(q: string) {
     if (q.trim().length < 10) {
-      setError('Add a little more detail.')
+      setError('Add a little more detail — a sentence or two works best.')
       return
     }
     setLoading(true)
@@ -35,105 +108,217 @@ export function HeroAnswerBox() {
       setAnswer((await apiClient.heroAnswer(q)).data)
     } catch (e: unknown) {
       const err = e as { response?: { data?: { detail?: string } } }
-      setError(err?.response?.data?.detail ?? 'Something went wrong.')
+      setError(err?.response?.data?.detail ?? 'Something went wrong. Try again.')
     } finally {
       setLoading(false)
     }
   }
 
+  const meter = answer ? METER[answer.meter] : null
+
   return (
-    <div className="w-full max-w-2xl font-mono">
-      <div className="flex items-stretch gap-2">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-3.5 h-4 w-4 text-muted-foreground" />
+    <div className="w-full max-w-2xl">
+      <div className="relative">
+        {/* Ambient glow that breathes and intensifies on focus */}
+        <motion.div
+          aria-hidden
+          className="pointer-events-none absolute -inset-x-6 -inset-y-4 -z-10 rounded-[2rem] bg-[#FB651E]/25 blur-2xl"
+          animate={{ opacity: focused ? 0.9 : [0.35, 0.55, 0.35] }}
+          transition={
+            focused
+              ? { duration: 0.4 }
+              : { duration: 5, repeat: Infinity, ease: 'easeInOut' }
+          }
+        />
+
+        {/* The search bar */}
+        <motion.div
+          initial={{ opacity: 0, y: 14, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={{ duration: 0.5, delay: 0.35, ease: [0.22, 1, 0.36, 1] }}
+          className={`group flex items-end gap-2 rounded-2xl border bg-background/85 p-2 pl-4 backdrop-blur-md transition-all duration-300 ${
+            focused
+              ? 'border-[#FB651E]/70 shadow-[0_0_0_4px_rgba(251,101,30,0.10),0_20px_60px_-20px_rgba(251,101,30,0.55)]'
+              : 'border-border shadow-[0_10px_40px_-24px_rgba(0,0,0,0.5)] hover:border-[#FB651E]/40'
+          }`}
+        >
+          <span
+            aria-hidden
+            className="select-none pt-3 font-mono text-lg font-bold leading-none text-[#FB651E]"
+          >
+            &gt;_
+          </span>
+
           <textarea
+            ref={taRef}
             value={idea}
             onChange={(e) => setIdea(e.target.value)}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) ask(idea)
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                ask(idea)
+              }
             }}
-            rows={2}
-            placeholder="Describe your startup idea…  (⌘+Enter)"
-            className="w-full resize-none rounded-md border border-border bg-background/70 pl-9 pr-3 py-3 text-sm outline-none focus:border-[#FB651E]/60"
+            rows={1}
+            placeholder={typed ? `${typed}` : 'Describe your startup idea…'}
+            className="min-h-[2.75rem] flex-1 resize-none bg-transparent py-3 font-mono text-[15px] leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/70"
           />
-        </div>
-        <button
-          onClick={() => ask(idea)}
-          disabled={loading}
-          className="group inline-flex items-center gap-2 rounded-md bg-[#FB651E] px-4 text-sm text-white hover:bg-[#E65C00] disabled:opacity-60 transition-colors"
-        >
-          {loading ? (
-            'Scanning…'
-          ) : (
-            <>
-              Ask
-              <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
-            </>
+
+          <button
+            onClick={() => ask(idea)}
+            disabled={loading}
+            aria-label="Ask"
+            className="group/btn inline-flex h-11 shrink-0 items-center gap-2 rounded-xl bg-[#FB651E] px-4 font-mono text-sm font-semibold text-white transition-all duration-200 hover:bg-[#E65C00] hover:shadow-[0_0_24px_-4px_rgba(251,101,30,0.8)] disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {loading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span className="hidden sm:inline">Scanning</span>
+              </>
+            ) : (
+              <>
+                <span>Ask</span>
+                <ArrowRight className="h-4 w-4 transition-transform group-hover/btn:translate-x-0.5" />
+              </>
+            )}
+          </button>
+        </motion.div>
+
+        {/* scanning beam while loading */}
+        <AnimatePresence>
+          {loading && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="absolute -bottom-px left-4 right-4 h-px overflow-hidden"
+            >
+              <motion.div
+                className="h-full w-1/3 bg-gradient-to-r from-transparent via-[#FB651E] to-transparent"
+                animate={{ x: ['-100%', '400%'] }}
+                transition={{ duration: 1.1, repeat: Infinity, ease: 'easeInOut' }}
+              />
+            </motion.div>
           )}
-        </button>
+        </AnimatePresence>
       </div>
 
-      <div className="mt-2 flex flex-wrap gap-2">
+      {/* hint + example chips */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.55 }}
+        className="mt-4 flex flex-wrap items-center justify-center gap-2"
+      >
+        <span className="mr-1 hidden items-center gap-1 font-mono text-[11px] text-muted-foreground/70 sm:inline-flex">
+          <CornerDownLeft className="h-3 w-3" /> try
+        </span>
         {EXAMPLES.map((ex) => (
-          <button
+          <motion.button
             key={ex}
             onClick={() => {
               setIdea(ex)
               ask(ex)
             }}
-            className="rounded-full border border-border px-3 py-1 text-xs text-muted-foreground hover:border-[#FB651E]/50 hover:text-foreground transition-colors"
+            whileHover={{ y: -2 }}
+            whileTap={{ scale: 0.97 }}
+            className="rounded-full border border-border/80 bg-background/50 px-3 py-1 font-mono text-xs text-muted-foreground backdrop-blur transition-colors hover:border-[#FB651E]/50 hover:text-foreground"
           >
             {ex}
-          </button>
+          </motion.button>
         ))}
-      </div>
+      </motion.div>
 
-      {error && <p className="mt-2 text-xs text-red-500">{error}</p>}
+      {error && (
+        <motion.p
+          initial={{ opacity: 0, y: -4 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mt-3 text-center font-mono text-xs text-red-500"
+        >
+          {error}
+        </motion.p>
+      )}
 
+      {/* answer card */}
       <AnimatePresence>
-        {answer && (
+        {answer && meter && (
           <motion.div
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0 }}
-            className="mt-4 rounded-md border border-border bg-card/40 p-4"
+            initial={{ opacity: 0, y: 12, height: 0 }}
+            animate={{ opacity: 1, y: 0, height: 'auto' }}
+            exit={{ opacity: 0, y: 8, height: 0 }}
+            transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+            className="overflow-hidden text-left"
           >
-            <div className="flex items-center gap-3">
-              <span
-                className={`rounded border px-2 py-0.5 text-[11px] tracking-wider ${METER[answer.meter].cls}`}
-              >
-                {METER[answer.meter].label}
-              </span>
-              <span className="text-sm font-semibold">{answer.headline}</span>
-            </div>
-            <p className="mt-2 text-sm text-muted-foreground">
-              {answer.prose || answer.summary}
-            </p>
-            {answer.closest.length > 0 && (
-              <div className="mt-3 flex flex-wrap gap-2">
-                {answer.closest.map((c) => (
-                  <Link
-                    key={c.id}
-                    to={`/company/${c.slug}`}
-                    className="inline-flex items-center gap-1 rounded border border-[#FB651E]/30 bg-[#FB651E]/5 px-2 py-1 text-xs hover:border-[#FB651E]/60 transition-colors"
-                  >
-                    {c.name}{' '}
-                    <span className="text-muted-foreground">
-                      {Math.round(c.similarity * 100)}%
-                    </span>
-                  </Link>
-                ))}
+            <div className="mt-5 rounded-2xl border border-border bg-card/60 p-5 backdrop-blur-md shadow-[0_20px_60px_-30px_rgba(0,0,0,0.6)]">
+              <div className="flex flex-wrap items-center gap-3">
+                <span
+                  className={`inline-flex items-center gap-1.5 rounded-full border bg-background/60 px-2.5 py-1 font-mono text-[11px] font-bold tracking-wider ${meter.text} ${meter.ring} ${meter.glow}`}
+                >
+                  <span className={`h-1.5 w-1.5 rounded-full ${meter.dot}`} />
+                  {meter.label}
+                </span>
+                <span className="font-mono text-sm font-semibold text-foreground">
+                  {answer.headline}
+                </span>
+                {answer.cached && (
+                  <span className="ml-auto inline-flex items-center gap-1 font-mono text-[10px] uppercase tracking-wide text-muted-foreground/60">
+                    <TrendingUp className="h-3 w-3" /> instant
+                  </span>
+                )}
               </div>
-            )}
-            <Link
-              to="/validator"
-              className="mt-3 inline-flex items-center gap-1 text-xs text-[#FB651E] hover:underline"
-            >
-              Full breakdown <ArrowRight className="h-3 w-3" />
-            </Link>
+
+              <p className="mt-3 font-mono text-sm leading-relaxed text-muted-foreground">
+                {answer.prose || answer.summary}
+              </p>
+
+              {answer.closest.length > 0 && (
+                <div className="mt-4">
+                  <p className="mb-2 font-mono text-[11px] uppercase tracking-wide text-muted-foreground/60">
+                    closest matches
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {answer.closest.map((c) => (
+                      <Link
+                        key={c.id}
+                        to={`/company/${c.slug}`}
+                        className="group/chip inline-flex items-center gap-1.5 rounded-lg border border-[#FB651E]/30 bg-[#FB651E]/5 px-2.5 py-1.5 font-mono text-xs text-foreground transition-all hover:border-[#FB651E]/60 hover:bg-[#FB651E]/10"
+                      >
+                        <span className="font-semibold">{c.name}</span>
+                        <span className="rounded bg-[#FB651E]/15 px-1 text-[10px] font-bold text-[#FB651E]">
+                          {Math.round(c.similarity * 100)}%
+                        </span>
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <Link
+                to="/validator"
+                className="mt-4 inline-flex items-center gap-1 font-mono text-xs font-semibold text-[#FB651E] transition-colors hover:text-[#E65C00]"
+              >
+                Full breakdown, charts & market map
+                <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+            </div>
           </motion.div>
         )}
       </AnimatePresence>
+
+      {/* subtle "powered by" line — reinforces the agentic angle */}
+      {!answer && !loading && (
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.7 }}
+          className="mt-4 flex items-center justify-center gap-1.5 font-mono text-[11px] text-muted-foreground/60"
+        >
+          <Sparkles className="h-3 w-3 text-[#FB651E]" />
+          instant semantic search across the YC &amp; a16z portfolio
+        </motion.p>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -41,82 +41,100 @@ export function HomePage() {
       <GridPattern size={32} className="opacity-50" />
 
       <div className="container relative mx-auto px-4 py-12">
-        {/* Hero - terminal style */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          className="mb-16"
-        >
-          <div className="flex items-center gap-2 mb-6 font-mono text-sm text-muted-foreground">
-            <Terminal className="h-4 w-4 text-[#FB651E]" />
-            <span>$ explore-yc --init</span>
-          </div>
-          <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-4">
-            <span className="text-[#FB651E]">&gt;</span>{' '}
-            <span className="bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text text-transparent">
-              Explore YC &amp; a16z startups
-            </span>
-          </h1>
-          <p className="text-lg text-muted-foreground font-mono max-w-2xl mb-8">
-            Search, analyze, and build on startup data from Y Combinator, a16z &amp; more — {totalCompanies.toLocaleString()}+ companies in one place, now with a free, open-source API.
-          </p>
+        {/* Hero — centered agentic search */}
+        <div className="relative mb-20 overflow-hidden pt-4 pb-2">
+          {/* ambient breathing glow anchored behind the search */}
+          <motion.div
+            aria-hidden
+            className="pointer-events-none absolute left-1/2 top-[46%] -z-0 h-[440px] w-[820px] max-w-[94vw] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#FB651E]/12 blur-[130px]"
+            animate={{ opacity: [0.5, 0.85, 0.5], scale: [1, 1.06, 1] }}
+            transition={{ duration: 7, repeat: Infinity, ease: 'easeInOut' }}
+          />
 
-          <div className="mb-8">
-            <HeroAnswerBox />
-          </div>
-
-          {/* Live Stats - inline terminal style */}
           <motion.div
             variants={container}
             initial="hidden"
             animate="show"
-            className="flex flex-wrap gap-3 mb-8"
+            className="relative z-10 flex flex-col items-center text-center"
           >
-            {[
-              { val: totalCompanies.toLocaleString(), label: 'companies', color: 'text-[#FB651E]' },
-              { val: `${totalCountries}+`, label: 'countries', color: 'text-[#FB651E]' },
-              { val: `${totalIndustries}+`, label: 'industries', color: 'text-[#FB651E]' },
-            ].map((s) => (
-              <motion.div
-                key={s.label}
-                variants={item}
-                className="flex items-baseline gap-2 font-mono"
+            {/* eyebrow chip */}
+            <motion.div
+              variants={item}
+              className="mb-7 inline-flex items-center gap-2 rounded-full border border-border bg-background/60 px-3.5 py-1.5 font-mono text-xs text-muted-foreground backdrop-blur"
+            >
+              <Terminal className="h-3.5 w-3.5 text-[#FB651E]" />
+              <span>$ explore-yc --init</span>
+              <span className="ml-0.5 inline-block h-3 w-[7px] animate-pulse bg-[#FB651E]" />
+            </motion.div>
+
+            {/* headline */}
+            <motion.h1
+              variants={item}
+              className="max-w-3xl text-4xl font-bold leading-[1.05] tracking-tight sm:text-5xl md:text-6xl"
+            >
+              <span className="text-[#FB651E]">&gt;</span>{' '}
+              <span className="bg-gradient-to-br from-foreground via-foreground to-foreground/60 bg-clip-text text-transparent">
+                Explore YC &amp; a16z startups
+              </span>
+            </motion.h1>
+
+            {/* subline */}
+            <motion.p
+              variants={item}
+              className="mt-5 max-w-xl font-mono text-base leading-relaxed text-muted-foreground"
+            >
+              Ask anything about {totalCompanies.toLocaleString()}+ startups from Y&nbsp;Combinator,
+              a16z &amp; more — instant answers on a free, open-source API.
+            </motion.p>
+
+            {/* SEARCH — the centerpiece */}
+            <motion.div variants={item} className="mt-9 flex w-full justify-center">
+              <HeroAnswerBox />
+            </motion.div>
+
+            {/* Live stats — compact terminal status row */}
+            <motion.div
+              variants={item}
+              className="mt-9 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 font-mono text-sm"
+            >
+              <span className="text-muted-foreground/50">$</span>
+              <span className="text-muted-foreground">
+                <span className="font-bold text-[#FB651E]">{totalCompanies.toLocaleString()}</span> companies
+              </span>
+              <span className="text-border">·</span>
+              <span className="text-muted-foreground">
+                <span className="font-bold text-[#FB651E]">{totalCountries}+</span> countries
+              </span>
+              <span className="text-border">·</span>
+              <span className="text-muted-foreground">
+                <span className="font-bold text-[#FB651E]">{totalIndustries}+</span> industries
+              </span>
+            </motion.div>
+
+            {/* Primary CTAs */}
+            <motion.div
+              variants={item}
+              className="mt-8 flex flex-wrap items-center justify-center gap-3"
+            >
+              <a
+                href="#map"
+                className="group inline-flex items-center gap-2 px-5 py-2.5 bg-[#FB651E] hover:bg-[#E65C00] text-white font-mono text-sm border border-[#FB651E]/50 transition-all duration-200 hover:shadow-[0_0_20px_rgba(251,101,30,0.3)]"
               >
-                <span className="text-muted-foreground">$</span>
-                <span className={`text-2xl font-bold ${s.color}`}>{s.val}</span>
-                <span className="text-sm text-muted-foreground">{s.label}</span>
-              </motion.div>
-            ))}
-          </motion.div>
+                Start Exploring
+                <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
+              </a>
+              <Link
+                to="/analytics"
+                className="inline-flex items-center gap-2 px-5 py-2.5 border border-border hover:border-[#FB651E]/50 font-mono text-sm bg-background/50 transition-all duration-200"
+              >
+                View Analytics
+              </Link>
+            </motion.div>
 
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.4 }}
-            className="flex flex-wrap gap-3"
-          >
-            <a
-              href="#map"
-              className="group inline-flex items-center gap-2 px-5 py-2.5 bg-[#FB651E] hover:bg-[#E65C00] text-white font-mono text-sm border border-[#FB651E]/50 transition-all duration-200 hover:shadow-[0_0_20px_rgba(251,101,30,0.3)]"
+            <motion.div
+              variants={item}
+              className="mt-8 flex flex-wrap items-center justify-center gap-4"
             >
-              Start Exploring
-              <ArrowRight className="h-4 w-4 group-hover:translate-x-1 transition-transform" />
-            </a>
-            <Link
-              to="/analytics"
-              className="inline-flex items-center gap-2 px-5 py-2.5 border border-border hover:border-[#FB651E]/50 font-mono text-sm bg-background/50 transition-all duration-200"
-            >
-              View Analytics
-            </Link>
-          </motion.div>
-
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.5 }}
-            className="mt-6 flex flex-wrap items-center gap-4"
-          >
             <motion.a
               href="https://www.producthunt.com/products/yc-company-explorer?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-exploreyc-2"
               target="_blank"
@@ -173,8 +191,9 @@ export function HomePage() {
                 <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
               </svg>
             </a>
+            </motion.div>
           </motion.div>
-        </motion.div>
+        </div>
 
         {/* Batch Wrapped Banner - hacker card */}
         {wrappedBatch && (


### PR DESCRIPTION
Follow-up to #46 — these two commits were made after #46 was merged, so they didn't land. Shipping them onto current master.

1. **Centered agentic-search hero redesign** — search bar as the centerpiece: centered single-column layout, breathing orange glow, typewriter placeholder cycling example prompts, focus glow-ring + scanning beam, staggered load reveal, refined answer card (glowing meter pill, match-% company chips). Stats/CTAs/badges recentered.
2. **Resilient answer-cache read** — if `idea_answer_cache` doesn't exist yet (migration not applied) or a transient DB error occurs, `/api/hero-answer` degrades to computing a fresh verdict instead of 500-ing. Lets the hero work in prod immediately; caching activates once the migration runs.

Verified: `tsc --noEmit` clean, `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)