### PR TITLE
Hero: graceful 503 on search failure + Ask-button alignment

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1064,10 +1064,23 @@ async def hero_answer(req: HeroAnswerRequest, request: Request):
     if db.count_companies_with_embeddings() == 0:
         raise HTTPException(status_code=503, detail="Company embeddings not yet generated.")
 
-    # Embed → similarity search → verdict (zero LLM chat calls)
-    search_text = get_search_text_for_embedding(idea)
-    embedding = get_embedding_service().generate_embedding_for_idea(search_text)
-    similar = db.find_similar_companies_by_embedding(embedding, limit=12, min_similarity=0.32)
+    # Embed → similarity search → verdict (zero LLM chat calls).
+    # Wrap in try/except so an embedding/search failure (e.g. OpenAI quota,
+    # transient DB error) returns a handled 503 — which passes through the CORS
+    # middleware — instead of a raw 500 that arrives at the browser without CORS
+    # headers (surfacing as a confusing cross-origin error).
+    try:
+        search_text = get_search_text_for_embedding(idea)
+        embedding = get_embedding_service().generate_embedding_for_idea(search_text)
+        similar = db.find_similar_companies_by_embedding(embedding, limit=12, min_similarity=0.32)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"hero-answer search failed: {e}")
+        raise HTTPException(
+            status_code=503,
+            detail="Search is temporarily unavailable — please try again shortly.",
+        )
 
     # Portfolio total: use YC-only count so the denominator matches the YC-only
     # numerator in market_size_percentage (both must be source='yc').

--- a/frontend/src/components/HeroAnswerBox.tsx
+++ b/frontend/src/components/HeroAnswerBox.tsx
@@ -136,7 +136,7 @@ export function HeroAnswerBox() {
           initial={{ opacity: 0, y: 14, scale: 0.98 }}
           animate={{ opacity: 1, y: 0, scale: 1 }}
           transition={{ duration: 0.5, delay: 0.35, ease: [0.22, 1, 0.36, 1] }}
-          className={`group flex items-end gap-2 rounded-2xl border bg-background/85 p-2 pl-4 backdrop-blur-md transition-all duration-300 ${
+          className={`group flex items-center gap-2 rounded-2xl border bg-background/85 p-2 pl-4 backdrop-blur-md transition-all duration-300 ${
             focused
               ? 'border-[#FB651E]/70 shadow-[0_0_0_4px_rgba(251,101,30,0.10),0_20px_60px_-20px_rgba(251,101,30,0.55)]'
               : 'border-border shadow-[0_10px_40px_-24px_rgba(0,0,0,0.5)] hover:border-[#FB651E]/40'
@@ -144,7 +144,7 @@ export function HeroAnswerBox() {
         >
           <span
             aria-hidden
-            className="select-none pt-3 font-mono text-lg font-bold leading-none text-[#FB651E]"
+            className="select-none self-center font-mono text-lg font-bold leading-none text-[#FB651E]"
           >
             &gt;_
           </span>


### PR DESCRIPTION
Two small production fixes for the live hero answer box.

1. **Graceful failure (fixes the CORS-looking error).** When embedding/search fails (currently: the prod OpenAI key is out of quota → 429 `insufficient_quota`), `/api/hero-answer` raised an unhandled 500. Unhandled 500s skip the CORS middleware, so the browser reported `No 'Access-Control-Allow-Origin' header`. Now it returns a handled **503** with a friendly detail, which flows through CORS correctly and shows a clean message in the UI.
2. **Button alignment.** The bar now vertically centers its contents so the **Ask** button matches the input height (was `items-end`, causing uneven top/bottom padding).

Note: the underlying reason the search returns no answers is the exhausted **OpenAI quota** — that's a billing fix on the OpenAI account, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)