### PR TITLE
Multi-source company sync: Hacker News + domain merge + all-source vector search

### DIFF
--- a/.github/workflows/daily-cron.yml
+++ b/.github/workflows/daily-cron.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     # Daily scrape at 2 AM UTC
     - cron: '0 2 * * *'
+    # Multi-source sync (Hacker News, ...) at 2:30 AM UTC (after scrape, before pre-warm)
+    - cron: '30 2 * * *'
     # Send digests at 10 AM UTC
     - cron: '0 10 * * *'
     # Hero answer-box pre-warm at 3 AM UTC (after scrape, needs Task 12 embeddings)
@@ -23,6 +25,19 @@ jobs:
             -H "Content-Type: application/json" \
             -v
         timeout-minutes: 10
+
+  sync-sources:
+    runs-on: ubuntu-latest
+    # Only run multi-source sync at 2:30 AM UTC (after daily scrape at 2 AM)
+    if: github.event.schedule == '30 2 * * *' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Sync non-YC company sources (Hacker News, ...)
+        run: |
+          curl -X POST "${{ secrets.BACKEND_URL }}/api/cron/sync-sources?sync=1" \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            -H "Content-Type: application/json" \
+            -v
+        timeout-minutes: 20
 
   send-digests:
     runs-on: ubuntu-latest

--- a/backend/company_cache.py
+++ b/backend/company_cache.py
@@ -150,6 +150,52 @@ class CompanyCache:
             return True
         return csrc == source
 
+    # Primary-row priority when merging the same company across sources
+    # (richest / most-geocoded first).
+    _SOURCE_PRIORITY = {"yc": 0, "a16z": 1, "techstars": 2, "producthunt": 3, "hackernews": 4}
+
+    @staticmethod
+    def _created_sort_key(c: Dict):
+        created = c.get("created_at")
+        if created is None:
+            return ""
+        return str(created) if not hasattr(created, "isoformat") else created.isoformat()
+
+    @staticmethod
+    def _merge_group(rows: List[Dict]) -> Dict:
+        """Collapse rows sharing a dedupe_key into one canonical presentation:
+        the highest-priority source is the primary; missing display fields are
+        gap-filled from other rows; is_hiring is OR-ed; merged_sources lists all."""
+        primary = min(
+            rows, key=lambda r: CompanyCache._SOURCE_PRIORITY.get(r.get("source") or "yc", 99)
+        )
+        merged = dict(primary)
+        for field in ("one_liner", "small_logo_thumb_url", "long_description",
+                      "country", "all_locations", "website"):
+            if not merged.get(field):
+                for r in rows:
+                    if r.get(field):
+                        merged[field] = r[field]
+                        break
+        merged["is_hiring"] = any(r.get("is_hiring") for r in rows)
+        merged["merged_sources"] = [
+            {"key": r.get("source") or "yc", "source_url": r.get("source_url")}
+            for r in sorted(rows, key=lambda r: CompanyCache._SOURCE_PRIORITY.get(
+                r.get("source") or "yc", 99))
+        ]
+        return merged
+
+    def _apply_merge(self, filtered: List[Dict]) -> List[Dict]:
+        """Group filtered rows by dedupe_key and merge each group. Rows without a
+        dedupe_key stand alone (keyed by id). Preserves created_at DESC ordering."""
+        groups: Dict[str, List[Dict]] = {}
+        for c in filtered:
+            key = c.get("dedupe_key") or f'id:{c.get("id")}'
+            groups.setdefault(key, []).append(c)
+        merged = [self._merge_group(g) for g in groups.values()]
+        merged.sort(key=self._created_sort_key, reverse=True)
+        return merged
+
     def _filter_companies(
         self,
         batch: Optional[str] = None,
@@ -187,9 +233,16 @@ class CompanyCache:
         search: Optional[str] = None,
         top_company: Optional[bool] = None,
         source: Optional[str] = None,
+        merged: bool = False,
     ) -> List[Dict]:
-        """Get companies with filters and pagination."""
+        """Get companies with filters and pagination.
+
+        When merged=True, rows sharing a dedupe_key are collapsed into one
+        canonical entry (with a merged_sources badge cluster) before pagination.
+        """
         filtered = self._filter_companies(batch, is_hiring, industry, country, search, top_company, source)
+        if merged:
+            filtered = self._apply_merge(filtered)
         return filtered[offset : offset + limit]
 
     def count_companies(
@@ -201,9 +254,12 @@ class CompanyCache:
         search: Optional[str] = None,
         top_company: Optional[bool] = None,
         source: Optional[str] = None,
+        merged: bool = False,
     ) -> int:
-        """Count companies matching filters."""
+        """Count companies matching filters (post-merge count when merged=True)."""
         filtered = self._filter_companies(batch, is_hiring, industry, country, search, top_company, source)
+        if merged:
+            filtered = self._apply_merge(filtered)
         return len(filtered)
 
     def get_company_by_id(self, company_id: int) -> Optional[Dict]:

--- a/backend/database.py
+++ b/backend/database.py
@@ -291,6 +291,19 @@ class Database:
                 )
             ''')
 
+            # Per-source incremental sync cursor (parity with the Postgres migration)
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS sync_state (
+                    source TEXT PRIMARY KEY,
+                    last_run_at TEXT,
+                    last_cursor TEXT,
+                    last_status TEXT,
+                    records_upserted INTEGER DEFAULT 0,
+                    error TEXT,
+                    updated_at TEXT
+                )
+            ''')
+
             # Bring existing databases up to the multi-source schema before indexing
             self._migrate_schema(cursor)
 
@@ -301,6 +314,7 @@ class Database:
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_country ON companies(country)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_funding_total ON companies(funding_total_usd)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_companies_source ON companies(source)')
+            cursor.execute('CREATE INDEX IF NOT EXISTS idx_dedupe_key ON companies(dedupe_key)')
             cursor.execute('CREATE UNIQUE INDEX IF NOT EXISTS uq_companies_source_slug ON companies(source, slug)')
             cursor.execute('CREATE UNIQUE INDEX IF NOT EXISTS uq_companies_source_native ON companies(source, source_id)')
             cursor.execute('CREATE INDEX IF NOT EXISTS idx_investor_name ON investors(name)')
@@ -333,6 +347,7 @@ class Database:
             "ticker_symbol": "TEXT",
             "funded_date": "TEXT",
             "source_url": "TEXT",
+            "dedupe_key": "TEXT",
         }
         for col, ddl in additions.items():
             if col not in existing:
@@ -564,8 +579,8 @@ class Database:
                  top_company, nonprofit, stage, small_logo_thumb_url, tags, regions,
                  industries, latitude, longitude, country,
                  founders, year_founded, exit_type, acquirer, ticker_symbol, funded_date, source_url,
-                 raw_json, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                 dedupe_key, raw_json, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
             ''', (
                 company.get('id'),
                 company.get('source', 'yc'),
@@ -599,9 +614,58 @@ class Database:
                 company.get('ticker_symbol'),
                 company.get('funded_date'),
                 company.get('source_url'),
+                company.get('dedupe_key'),
                 json.dumps(company)
             ))
             return cursor.lastrowid
+
+    # ========== MULTI-SOURCE SYNC: cursor + dedupe_key ==========
+
+    def get_sync_cursor(self, source: str) -> Optional[str]:
+        """Return the stored incremental cursor for a source (None if never run)."""
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT last_cursor FROM sync_state WHERE source = ?", (source,))
+            row = cursor.fetchone()
+            return row[0] if row else None
+
+    def save_sync_state(self, source: str, cursor_value: Optional[str], status: str,
+                        records_upserted: int, error: Optional[str] = None) -> None:
+        """Upsert the per-source sync bookkeeping row."""
+        with self.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT OR REPLACE INTO sync_state
+                (source, last_run_at, last_cursor, last_status, records_upserted, error, updated_at)
+                VALUES (?, CURRENT_TIMESTAMP, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                """,
+                (source, cursor_value, status, records_upserted, error),
+            )
+
+    def set_dedupe_key(self, company_id: int, key: str) -> None:
+        with self.get_connection() as conn:
+            conn.cursor().execute(
+                "UPDATE companies SET dedupe_key = ? WHERE id = ?", (key, company_id)
+            )
+
+    def backfill_dedupe_keys(self) -> int:
+        """Populate dedupe_key for any rows missing one, using the shared normalizer."""
+        from ingestion.normalize import norm_domain, dedupe_key
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT id, source, slug, website FROM companies WHERE dedupe_key IS NULL"
+            )
+            rows = cursor.fetchall()
+            for r in rows:
+                key = dedupe_key(
+                    norm_domain(r["website"]), r["source"] or "yc", r["slug"] or str(r["id"])
+                )
+                cursor.execute(
+                    "UPDATE companies SET dedupe_key = ? WHERE id = ?", (key, r["id"])
+                )
+            return len(rows)
 
     def record_feature_interest(self, feature: str, user_identifier: Optional[str] = None,
                                 email: Optional[str] = None) -> Dict:

--- a/backend/database_postgres.py
+++ b/backend/database_postgres.py
@@ -882,7 +882,7 @@ class DatabasePostgres:
         with self.get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT COUNT(*) FROM companies WHERE embedding IS NOT NULL AND source = 'yc'"
+                    "SELECT COUNT(*) FROM companies WHERE embedding IS NOT NULL"
                 )
                 return cur.fetchone()[0] or 0
 
@@ -902,7 +902,6 @@ class DatabasePostgres:
                     SELECT id, name, one_liner, long_description
                     FROM companies
                     WHERE embedding IS NULL
-                        AND source = 'yc'
                         AND (one_liner IS NOT NULL OR long_description IS NOT NULL)
                     ORDER BY id DESC
                     LIMIT %s
@@ -944,10 +943,10 @@ class DatabasePostgres:
         Returns:
             List of dicts with id, name, one_liner, long_description,
             industry, subindustry, tags, industries.
+
+        Covers ALL sources (not just YC) so vector search spans the full corpus.
         """
-        where = "WHERE source = 'yc'"
-        if only_missing:
-            where += " AND embedding IS NULL"
+        where = "WHERE embedding IS NULL" if only_missing else "WHERE TRUE"
         with self.get_connection() as conn:
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
                 cur.execute(
@@ -1008,19 +1007,29 @@ class DatabasePostgres:
         self,
         embedding: List[float],
         limit: int = 10,
-        min_similarity: float = 0.5
+        min_similarity: float = 0.5,
+        source_filter: Optional[str] = None,
     ) -> List[Dict]:
         """
-        Find companies similar to the given embedding vector using cosine similarity
+        Find companies similar to the given embedding vector using cosine similarity.
 
         Args:
             embedding: The embedding vector (1536 dimensions)
             limit: Maximum number of results to return
             min_similarity: Minimum similarity score (0-1, where 1 is identical)
+            source_filter:
+                - a source key (e.g. 'yc') -> restrict to that source. The hero
+                  idea-validator passes 'yc' so its market-size % / "N YC companies
+                  overlap" verdict stays YC-scoped and unchanged.
+                - None -> search ALL sources, deduped by dedupe_key so a company
+                  present in several sources appears once (all-source semantic search).
 
         Returns:
             List of companies with similarity scores, ordered by similarity (highest first)
         """
+        cols = ("id, name, slug, website, one_liner, long_description, "
+                "industry, subindustry, tags, industries, batch, is_hiring, "
+                "team_size, all_locations, country, small_logo_thumb_url, source, dedupe_key")
         with self.get_connection() as conn:
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
                 # Convert Python list to PostgreSQL vector format
@@ -1029,22 +1038,34 @@ class DatabasePostgres:
                 # Raise HNSW index recall (no-op for IVFFlat indexes)
                 cur.execute("SET LOCAL hnsw.ef_search = 60")
 
-                # Query using cosine similarity
-                # <=> is the cosine distance operator in pgvector
-                # 1 - cosine_distance = cosine_similarity
-                cur.execute("""
-                    SELECT
-                        id, name, slug, website, one_liner, long_description,
-                        industry, subindustry, tags, industries, batch, is_hiring,
-                        team_size, all_locations, country, small_logo_thumb_url,
-                        (1 - (embedding <=> %s::vector)) AS similarity_score
-                    FROM companies
-                    WHERE embedding IS NOT NULL
-                        AND source = 'yc'
-                        AND (1 - (embedding <=> %s::vector)) >= %s
-                    ORDER BY embedding <=> %s::vector
-                    LIMIT %s
-                """, (embedding_str, embedding_str, min_similarity, embedding_str, limit))
+                # <=> is the cosine distance operator in pgvector; 1 - dist = similarity
+                if source_filter:
+                    cur.execute(f"""
+                        SELECT {cols},
+                            (1 - (embedding <=> %s::vector)) AS similarity_score
+                        FROM companies
+                        WHERE embedding IS NOT NULL
+                            AND source = %s
+                            AND (1 - (embedding <=> %s::vector)) >= %s
+                        ORDER BY embedding <=> %s::vector
+                        LIMIT %s
+                    """, (embedding_str, source_filter, embedding_str, min_similarity,
+                          embedding_str, limit))
+                else:
+                    # All sources: keep one row per company (dedupe by domain), then rank.
+                    cur.execute(f"""
+                        SELECT * FROM (
+                            SELECT DISTINCT ON (COALESCE(dedupe_key, id::text))
+                                {cols},
+                                (1 - (embedding <=> %s::vector)) AS similarity_score
+                            FROM companies
+                            WHERE embedding IS NOT NULL
+                                AND (1 - (embedding <=> %s::vector)) >= %s
+                            ORDER BY COALESCE(dedupe_key, id::text), embedding <=> %s::vector
+                        ) sub
+                        ORDER BY similarity_score DESC
+                        LIMIT %s
+                    """, (embedding_str, embedding_str, min_similarity, embedding_str, limit))
 
                 companies = [dict(row) for row in cur.fetchall()]
 
@@ -1058,12 +1079,16 @@ class DatabasePostgres:
     def find_companies_by_text_search(
         self,
         idea: str,
-        limit: int = 10
+        limit: int = 10,
+        source_filter: Optional[str] = None,
     ) -> List[Dict]:
         """
         Fallback: find companies by text match when embedding search returns nothing.
         Useful when user pastes a company description - finds companies whose
         one_liner or long_description overlaps with the pasted text.
+
+        source_filter mirrors find_similar_companies_by_embedding: 'yc' restricts to
+        YC (hero verdict), None searches all sources deduped by dedupe_key.
         """
         if not idea or len(idea.strip()) < 10:
             return []
@@ -1074,21 +1099,36 @@ class DatabasePostgres:
         if len(phrase) < 10:
             return []
         search_term = f"%{phrase}%"
+        src_clause = "AND source = %s" if source_filter else ""
+        params = [search_term, search_term]
+        if source_filter:
+            params.append(source_filter)
+        params.extend([search_term, limit])
         with self.get_connection() as conn:
             with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                cur.execute("""
+                cur.execute(f"""
                     SELECT
                         id, name, slug, website, one_liner, long_description,
                         industry, subindustry, tags, industries, batch, is_hiring,
-                        team_size, all_locations, country, small_logo_thumb_url
+                        team_size, all_locations, country, small_logo_thumb_url, source, dedupe_key
                     FROM companies
                     WHERE (one_liner ILIKE %s OR long_description ILIKE %s)
-                        AND source = 'yc'
+                        {src_clause}
                         AND (one_liner IS NOT NULL OR long_description IS NOT NULL)
                     ORDER BY CASE WHEN one_liner ILIKE %s THEN 0 ELSE 1 END
                     LIMIT %s
-                """, (search_term, search_term, search_term, limit))
+                """, params)
                 companies = [dict(row) for row in cur.fetchall()]
+                # When searching all sources, keep one row per company (dedupe by domain).
+                if not source_filter:
+                    seen, deduped = set(), []
+                    for c in companies:
+                        key = c.get("dedupe_key") or f'id:{c.get("id")}'
+                        if key in seen:
+                            continue
+                        seen.add(key)
+                        deduped.append(c)
+                    companies = deduped
                 for c in companies:
                     c["similarity_score"] = 0.65  # Placeholder for text match
                 return companies

--- a/backend/database_postgres.py
+++ b/backend/database_postgres.py
@@ -59,8 +59,8 @@ class DatabasePostgres:
                      top_company, nonprofit, stage, small_logo_thumb_url, tags, regions,
                      industries, latitude, longitude, country,
                      founders, year_founded, exit_type, acquirer, ticker_symbol, funded_date, source_url,
-                     raw_json, updated_at)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
+                     dedupe_key, raw_json, updated_at)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
                     ON CONFLICT (id) DO UPDATE SET
                         source = EXCLUDED.source,
                         source_id = EXCLUDED.source_id,
@@ -93,6 +93,7 @@ class DatabasePostgres:
                         ticker_symbol = EXCLUDED.ticker_symbol,
                         funded_date = EXCLUDED.funded_date,
                         source_url = EXCLUDED.source_url,
+                        dedupe_key = COALESCE(EXCLUDED.dedupe_key, companies.dedupe_key),
                         raw_json = EXCLUDED.raw_json,
                         updated_at = NOW()
                 """, (
@@ -128,6 +129,7 @@ class DatabasePostgres:
                     company.get("ticker_symbol"),
                     company.get("funded_date"),
                     company.get("source_url"),
+                    company.get("dedupe_key"),
                     json.dumps(company) if company else None,
                 ))
                 return cur.rowcount
@@ -186,11 +188,12 @@ class DatabasePostgres:
                 company.get("ticker_symbol"),
                 company.get("funded_date"),
                 company.get("source_url"),
+                company.get("dedupe_key"),
                 json.dumps(company) if company else None,
             )
 
         total = 0
-        cols = "(id, source, source_id, name, slug, website, one_liner, long_description, team_size, batch, status, industry, subindustry, all_locations, is_hiring, top_company, nonprofit, stage, small_logo_thumb_url, tags, regions, industries, latitude, longitude, country, founders, year_founded, exit_type, acquirer, ticker_symbol, funded_date, source_url, raw_json)"
+        cols = "(id, source, source_id, name, slug, website, one_liner, long_description, team_size, batch, status, industry, subindustry, all_locations, is_hiring, top_company, nonprofit, stage, small_logo_thumb_url, tags, regions, industries, latitude, longitude, country, founders, year_founded, exit_type, acquirer, ticker_symbol, funded_date, source_url, dedupe_key, raw_json)"
         upsert_sql = f"""
             INSERT INTO companies {cols}
             VALUES %s
@@ -209,6 +212,7 @@ class DatabasePostgres:
                 exit_type = EXCLUDED.exit_type, acquirer = EXCLUDED.acquirer,
                 ticker_symbol = EXCLUDED.ticker_symbol, funded_date = EXCLUDED.funded_date,
                 source_url = EXCLUDED.source_url,
+                dedupe_key = COALESCE(EXCLUDED.dedupe_key, companies.dedupe_key),
                 raw_json = EXCLUDED.raw_json, updated_at = NOW()
         """
         rows = [_row(c) for c in companies]
@@ -217,6 +221,65 @@ class DatabasePostgres:
                 execute_values(cur, upsert_sql, rows, page_size=batch_size)
                 total = cur.rowcount
         return total
+
+    # ========== MULTI-SOURCE SYNC: cursor + dedupe_key ==========
+
+    def get_sync_cursor(self, source: str) -> Optional[str]:
+        """Return the stored incremental cursor for a source (None if never run)."""
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT last_cursor FROM sync_state WHERE source = %s", (source,))
+                row = cur.fetchone()
+                return row[0] if row else None
+
+    def save_sync_state(self, source: str, cursor_value: Optional[str], status: str,
+                        records_upserted: int, error: Optional[str] = None) -> None:
+        """Upsert the per-source sync bookkeeping row."""
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO sync_state
+                    (source, last_run_at, last_cursor, last_status, records_upserted, error, updated_at)
+                    VALUES (%s, NOW(), %s, %s, %s, %s, NOW())
+                    ON CONFLICT (source) DO UPDATE SET
+                        last_run_at = NOW(), last_cursor = EXCLUDED.last_cursor,
+                        last_status = EXCLUDED.last_status,
+                        records_upserted = EXCLUDED.records_upserted,
+                        error = EXCLUDED.error, updated_at = NOW()
+                    """,
+                    (source, cursor_value, status, records_upserted, error),
+                )
+                conn.commit()
+
+    def set_dedupe_key(self, company_id: int, key: str) -> None:
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE companies SET dedupe_key = %s WHERE id = %s", (key, company_id)
+                )
+                conn.commit()
+
+    def backfill_dedupe_keys(self) -> int:
+        """Populate dedupe_key for any rows missing one, using the shared normalizer."""
+        from ingestion.normalize import norm_domain, dedupe_key
+        with self.get_connection() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute(
+                    "SELECT id, source, slug, website FROM companies WHERE dedupe_key IS NULL"
+                )
+                rows = cur.fetchall()
+            with conn.cursor() as cur:
+                for r in rows:
+                    key = dedupe_key(
+                        norm_domain(r["website"]), r["source"] or "yc",
+                        r["slug"] or str(r["id"]),
+                    )
+                    cur.execute(
+                        "UPDATE companies SET dedupe_key = %s WHERE id = %s", (key, r["id"])
+                    )
+            conn.commit()
+        return len(rows)
 
     def get_companies(
         self,

--- a/backend/ingestion/base.py
+++ b/backend/ingestion/base.py
@@ -1,0 +1,30 @@
+"""Source-adapter contract for the multi-source sync.
+
+An adapter fetches from one external source and returns rows already normalized
+into ExploreYC's canonical column names (the same keys `insert_company` reads).
+
+Adapter contract (duck-typed — no ABC needed):
+
+    class MyAdapter:
+        key = "mysource"            # matches sources.SOURCES / SOURCE_ID_OFFSETS
+        display_name = "My Source"
+        def fetch(self, cursor, full=False) -> FetchResult: ...
+
+`cursor` is the last stored incremental cursor (str) or None on first run.
+`full=True` requests a complete backfill (ignore the cursor).
+
+Each row dict SHOULD carry: id (global, via sources.to_global_id), source,
+source_id, source_url, name, slug, website, one_liner, long_description, batch,
+tags/industries/regions (lists), isHiring (NOT is_hiring — that's the key
+insert_company reads), top_company, nonprofit, country, dedupe_key, raw_json.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class FetchResult:
+    rows: List[dict] = field(default_factory=list)
+    cursor: Optional[str] = None
+    removed_source_ids: List[str] = field(default_factory=list)

--- a/backend/ingestion/hackernews.py
+++ b/backend/ingestion/hackernews.py
@@ -1,0 +1,112 @@
+"""Hacker News source adapter — Launch HN / Show HN posts.
+
+Ports the sync-PR's HN parsing into a native Python adapter. Uses the HN Algolia
+search_by_date endpoint (no key) filtered on created_at_i for incremental pulls.
+"""
+
+import json
+import re
+import time
+import urllib.parse
+import urllib.request
+
+from ingestion.base import FetchResult
+from ingestion.normalize import norm_domain, slugify, dedupe_key
+from sources import to_global_id
+
+_SEARCH = "https://hn.algolia.com/api/v1/search_by_date"
+_MAX_PAGES = 20
+_HITS_PER_PAGE = 100
+
+
+def parse_title(title):
+    """Parse 'Launch HN: Acme (YC S26) – blurb' -> {name, batch, blurb}.
+
+    Falls back gracefully when the format varies.
+    """
+    body = re.sub(r"^\s*(launch|show)\s+hn:\s*", "", title or "", flags=re.I).strip()
+    segs = re.split(r"\s+[–—-]\s+", body, maxsplit=1)
+    head = segs[0].strip() if segs else body
+    blurb = segs[1].strip() if len(segs) > 1 else None
+    m = re.search(r"\(YC\s+([A-Za-z]\d{2})\)", head, re.I)
+    batch = m.group(1).upper() if m else None
+    name = re.sub(r"\s*\(YC\s+[A-Za-z]\d{2}\)\s*", "", head, flags=re.I)
+    name = re.sub(r"\s*\([^)]*\)\s*$", "", name).strip()
+    return {"name": name or head, "batch": batch, "blurb": blurb}
+
+
+def _get(url):
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode())
+
+
+class HackerNewsAdapter:
+    key = "hackernews"
+    display_name = "Hacker News"
+
+    def _to_row(self, hit):
+        parsed = parse_title(hit.get("title", ""))
+        name = parsed["name"]
+        if not name:
+            return None
+        domain = norm_domain(hit.get("url"))
+        # Require a real domain OR a YC-batch marker to count as a company (drops noise).
+        if not domain and not parsed["batch"]:
+            return None
+        slug = slugify(name)
+        if not slug:
+            return None
+        is_launch = bool(re.match(r"^\s*launch\s+hn", hit.get("title", ""), re.I))
+        tag = "Launch HN" if is_launch else "Show HN"
+        object_id = str(hit["objectID"])
+        return {
+            "id": to_global_id("hackernews", int(object_id)),
+            "source": "hackernews",
+            "source_id": object_id,
+            "source_url": f"https://news.ycombinator.com/item?id={object_id}",
+            "name": name,
+            "slug": slug,
+            "website": hit.get("url"),
+            "one_liner": parsed["blurb"],
+            "long_description": hit.get("story_text"),
+            "batch": parsed["batch"],
+            "tags": [tag],
+            "industries": [],
+            "regions": [],
+            "isHiring": False,
+            "top_company": False,
+            "nonprofit": False,
+            "country": None,
+            "dedupe_key": dedupe_key(domain, "hackernews", slug),
+            "raw_json": hit,
+        }
+
+    def fetch(self, cursor, full=False):
+        lookback_days = 3650 if full else 30
+        since = int(cursor) if cursor else int(time.time()) - lookback_days * 86400
+        seen = set()
+        rows = []
+        max_ts = since
+        for query in ('"Launch HN"', '"Show HN"'):
+            for page in range(_MAX_PAGES):
+                url = (
+                    f"{_SEARCH}?query={urllib.parse.quote(query)}&tags=story"
+                    f"&numericFilters=created_at_i>{since}"
+                    f"&hitsPerPage={_HITS_PER_PAGE}&page={page}"
+                )
+                data = _get(url)
+                for hit in data.get("hits", []):
+                    oid = hit.get("objectID")
+                    if not oid or oid in seen:
+                        continue
+                    seen.add(oid)
+                    ts = hit.get("created_at_i") or 0
+                    if ts > max_ts:
+                        max_ts = ts
+                    row = self._to_row(hit)
+                    if row:
+                        rows.append(row)
+                if page + 1 >= data.get("nbPages", 0):
+                    break
+        return FetchResult(rows=rows, cursor=str(max_ts), removed_source_ids=[])

--- a/backend/ingestion/normalize.py
+++ b/backend/ingestion/normalize.py
@@ -1,0 +1,73 @@
+"""Shared normalization helpers for source adapters.
+
+Python port of the sync-PR's normalize.ts. Every adapter maps raw source data
+into ExploreYC's canonical column names; these helpers produce the domain,
+slug, and cross-source `dedupe_key` used for read-time merge.
+"""
+
+from urllib.parse import urlparse
+import re
+import unicodedata
+
+# Hosts shared by many unrelated projects. A company whose only "website" is a
+# shared host must NOT merge with another on the same host, so we fall back to a
+# source-scoped dedupe key for these.
+SHARED_HOST_DENYLIST = {
+    "github.io", "notion.site", "vercel.app", "netlify.app", "webflow.io",
+    "wixsite.com", "substack.com", "medium.com", "gitbook.io", "herokuapp.com",
+    "pages.dev", "framer.website", "carrd.co", "bubbleapps.io", "replit.app",
+    "onrender.com", "web.app", "firebaseapp.com", "square.site", "godaddysites.com",
+}
+
+
+def norm_domain(url):
+    """Strip scheme/www/path/port -> bare lowercase host, or None if unparseable."""
+    if not url:
+        return None
+    raw = url.strip()
+    if not re.match(r"^https?://", raw, re.I):
+        raw = "https://" + raw
+    try:
+        host = urlparse(raw).hostname
+    except ValueError:
+        return None
+    if not host:
+        return None
+    host = host.lower()
+    if host.startswith("www."):
+        host = host[4:]
+    # Reject non-domains: a real company host has only [a-z0-9.-] and a dot.
+    if not host or "." not in host or not re.match(r"^[a-z0-9.-]+$", host):
+        return None
+    return host
+
+
+def _registrable_suffix(host):
+    """Last two labels of a host, e.g. 'a.github.io' -> 'github.io'."""
+    parts = host.split(".")
+    return ".".join(parts[-2:]) if len(parts) >= 2 else host
+
+
+def slugify(name):
+    """URL/id-safe slug from a display name."""
+    s = unicodedata.normalize("NFKD", name or "")
+    s = s.encode("ascii", "ignore").decode("ascii").lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
+    return s[:80]
+
+
+def dedupe_key(domain, source, source_slug):
+    """Merge key across sources: the domain when it's a real (non-shared) host,
+    else a source-scoped fallback so unrelated same-named companies never collide."""
+    if domain and _registrable_suffix(domain) not in SHARED_HOST_DENYLIST:
+        return domain
+    return f"{source}:{source_slug}"
+
+
+def country_from_locations(loc):
+    """Best-effort country from a 'City, ST, Country; ...' locations string."""
+    if not loc:
+        return None
+    first = loc.split(";")[0].strip()
+    parts = [p.strip() for p in first.split(",") if p.strip()]
+    return parts[-1] if parts else None

--- a/backend/ingestion/normalize.py
+++ b/backend/ingestion/normalize.py
@@ -10,13 +10,33 @@ import re
 import unicodedata
 
 # Hosts shared by many unrelated projects. A company whose only "website" is a
-# shared host must NOT merge with another on the same host, so we fall back to a
-# source-scoped dedupe key for these.
+# shared host must NOT merge with another on the same host (the meaningful
+# identity there is the URL path, e.g. github.com/<user>/<repo>), so we fall back
+# to a source-scoped dedupe key. Entries are registrable (last-two-label) domains.
 SHARED_HOST_DENYLIST = {
-    "github.io", "notion.site", "vercel.app", "netlify.app", "webflow.io",
-    "wixsite.com", "substack.com", "medium.com", "gitbook.io", "herokuapp.com",
-    "pages.dev", "framer.website", "carrd.co", "bubbleapps.io", "replit.app",
-    "onrender.com", "web.app", "firebaseapp.com", "square.site", "godaddysites.com",
+    # Code / project hosts (very common in Show HN links)
+    "github.com", "github.io", "githubusercontent.com", "gitlab.com", "bitbucket.org",
+    "sourceforge.net", "codeberg.org", "gitea.com", "npmjs.com", "pypi.org", "crates.io",
+    "huggingface.co", "kaggle.com", "codepen.io", "codesandbox.io", "stackblitz.com",
+    "glitch.me", "jsfiddle.net", "observablehq.com",
+    # Site builders / app-hosting platforms
+    "notion.site", "vercel.app", "netlify.app", "webflow.io", "wixsite.com",
+    "gitbook.io", "herokuapp.com", "pages.dev", "framer.website", "carrd.co",
+    "bubbleapps.io", "replit.app", "replit.com", "onrender.com", "web.app",
+    "firebaseapp.com", "square.site", "godaddysites.com", "streamlit.app", "fly.dev",
+    "railway.app", "surge.sh", "github.dev",
+    # Publishing / social / content platforms
+    "substack.com", "medium.com", "dev.to", "hashnode.dev", "blogspot.com",
+    "wordpress.com", "tumblr.com", "youtube.com", "youtu.be", "vimeo.com",
+    "twitter.com", "x.com", "reddit.com", "linkedin.com", "facebook.com",
+    "instagram.com", "threads.net", "producthunt.com", "news.ycombinator.com",
+    "arxiv.org", "t.me", "discord.gg", "discord.com", "slack.com",
+    # Docs / paste / forms / stores
+    "docs.google.com", "drive.google.com", "sites.google.com", "google.com",
+    "notion.so", "figma.com", "loom.com", "typeform.com", "airtable.com",
+    "apps.apple.com", "apple.com", "play.google.com", "gumroad.com", "itch.io",
+    # App / extension marketplaces (path is the identity, not the host)
+    "visualstudio.com", "mozilla.org", "atlassian.com", "shopify.com", "chrome.com",
 }
 
 

--- a/backend/ingestion/producthunt.py
+++ b/backend/ingestion/producthunt.py
@@ -1,0 +1,20 @@
+"""Product Hunt source adapter (STUB).
+
+Framework proof — implements the adapter contract but returns no rows yet.
+To finish: use the Product Hunt GraphQL API
+(https://api.producthunt.com/v2/api/graphql, needs a PH_TOKEN), page over
+`posts` by `postedAfter` (cursor = last posted-at), and map each post to a row
+with source='producthunt', website -> dedupe_key, tagline -> one_liner,
+topics -> industries, and to_global_id('producthunt', post_numeric_id).
+"""
+
+from ingestion.base import FetchResult
+
+
+class ProductHuntAdapter:
+    key = "producthunt"
+    display_name = "Product Hunt"
+
+    def fetch(self, cursor, full=False):
+        # TODO: fetch from the Product Hunt GraphQL API and map posts -> rows.
+        return FetchResult(rows=[], cursor=cursor, removed_source_ids=[])

--- a/backend/ingestion/registry.py
+++ b/backend/ingestion/registry.py
@@ -1,0 +1,17 @@
+"""Registry of source adapters. Add a source = add one import + entry here."""
+
+from ingestion.hackernews import HackerNewsAdapter
+from ingestion.producthunt import ProductHuntAdapter
+from ingestion.techstars import TechstarsAdapter
+
+ADAPTERS = {
+    a.key: a for a in (
+        HackerNewsAdapter(),
+        ProductHuntAdapter(),
+        TechstarsAdapter(),
+    )
+}
+
+
+def get_adapter(key):
+    return ADAPTERS.get(key)

--- a/backend/ingestion/sync_service.py
+++ b/backend/ingestion/sync_service.py
@@ -1,0 +1,66 @@
+"""Orchestrates incremental multi-source sync.
+
+For each registered adapter: read its cursor, fetch the delta, upsert rows
+(existing insert_company handles dedup on id / (source, source_id)), record the
+new cursor, and soft-remove upstream-removed rows. Embedding backfill + cache
+refresh are triggered by the caller (cron endpoint) after run_sync.
+"""
+
+import logging
+
+from ingestion import registry
+
+logger = logging.getLogger(__name__)
+
+
+def run_sync(db, sources=None, full=False):
+    """Run the given sources (default: all registered). Returns per-source summary."""
+    keys = sources if sources else list(registry.ADAPTERS.keys())
+    results = {}
+    for key in keys:
+        adapter = registry.get_adapter(key)
+        if adapter is None:
+            results[key] = {"upserted": 0, "cursor": None, "status": "error",
+                            "error": "unknown source"}
+            continue
+        try:
+            cursor = db.get_sync_cursor(key)
+            result = adapter.fetch(cursor, full=full)
+            for row in result.rows:
+                db.insert_company(row)
+            _soft_remove(db, key, result.removed_source_ids)
+            db.save_sync_state(key, result.cursor, "ok", len(result.rows))
+            results[key] = {"upserted": len(result.rows), "cursor": result.cursor,
+                            "status": "ok"}
+            logger.info("sync %s: upserted %d, cursor %s", key, len(result.rows), result.cursor)
+        except Exception as e:  # noqa: BLE001 — one bad source must not sink the rest
+            db.save_sync_state(key, None, "error", 0, str(e))
+            results[key] = {"upserted": 0, "cursor": None, "status": "error", "error": str(e)}
+            logger.error("sync %s failed: %s", key, e)
+    return results
+
+
+def _soft_remove(db, source, source_ids):
+    """Soft-delete rows whose upstream source record disappeared (never a hard delete)."""
+    if not source_ids or not hasattr(db, "mark_companies_removed"):
+        return
+    try:
+        db.mark_companies_removed(source, source_ids)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("soft-remove for %s skipped: %s", source, e)
+
+
+def embed_missing(db, limit=2000):
+    """Embed any rows (all sources) missing an embedding. No-op on SQLite."""
+    if not hasattr(db, "get_companies_for_embedding"):
+        return 0
+    from embedding_service import get_embedding_service
+    from idea_filter import get_search_text_for_embedding
+
+    missing = db.get_companies_for_embedding(only_missing=True, limit=limit)
+    if not missing:
+        return 0
+    svc = get_embedding_service()
+    texts = [get_search_text_for_embedding(db.build_company_embedding_text(c)) for c in missing]
+    vectors = svc.generate_embeddings_batch(texts)
+    return db.update_company_embeddings_batch([(c["id"], v) for c, v in zip(missing, vectors)])

--- a/backend/ingestion/techstars.py
+++ b/backend/ingestion/techstars.py
@@ -1,0 +1,20 @@
+"""Techstars source adapter (STUB).
+
+Framework proof — implements the adapter contract but returns no rows yet.
+To finish: scrape the Techstars portfolio (https://www.techstars.com/portfolio,
+which hydrates from a JSON payload), map each company to a row with
+source='techstars', website -> dedupe_key, program/batch -> batch, and
+to_global_id('techstars', native_id). No incremental cursor upstream, so a
+periodic full pull (full=True) is the expected mode.
+"""
+
+from ingestion.base import FetchResult
+
+
+class TechstarsAdapter:
+    key = "techstars"
+    display_name = "Techstars"
+
+    def fetch(self, cursor, full=False):
+        # TODO: fetch the Techstars portfolio payload and map companies -> rows.
+        return FetchResult(rows=[], cursor=cursor, removed_source_ids=[])

--- a/backend/main.py
+++ b/backend/main.py
@@ -1777,6 +1777,41 @@ async def daily_scrape(request: Request, background_tasks: BackgroundTasks):
     }
 
 
+async def _run_source_sync(full: bool = False):
+    """Background task: pull new companies from all registered sources, embed, refresh."""
+    from ingestion import sync_service
+    try:
+        db.backfill_dedupe_keys()
+        results = sync_service.run_sync(db, full=full)
+        embedded = sync_service.embed_missing(db)
+        company_cache.refresh(db)
+        logger.info(f"Source sync completed: {results}, embedded {embedded}")
+        return {"results": results, "embedded": embedded}
+    except Exception as e:
+        logger.error(f"Source sync error: {e}")
+        raise
+
+
+@app.post("/api/cron/sync-sources")
+async def cron_sync_sources(request: Request, background_tasks: BackgroundTasks):
+    """Pull new companies from non-YC sources (Hacker News, ...), backfill dedupe_key
+    + embeddings, and refresh the cache. ?full=1 forces a full backfill; ?sync=1 waits."""
+    _verify_cron_secret(request)
+    full = request.query_params.get("full", "").lower() in ("1", "true", "yes")
+    sync_mode = request.query_params.get("sync", "").lower() in ("1", "true", "yes")
+
+    if sync_mode:
+        result = await _run_source_sync(full=full)
+        return {"success": True, "status": "completed", **result}
+
+    background_tasks.add_task(_run_source_sync, full)
+    return {
+        "success": True,
+        "status": "started",
+        "message": "Source sync started in background. Check logs for completion.",
+    }
+
+
 @app.post("/api/cron/update-hiring-board")
 async def update_hiring_board_cron(request: Request, background_tasks: BackgroundTasks):
     """Update hiring board data from WorkAtAStartup API (triggered by daily cron)"""

--- a/backend/main.py
+++ b/backend/main.py
@@ -282,6 +282,7 @@ class CompanyFilter(BaseModel):
     search: Optional[str] = None
     top_company: Optional[bool] = None
     source: Optional[str] = None  # None -> YC only, 'all' -> every source, or a source key
+    merged: bool = False  # collapse same-domain rows across sources into one card
 
 
 # Background task storage
@@ -558,6 +559,7 @@ async def get_companies(filters: CompanyFilter):
         search=filters.search,
         top_company=filters.top_company,
         source=filters.source,
+        merged=filters.merged,
     )
 
     total = company_cache.count_companies(
@@ -568,6 +570,7 @@ async def get_companies(filters: CompanyFilter):
         search=filters.search,
         top_company=filters.top_company,
         source=filters.source,
+        merged=filters.merged,
     )
 
     return {

--- a/backend/main.py
+++ b/backend/main.py
@@ -611,6 +611,31 @@ async def get_company_by_slug(slug: str):
     return company
 
 
+class SimilarQuery(BaseModel):
+    query: str
+    limit: int = 12
+
+
+@app.post("/api/companies/similar")
+async def companies_similar(body: SimilarQuery):
+    """All-source semantic search: return companies across every source most similar
+    to a free-text query, deduped by domain. Vector search spans the full corpus
+    (YC + Hacker News + a16z + ...), unlike the YC-scoped hero idea-validator."""
+    if not body.query or not body.query.strip():
+        raise HTTPException(status_code=400, detail="query is required")
+    if not hasattr(db, "find_similar_companies_by_embedding"):
+        raise HTTPException(status_code=503, detail="Semantic search unavailable (no vector DB)")
+    if db.count_companies_with_embeddings() == 0:
+        raise HTTPException(status_code=503, detail="Company embeddings not yet generated")
+    search_text = get_search_text_for_embedding(body.query, min_length=3)
+    embedding = get_embedding_service().generate_embedding_for_idea(search_text)
+    # source_filter=None -> all sources, deduped by dedupe_key
+    results = db.find_similar_companies_by_embedding(
+        embedding, limit=min(body.limit, 50), min_similarity=0.3
+    )
+    return {"companies": results, "total": len(results)}
+
+
 # Allowed domains for logo proxy (YC and common CDNs)
 _LOGO_PROXY_ALLOWED = (
     "yc.co", "ycombinator.com", "bookface-images.s3.amazonaws.com", "s3.amazonaws.com",
@@ -964,13 +989,14 @@ async def validate_startup_idea(request: IdeaValidationRequest, request_obj: Req
             similar_companies = db.find_similar_companies_by_embedding(
                 embedding=idea_embedding,
                 limit=max_similar,
-                min_similarity=0.32  # Lower threshold to catch pasted descriptions & near-matches
+                min_similarity=0.32,  # Lower threshold to catch pasted descriptions & near-matches
+                source_filter="yc",   # Hero verdict is YC-framed (market-size % = % of YC companies)
             )
             logger.info(f"Found {len(similar_companies)} similar companies (embedding)")
 
             # Fallback: when embedding returns nothing, try text search (catches pasted company descriptions)
             if len(similar_companies) == 0 and hasattr(db, 'find_companies_by_text_search'):
-                text_matches = db.find_companies_by_text_search(idea_text, limit=max_similar)
+                text_matches = db.find_companies_by_text_search(idea_text, limit=max_similar, source_filter="yc")
                 if text_matches:
                     similar_companies = text_matches
                     logger.info(f"Fallback text search found {len(similar_companies)} companies")
@@ -1072,10 +1098,11 @@ async def hero_answer(req: HeroAnswerRequest, request: Request):
     # transient DB error) returns a handled 503 — which passes through the CORS
     # middleware — instead of a raw 500 that arrives at the browser without CORS
     # headers (surfacing as a confusing cross-origin error).
+    # source_filter="yc": the hero verdict is YC-framed (market-size % = % of YC).
     try:
         search_text = get_search_text_for_embedding(idea)
         embedding = get_embedding_service().generate_embedding_for_idea(search_text)
-        similar = db.find_similar_companies_by_embedding(embedding, limit=12, min_similarity=0.32)
+        similar = db.find_similar_companies_by_embedding(embedding, limit=12, min_similarity=0.32, source_filter="yc")
     except HTTPException:
         raise
     except Exception as e:
@@ -1180,12 +1207,13 @@ async def gamified_startup_prediction(request: GamifiedPredictionRequest, reques
             matched_companies = db.find_similar_companies_by_embedding(
                 embedding=idea_embedding,
                 limit=max_matches,
-                min_similarity=0.32
+                min_similarity=0.32,
+                source_filter="yc",   # gamified predictor scores against YC portfolio
             )
 
             # Fallback to text search if needed
             if len(matched_companies) == 0 and hasattr(db, 'find_companies_by_text_search'):
-                matched_companies = db.find_companies_by_text_search(idea_text, limit=max_matches)
+                matched_companies = db.find_companies_by_text_search(idea_text, limit=max_matches, source_filter="yc")
 
         except Exception as e:
             logger.error(f"Similarity search failed: {e}")

--- a/backend/sources.py
+++ b/backend/sources.py
@@ -25,6 +25,9 @@ from typing import Dict
 SOURCES: Dict[str, Dict[str, str]] = {
     "yc": {"key": "yc", "display_name": "Y Combinator"},
     "a16z": {"key": "a16z", "display_name": "Andreessen Horowitz (a16z)"},
+    "hackernews": {"key": "hackernews", "display_name": "Hacker News"},
+    "producthunt": {"key": "producthunt", "display_name": "Product Hunt"},
+    "techstars": {"key": "techstars", "display_name": "Techstars"},
 }
 
 # Default source for existing/unspecified rows (backward compatibility).
@@ -35,6 +38,9 @@ DEFAULT_SOURCE = "yc"
 SOURCE_ID_OFFSETS: Dict[str, int] = {
     "yc": 0,
     "a16z": 2_000_000_000,
+    "hackernews": 3_000_000_000,
+    "producthunt": 4_000_000_000,
+    "techstars": 5_000_000_000,
 }
 
 # Width of each source's reserved id block. The precondition for correctness is

--- a/backend/test_embedding_all_sources.py
+++ b/backend/test_embedding_all_sources.py
@@ -57,7 +57,9 @@ def test_hero_callsites_pass_source_filter_yc():
     src = MAIN.read_text()
     # The 5 hero/validator paths (3 embedding + 2 text-search fallbacks) must all
     # pin source_filter="yc"; the all-source endpoint (below) must NOT.
-    assert src.count('source_filter="yc"') == 5, "expected exactly 5 YC-scoped hero calls"
+    # Count code lines only — comments may mention the kwarg without being a call.
+    code = "\n".join(l for l in src.splitlines() if not l.strip().startswith("#"))
+    assert code.count('source_filter="yc"') == 5, "expected exactly 5 YC-scoped hero calls"
 
 
 def test_all_source_endpoint_is_not_yc_scoped():

--- a/backend/test_embedding_all_sources.py
+++ b/backend/test_embedding_all_sources.py
@@ -1,0 +1,68 @@
+"""Regression guards for all-source embeddings / vector search.
+
+These are source-level assertions (not live-DB) because pgvector isn't available
+in the unit-test environment. They lock in the two invariants that matter:
+
+  1. embedding generation + all-source retrieval are NOT restricted to source='yc'
+  2. the YC-denominated market-size metric IS still restricted to source='yc'
+
+so a future edit can't silently re-scope either one and re-trigger the
+market-size over-counting bug.
+"""
+
+import re
+from pathlib import Path
+
+DB_PG = Path(__file__).parent / "database_postgres.py"
+MAIN = Path(__file__).parent / "main.py"
+
+
+def _method_body(src, name):
+    """Return the text of a `def name(...)` block up to the next top-level def."""
+    lines = src.splitlines()
+    start = next(i for i, l in enumerate(lines) if re.match(rf"\s*(async )?def {name}\b", l))
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    body = [lines[start]]
+    for l in lines[start + 1:]:
+        at_top = l.strip() and (len(l) - len(l.lstrip())) <= indent
+        if at_top and re.match(r"\s*(@app|(async )?def )", l):
+            break
+        body.append(l)
+    return "\n".join(body)
+
+
+def test_generation_covers_all_sources():
+    src = DB_PG.read_text()
+    gen = _method_body(src, "get_companies_for_embedding")
+    assert "source = 'yc'" not in gen, "embedding generation must not be YC-only"
+    without = _method_body(src, "get_companies_without_embeddings")
+    assert "source = 'yc'" not in without
+
+
+def test_retrieval_has_source_filter_and_dedup():
+    src = DB_PG.read_text()
+    body = _method_body(src, "find_similar_companies_by_embedding")
+    assert "source_filter" in body, "retrieval must accept a source_filter"
+    assert "AND source = %s" in body, "YC-scoped branch must filter by source"
+    assert "DISTINCT ON" in body, "all-source branch must dedupe by dedupe_key"
+
+
+def test_market_size_denominator_stays_yc_only():
+    src = DB_PG.read_text()
+    yc_count = _method_body(src, "get_yc_company_count")
+    assert "WHERE source = 'yc'" in yc_count, "market-size denominator must stay YC-only"
+
+
+def test_hero_callsites_pass_source_filter_yc():
+    src = MAIN.read_text()
+    # The 5 hero/validator paths (3 embedding + 2 text-search fallbacks) must all
+    # pin source_filter="yc"; the all-source endpoint (below) must NOT.
+    assert src.count('source_filter="yc"') == 5, "expected exactly 5 YC-scoped hero calls"
+
+
+def test_all_source_endpoint_is_not_yc_scoped():
+    src = MAIN.read_text()
+    assert '@app.post("/api/companies/similar")' in src
+    body = _method_body(src, "companies_similar")
+    assert "find_similar_companies_by_embedding" in body
+    assert 'source_filter="yc"' not in body, "all-source semantic search must not be YC-scoped"

--- a/backend/test_hackernews_adapter.py
+++ b/backend/test_hackernews_adapter.py
@@ -1,0 +1,64 @@
+from ingestion.hackernews import parse_title, HackerNewsAdapter
+from ingestion import registry
+
+
+def test_parse_launch_with_yc_batch():
+    r = parse_title("Launch HN: Acme (YC S26) – AI for dentists")
+    assert r["name"] == "Acme"
+    assert r["batch"] == "S26"
+    assert "dentists" in r["blurb"]
+
+
+def test_parse_show_hn_no_batch():
+    r = parse_title("Show HN: Bpar – a faster bundler")
+    assert r["name"] == "Bpar"
+    assert r["batch"] is None
+    assert r["blurb"] == "a faster bundler"
+
+
+def test_parse_hyphen_and_trailing_paren():
+    r = parse_title("Launch HN: Nimbus (YC W24) - weather API (open source)")
+    assert r["name"] == "Nimbus"
+    assert r["batch"] == "W24"
+
+
+def _hit(**kw):
+    base = {
+        "objectID": "42", "title": "Launch HN: Acme (YC S26) – x",
+        "url": "https://acme.com", "created_at_i": 1700000000,
+        "author": "pg", "points": 10, "num_comments": 3, "story_text": None,
+    }
+    base.update(kw)
+    return base
+
+
+def test_to_row_sets_source_and_key():
+    row = HackerNewsAdapter()._to_row(_hit())
+    assert row["source"] == "hackernews"
+    assert row["source_id"] == "42"
+    assert row["id"] == 3_000_000_042
+    assert row["dedupe_key"] == "acme.com"
+    assert row["batch"] == "S26"
+    assert row["isHiring"] is False
+    assert row["tags"] == ["Launch HN"]
+    assert row["source_url"].endswith("id=42")
+
+
+def test_to_row_drops_noise_without_domain_or_batch():
+    # A Show HN with no URL and no YC batch is not a company.
+    row = HackerNewsAdapter()._to_row(_hit(
+        title="Show HN: My weekend project", url=None, objectID="99",
+    ))
+    assert row is None
+
+
+def test_to_row_shared_host_falls_back_to_source_slug():
+    row = HackerNewsAdapter()._to_row(_hit(
+        title="Show HN: MyProj – a tool", url="https://myproj.github.io", objectID="7",
+    ))
+    assert row["dedupe_key"] == "hackernews:myproj"
+
+
+def test_registry_has_all_adapters():
+    for k in ("hackernews", "producthunt", "techstars"):
+        assert registry.get_adapter(k) is not None

--- a/backend/test_ingestion_normalize.py
+++ b/backend/test_ingestion_normalize.py
@@ -29,6 +29,21 @@ def test_dedupe_key_shared_host_falls_back_to_source_slug():
     assert dedupe_key("myproj.github.io", "hackernews", "myproj") == "hackernews:myproj"
 
 
+def test_dedupe_key_code_hosts_do_not_mega_merge():
+    # Regression: Show HN posts linking github.com/<user>/<repo> must NOT collapse
+    # into one card (the path is the identity, not the domain).
+    assert dedupe_key("github.com", "hackernews", "trace") == "hackernews:trace"
+    assert dedupe_key("github.com", "hackernews", "comcent-ce") == "hackernews:comcent-ce"
+    # But a real product domain still merges on domain.
+    assert dedupe_key("diagraw.com", "hackernews", "diagraw") == "diagraw.com"
+
+
+def test_dedupe_key_platform_subdomains_denylisted_via_registrable_suffix():
+    # play.google.com / apps.apple.com collapse to google.com / apple.com -> denylisted.
+    assert dedupe_key(norm_domain("https://play.google.com/store/apps/x"),
+                      "hackernews", "x") == "hackernews:x"
+
+
 def test_country_from_locations():
     assert country_from_locations("San Francisco, CA, USA; Remote") == "USA"
     assert country_from_locations(None) is None

--- a/backend/test_ingestion_normalize.py
+++ b/backend/test_ingestion_normalize.py
@@ -1,0 +1,35 @@
+from ingestion.normalize import (
+    norm_domain, slugify, dedupe_key, country_from_locations, SHARED_HOST_DENYLIST,
+)
+
+
+def test_norm_domain_strips_scheme_www_path():
+    assert norm_domain("https://www.Acme.com/careers") == "acme.com"
+    assert norm_domain("acme.com") == "acme.com"
+    assert norm_domain("http://sub.acme.co.uk:8080/x") == "sub.acme.co.uk"
+    assert norm_domain(None) is None
+    assert norm_domain("") is None
+    assert norm_domain("not a url with spaces") is None
+
+
+def test_slugify():
+    assert slugify("Acme, Inc.") == "acme-inc"
+    assert slugify("  Héllo World  ") == "hello-world"
+    assert slugify("") == ""
+
+
+def test_dedupe_key_prefers_domain_else_source_slug():
+    assert dedupe_key("acme.com", "yc", "acme") == "acme.com"
+    assert dedupe_key(None, "hackernews", "acme") == "hackernews:acme"
+
+
+def test_dedupe_key_shared_host_falls_back_to_source_slug():
+    # A shared host must not merge unrelated companies.
+    assert "github.io" in SHARED_HOST_DENYLIST
+    assert dedupe_key("myproj.github.io", "hackernews", "myproj") == "hackernews:myproj"
+
+
+def test_country_from_locations():
+    assert country_from_locations("San Francisco, CA, USA; Remote") == "USA"
+    assert country_from_locations(None) is None
+    assert country_from_locations("") is None

--- a/backend/test_merge_grouping.py
+++ b/backend/test_merge_grouping.py
@@ -1,0 +1,79 @@
+from company_cache import CompanyCache
+
+
+def _c(**kw):
+    base = {
+        "id": 0, "source": "yc", "dedupe_key": "acme.com", "name": "Acme",
+        "one_liner": None, "is_hiring": False, "created_at": "2026-01-01",
+        "small_logo_thumb_url": None, "source_url": None,
+    }
+    base.update(kw)
+    return base
+
+
+def test_merge_collapses_same_domain_with_badges():
+    cache = CompanyCache()
+    cache._build_cache([
+        _c(id=1, source="yc", one_liner="YC one liner", source_url="yc/acme"),
+        _c(id=3_000_000_001, source="hackernews", one_liner=None,
+           is_hiring=True, source_url="hn/1"),
+    ])
+    rows = cache.get_companies(merged=True, source="all")
+    acme = [r for r in rows if r["dedupe_key"] == "acme.com"]
+    assert len(acme) == 1
+    assert acme[0]["source"] == "yc"                     # yc wins primary
+    assert acme[0]["is_hiring"] is True                  # OR across the group
+    assert acme[0]["one_liner"] == "YC one liner"        # primary keeps its value
+    assert {s["key"] for s in acme[0]["merged_sources"]} == {"yc", "hackernews"}
+
+
+def test_merge_gap_fills_missing_fields_from_other_source():
+    cache = CompanyCache()
+    cache._build_cache([
+        _c(id=1, source="yc", one_liner=None, small_logo_thumb_url=None),
+        _c(id=3_000_000_001, source="hackernews",
+           one_liner="HN blurb", small_logo_thumb_url="logo.png"),
+    ])
+    row = cache.get_companies(merged=True, source="all")[0]
+    assert row["source"] == "yc"                          # primary is still YC
+    assert row["one_liner"] == "HN blurb"                 # gap-filled from HN
+    assert row["small_logo_thumb_url"] == "logo.png"
+
+
+def test_merged_false_keeps_rows_separate():
+    cache = CompanyCache()
+    cache._build_cache([
+        _c(id=1, source="yc"),
+        _c(id=3_000_000_001, source="hackernews"),
+    ])
+    assert len(cache.get_companies(merged=False, source="all")) == 2
+
+
+def test_default_view_unaffected_by_merge_code():
+    # source=None must remain YC-only whether or not merged is requested.
+    cache = CompanyCache()
+    cache._build_cache([
+        _c(id=1, source="yc"),
+        _c(id=3_000_000_001, source="hackernews", dedupe_key="other.com"),
+    ])
+    assert len(cache.get_companies(merged=False)) == 1
+    assert len(cache.get_companies(merged=True)) == 1
+
+
+def test_rows_without_dedupe_key_stand_alone():
+    cache = CompanyCache()
+    cache._build_cache([
+        _c(id=1, source="yc", dedupe_key=None),
+        _c(id=2, source="yc", dedupe_key=None),
+    ])
+    assert len(cache.get_companies(merged=True, source="all")) == 2
+
+
+def test_count_companies_merged():
+    cache = CompanyCache()
+    cache._build_cache([
+        _c(id=1, source="yc", source_url="yc/acme"),
+        _c(id=3_000_000_001, source="hackernews", source_url="hn/1"),
+    ])
+    assert cache.count_companies(merged=True, source="all") == 1
+    assert cache.count_companies(merged=False, source="all") == 2

--- a/backend/test_sources_registry.py
+++ b/backend/test_sources_registry.py
@@ -1,0 +1,18 @@
+from sources import SOURCES, SOURCE_ID_OFFSETS, to_global_id, from_global_id
+
+
+def test_new_sources_registered():
+    for k in ("hackernews", "producthunt", "techstars"):
+        assert k in SOURCES
+        assert "display_name" in SOURCES[k]
+        assert k in SOURCE_ID_OFFSETS
+
+
+def test_global_id_roundtrip_for_new_sources():
+    assert to_global_id("hackernews", 42) == 3_000_000_042
+    assert to_global_id("producthunt", 7) == 4_000_000_007
+    assert from_global_id(3_000_000_042) == ("hackernews", 42)
+    assert from_global_id(5_000_000_001) == ("techstars", 1)
+    # Existing sources unchanged.
+    assert to_global_id("yc", 12345) == 12345
+    assert to_global_id("a16z", 371262) == 2_000_371_262

--- a/backend/test_sync_service.py
+++ b/backend/test_sync_service.py
@@ -1,0 +1,65 @@
+from database import Database
+from ingestion import sync_service
+from ingestion.base import FetchResult
+
+
+class FakeAdapter:
+    key = "hackernews"
+    display_name = "HN"
+
+    def __init__(self, rows, cursor):
+        self._rows = rows
+        self._cursor = cursor
+        self.seen_cursor = "unset"
+
+    def fetch(self, cursor, full=False):
+        self.seen_cursor = cursor
+        return FetchResult(rows=self._rows, cursor=self._cursor, removed_source_ids=[])
+
+
+class BoomAdapter:
+    key = "hackernews"
+    display_name = "HN"
+
+    def fetch(self, cursor, full=False):
+        raise RuntimeError("network down")
+
+
+def _row(**kw):
+    base = {
+        "id": 3_000_000_001, "source": "hackernews", "source_id": "1",
+        "name": "Acme", "slug": "acme", "website": "https://acme.com",
+        "dedupe_key": "acme.com", "isHiring": False, "raw_json": {"x": 1},
+        "tags": ["Launch HN"], "industries": [], "regions": [],
+    }
+    base.update(kw)
+    return base
+
+
+def test_run_sync_upserts_and_saves_cursor(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "t.db"))
+    monkeypatch.setitem(sync_service.registry.ADAPTERS, "hackernews", FakeAdapter([_row()], "123"))
+    out = sync_service.run_sync(db, sources=["hackernews"])
+    assert out["hackernews"]["status"] == "ok"
+    assert out["hackernews"]["upserted"] == 1
+    assert db.get_sync_cursor("hackernews") == "123"
+    assert db.get_company_by_id(3_000_000_001)["dedupe_key"] == "acme.com"
+
+
+def test_run_sync_passes_stored_cursor_next_time(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "t.db"))
+    a1 = FakeAdapter([_row()], "123")
+    monkeypatch.setitem(sync_service.registry.ADAPTERS, "hackernews", a1)
+    sync_service.run_sync(db, sources=["hackernews"])
+    a2 = FakeAdapter([], "123")
+    monkeypatch.setitem(sync_service.registry.ADAPTERS, "hackernews", a2)
+    sync_service.run_sync(db, sources=["hackernews"])
+    assert a2.seen_cursor == "123"  # second run reads the cursor saved by the first
+
+
+def test_run_sync_isolates_source_failure(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "t.db"))
+    monkeypatch.setitem(sync_service.registry.ADAPTERS, "hackernews", BoomAdapter())
+    out = sync_service.run_sync(db, sources=["hackernews"])
+    assert out["hackernews"]["status"] == "error"
+    assert "network down" in out["hackernews"]["error"]

--- a/backend/test_sync_state.py
+++ b/backend/test_sync_state.py
@@ -1,0 +1,44 @@
+from database import Database
+
+
+def test_sync_cursor_roundtrip(tmp_path):
+    db = Database(str(tmp_path / "t.db"))
+    assert db.get_sync_cursor("hackernews") is None
+    db.save_sync_state("hackernews", "1700000000", "ok", 5)
+    assert db.get_sync_cursor("hackernews") == "1700000000"
+    # Upsert (not duplicate insert) on a second run.
+    db.save_sync_state("hackernews", "1700000500", "ok", 3)
+    assert db.get_sync_cursor("hackernews") == "1700000500"
+
+
+def test_save_sync_state_error(tmp_path):
+    db = Database(str(tmp_path / "t.db"))
+    db.save_sync_state("producthunt", None, "error", 0, "boom")
+    assert db.get_sync_cursor("producthunt") is None
+
+
+def test_backfill_dedupe_keys(tmp_path):
+    db = Database(str(tmp_path / "t.db"))
+    db.insert_company({
+        "id": 1, "source": "yc", "slug": "acme", "name": "Acme",
+        "website": "https://www.acme.com/careers", "isHiring": False,
+    })
+    db.insert_company({
+        "id": 2, "source": "hackernews", "slug": "noweb", "name": "NoWeb",
+        "website": None, "isHiring": False,
+    })
+    n = db.backfill_dedupe_keys()
+    assert n == 2
+    assert db.get_company_by_id(1)["dedupe_key"] == "acme.com"
+    assert db.get_company_by_id(2)["dedupe_key"] == "hackernews:noweb"
+    # Idempotent: nothing left to backfill.
+    assert db.backfill_dedupe_keys() == 0
+
+
+def test_insert_company_persists_dedupe_key(tmp_path):
+    db = Database(str(tmp_path / "t.db"))
+    db.insert_company({
+        "id": 3, "source": "hackernews", "slug": "acme", "name": "Acme",
+        "website": "https://acme.com", "dedupe_key": "acme.com", "isHiring": True,
+    })
+    assert db.get_company_by_id(3)["dedupe_key"] == "acme.com"

--- a/docs/superpowers/plans/2026-07-11-multi-source-company-sync.md
+++ b/docs/superpowers/plans/2026-07-11-multi-source-company-sync.md
@@ -1,0 +1,753 @@
+# Multi-source Company Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend ExploreYC to ingest companies from new sources (Hacker News now; Product Hunt / Techstars stubbed), merge same-company rows on domain at read time, and make vector search + embeddings cover all sources — meshing with the existing Python ingestion, schema, and source-aware UI without data loss.
+
+**Architecture:** A native Python source-adapter framework (`backend/ingestion/`) reuses the existing `to_global_id` id-block scheme, `insert_company` upsert, and cache refresh. A `dedupe_key` column (normalized domain, else `source:slug`) is added to every row; "merge" is a read-time grouping in `company_cache`, opt-in via a `merged` flag, so default YC-only views and all `WHERE source='yc'` analytics stay untouched. Embedding generation + similarity retrieval drop their YC-only filter (retrieval deduped by `dedupe_key`), while the hero idea-validator keeps a YC-scoped path so its market-size % / "N YC companies overlap" verdict is unchanged.
+
+**Tech Stack:** FastAPI (Python 3.11), psycopg2 + SQLite, pgvector (HNSW), React 19 + Vite + TS + Tailwind. No new runtime deps.
+
+## Global Constraints
+
+- **No data loss / no destructive migration.** Only additive DDL (`ADD COLUMN`, new tables, new indexes). Every source keeps its own disjoint 1e9 id block; `insert_company` upserts `ON CONFLICT (id)` so no source can overwrite another's row. Upstream removals are soft-deletes only.
+- **Default view unchanged.** `CompanyFilter.source is None → YC only`. Merge is opt-in via a new `merged: bool = False`.
+- **Market-size % / crowding stays YC-denominated.** `get_yc_company_count()` and `hero_service.build_verdict` semantics are byte-for-byte unchanged; the hero passes `source_filter='yc'` to similarity search.
+- **Column names are the existing ones:** `one_liner`, `long_description`, `all_locations`, `small_logo_thumb_url`, `team_size`, `batch`, `status`, `industry`, `subindustry`, `stage`, `country`; `tags`/`regions`/`industries` are JSON **strings**. `is_hiring` is read by `insert_company` from the key `isHiring`.
+- **Both DBs.** Every schema/query change lands in both `backend/database_postgres.py` (Postgres) and `backend/database.py` (SQLite). Vector search is Postgres-only, as today.
+- **Source id offsets:** yc=0, a16z=2e9, hackernews=3e9, producthunt=4e9, techstars=5e9 (block width 1e9).
+- **Commit after every task.** PR-based workflow; branch is `feat/db-feature-requests`. Never push to master.
+
+---
+
+### Task 1: Normalization helpers
+
+**Files:**
+- Create: `backend/ingestion/__init__.py` (empty)
+- Create: `backend/ingestion/normalize.py`
+- Test: `backend/test_ingestion_normalize.py`
+
+**Interfaces:**
+- Produces:
+  - `norm_domain(url: str | None) -> str | None`
+  - `slugify(name: str) -> str`
+  - `dedupe_key(domain: str | None, source: str, source_slug: str) -> str`
+  - `country_from_locations(loc: str | None) -> str | None`
+  - `SHARED_HOST_DENYLIST: set[str]`
+
+- [ ] **Step 1: Write the failing test** — `backend/test_ingestion_normalize.py`
+
+```python
+from ingestion.normalize import norm_domain, slugify, dedupe_key, country_from_locations
+
+def test_norm_domain_strips_scheme_www_path():
+    assert norm_domain("https://www.Acme.com/careers") == "acme.com"
+    assert norm_domain("acme.com") == "acme.com"
+    assert norm_domain("http://sub.acme.co.uk:8080/x") == "sub.acme.co.uk"
+    assert norm_domain(None) is None
+    assert norm_domain("not a url") is None
+
+def test_slugify():
+    assert slugify("Acme, Inc.") == "acme-inc"
+    assert slugify("  Héllo World  ") == "hello-world"
+
+def test_dedupe_key_prefers_domain_else_source_slug():
+    assert dedupe_key("acme.com", "yc", "acme") == "acme.com"
+    assert dedupe_key(None, "hackernews", "acme") == "hackernews:acme"
+
+def test_dedupe_key_shared_host_falls_back_to_source_slug():
+    # A shared host must not merge unrelated companies.
+    assert dedupe_key("myproj.github.io", "hackernews", "myproj") == "hackernews:myproj"
+
+def test_country_from_locations():
+    assert country_from_locations("San Francisco, CA, USA; Remote") == "USA"
+    assert country_from_locations(None) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails** — `cd backend && python -m pytest test_ingestion_normalize.py -v` → FAIL (module missing)
+
+- [ ] **Step 3: Implement** — `backend/ingestion/normalize.py`
+
+```python
+"""Shared normalization for source adapters (Python port of the sync PR helpers)."""
+from urllib.parse import urlparse
+import re
+import unicodedata
+
+# Hosts shared by many unrelated projects — never merge companies on these.
+SHARED_HOST_DENYLIST = {
+    "github.io", "notion.site", "vercel.app", "netlify.app", "webflow.io",
+    "wixsite.com", "substack.com", "medium.com", "gitbook.io", "herokuapp.com",
+    "pages.dev", "framer.website", "carrd.co", "bubbleapps.io",
+}
+
+
+def norm_domain(url):
+    """Bare lowercase host: strip scheme/www/path/port. None if unparseable."""
+    if not url:
+        return None
+    raw = url.strip()
+    if not re.match(r"^https?://", raw, re.I):
+        raw = "https://" + raw
+    try:
+        host = urlparse(raw).hostname
+    except ValueError:
+        return None
+    if not host:
+        return None
+    host = host.lower()
+    if host.startswith("www."):
+        host = host[4:]
+    return host or None
+
+
+def _registrable_suffix(host):
+    """Last two labels, e.g. 'a.github.io' -> 'github.io' (denylist check)."""
+    parts = host.split(".")
+    return ".".join(parts[-2:]) if len(parts) >= 2 else host
+
+
+def slugify(name):
+    s = unicodedata.normalize("NFKD", name or "")
+    s = s.encode("ascii", "ignore").decode("ascii").lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
+    return s[:80]
+
+
+def dedupe_key(domain, source, source_slug):
+    """Domain when it's a real (non-shared) host, else source-scoped slug."""
+    if domain and _registrable_suffix(domain) not in SHARED_HOST_DENYLIST:
+        return domain
+    return f"{source}:{source_slug}"
+
+
+def country_from_locations(loc):
+    if not loc:
+        return None
+    first = loc.split(";")[0].strip()
+    parts = [p.strip() for p in first.split(",") if p.strip()]
+    return parts[-1] if parts else None
+```
+
+- [ ] **Step 4: Run tests** — `python -m pytest test_ingestion_normalize.py -v` → PASS
+- [ ] **Step 5: Commit** — `git add backend/ingestion/__init__.py backend/ingestion/normalize.py backend/test_ingestion_normalize.py && git commit -m "feat(sync): shared normalization helpers for source adapters"`
+
+---
+
+### Task 2: Schema — dedupe_key, sync_state, DB methods (both DBs)
+
+**Files:**
+- Create: `supabase/migrations/20260711130000_multi_source_sync.sql`
+- Modify: `backend/database.py` (SQLite schema + insert + new methods)
+- Modify: `backend/database_postgres.py` (insert dedupe_key + new methods)
+- Test: `backend/test_sync_state.py`
+
+**Interfaces:**
+- Produces on both DB classes:
+  - `get_sync_cursor(source: str) -> str | None`
+  - `save_sync_state(source, cursor, status, records_upserted, error=None) -> None`
+  - `set_dedupe_key(company_id: int, key: str) -> None`
+  - `backfill_dedupe_keys() -> int` (fills rows where `dedupe_key IS NULL`)
+  - `insert_company(...)` now persists `company.get("dedupe_key")`.
+
+- [ ] **Step 1: Postgres migration** — `supabase/migrations/20260711130000_multi_source_sync.sql`
+
+```sql
+-- Multi-source sync: dedupe_key merge column + per-source cursor. Additive only.
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS dedupe_key TEXT;
+CREATE INDEX IF NOT EXISTS idx_companies_dedupe_key
+  ON companies (dedupe_key) WHERE dedupe_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS sync_state (
+  source           TEXT PRIMARY KEY,
+  last_run_at      TIMESTAMPTZ,
+  last_cursor      TEXT,
+  last_status      TEXT,
+  records_upserted INTEGER DEFAULT 0,
+  error            TEXT,
+  updated_at       TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+- [ ] **Step 2: SQLite parity** — in `backend/database.py`, add to the `companies` CREATE (or as `ALTER TABLE ADD COLUMN` in the migration block) a `dedupe_key TEXT` column, an index `CREATE INDEX IF NOT EXISTS idx_dedupe_key ON companies(dedupe_key)`, and:
+
+```sql
+CREATE TABLE IF NOT EXISTS sync_state (
+  source TEXT PRIMARY KEY, last_run_at TEXT, last_cursor TEXT,
+  last_status TEXT, records_upserted INTEGER DEFAULT 0, error TEXT, updated_at TEXT
+);
+```
+Use the existing `ALTER TABLE ... ADD COLUMN` idempotent pattern already in `database.py` for `dedupe_key` so existing local DBs upgrade in place.
+
+- [ ] **Step 3: Wire `dedupe_key` into `insert_company` + `bulk_insert_companies`** (both DBs). Add `dedupe_key` to the column list, the `VALUES` params (`company.get("dedupe_key")`), and the `ON CONFLICT DO UPDATE SET dedupe_key = COALESCE(EXCLUDED.dedupe_key, companies.dedupe_key)`.
+
+- [ ] **Step 4: Add sync_state + dedupe methods** to both DB classes. Postgres example:
+
+```python
+def get_sync_cursor(self, source: str):
+    with self.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT last_cursor FROM sync_state WHERE source = %s", (source,))
+            row = cur.fetchone()
+            return row[0] if row else None
+
+def save_sync_state(self, source, cursor, status, records_upserted, error=None):
+    with self.get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("""
+                INSERT INTO sync_state (source, last_run_at, last_cursor, last_status, records_upserted, error, updated_at)
+                VALUES (%s, NOW(), %s, %s, %s, %s, NOW())
+                ON CONFLICT (source) DO UPDATE SET
+                    last_run_at = NOW(), last_cursor = EXCLUDED.last_cursor,
+                    last_status = EXCLUDED.last_status, records_upserted = EXCLUDED.records_upserted,
+                    error = EXCLUDED.error, updated_at = NOW()
+            """, (source, cursor, status, records_upserted, error))
+            conn.commit()
+
+def backfill_dedupe_keys(self):
+    from ingestion.normalize import norm_domain, dedupe_key
+    with self.get_connection() as conn:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute("SELECT id, source, slug, website FROM companies WHERE dedupe_key IS NULL")
+            rows = cur.fetchall()
+        with conn.cursor() as cur:
+            for r in rows:
+                key = dedupe_key(norm_domain(r["website"]), r["source"] or "yc", r["slug"] or str(r["id"]))
+                cur.execute("UPDATE companies SET dedupe_key = %s WHERE id = %s", (key, r["id"]))
+            conn.commit()
+    return len(rows)
+```
+(SQLite: same logic, `?` placeholders, `sqlite3.Row`.)
+
+- [ ] **Step 5: Test (SQLite)** — `backend/test_sync_state.py`
+
+```python
+from database import Database  # SQLite impl; adjust import to the project's class name
+
+def test_sync_cursor_roundtrip(tmp_path):
+    db = Database(str(tmp_path / "t.db"))
+    assert db.get_sync_cursor("hackernews") is None
+    db.save_sync_state("hackernews", "1700000000", "ok", 5)
+    assert db.get_sync_cursor("hackernews") == "1700000000"
+
+def test_backfill_dedupe_keys(tmp_path):
+    db = Database(str(tmp_path / "t.db"))
+    db.insert_company({"id": 1, "source": "yc", "slug": "acme", "name": "Acme",
+                       "website": "https://acme.com", "isHiring": False})
+    n = db.backfill_dedupe_keys()
+    assert n >= 1
+    assert db.get_company_by_id(1)["dedupe_key"] == "acme.com"
+```
+
+- [ ] **Step 6: Run** — `python -m pytest test_sync_state.py -v` → PASS
+- [ ] **Step 7: Commit** — `git commit -am "feat(sync): dedupe_key + sync_state schema and DB methods"`
+
+---
+
+### Task 3: Register new sources
+
+**Files:**
+- Modify: `backend/sources.py:25-38`
+- Test: `backend/test_sources_registry.py`
+
+**Interfaces:**
+- Produces: `SOURCES` and `SOURCE_ID_OFFSETS` include `hackernews`, `producthunt`, `techstars`.
+
+- [ ] **Step 1: Test**
+
+```python
+from sources import SOURCES, SOURCE_ID_OFFSETS, to_global_id
+def test_new_sources_registered():
+    for k in ("hackernews", "producthunt", "techstars"):
+        assert k in SOURCES and k in SOURCE_ID_OFFSETS
+    assert to_global_id("hackernews", 42) == 3_000_000_042
+```
+
+- [ ] **Step 2: Run** → FAIL
+- [ ] **Step 3: Implement** — extend the dicts:
+
+```python
+SOURCES.update({
+    "hackernews":  {"key": "hackernews",  "display_name": "Hacker News"},
+    "producthunt": {"key": "producthunt", "display_name": "Product Hunt"},
+    "techstars":   {"key": "techstars",   "display_name": "Techstars"},
+})
+SOURCE_ID_OFFSETS.update({
+    "hackernews": 3_000_000_000, "producthunt": 4_000_000_000, "techstars": 5_000_000_000,
+})
+```
+
+- [ ] **Step 4: Run** → PASS
+- [ ] **Step 5: Commit** — `git commit -am "feat(sync): register hackernews/producthunt/techstars sources"`
+
+---
+
+### Task 4: Adapter framework + HN adapter + stubs
+
+**Files:**
+- Create: `backend/ingestion/base.py`
+- Create: `backend/ingestion/hackernews.py`
+- Create: `backend/ingestion/producthunt.py` (stub)
+- Create: `backend/ingestion/techstars.py` (stub)
+- Create: `backend/ingestion/registry.py`
+- Test: `backend/test_hackernews_adapter.py`
+
+**Interfaces:**
+- Produces:
+  - `base.FetchResult` = dataclass `(rows: list[dict], cursor: str | None, removed_source_ids: list[str])`
+  - `base.SourceAdapter` protocol: attrs `key`, `display_name`; method `fetch(self, cursor, full=False) -> FetchResult`
+  - `hackernews.parse_title(title: str) -> dict{name, batch, blurb}`
+  - `hackernews.HackerNewsAdapter`
+  - `registry.ADAPTERS: dict[str, SourceAdapter]`, `registry.get_adapter(key)`
+- Each row dict is keyed with real column names + `source`, `source_id`, `source_url`, `dedupe_key`, `isHiring` (not `is_hiring`), `raw_json` (a dict).
+
+- [ ] **Step 1: Test HN title parsing** — `backend/test_hackernews_adapter.py`
+
+```python
+from ingestion.hackernews import parse_title, HackerNewsAdapter
+
+def test_parse_launch_with_yc_batch():
+    r = parse_title("Launch HN: Acme (YC S26) – AI for dentists")
+    assert r["name"] == "Acme" and r["batch"] == "S26" and "dentists" in r["blurb"]
+
+def test_parse_show_hn_no_batch():
+    r = parse_title("Show HN: Bpar – a faster bundler")
+    assert r["name"] == "Bpar" and r["batch"] is None
+
+def test_hit_to_row_sets_source_and_key():
+    hit = {"objectID": "42", "title": "Launch HN: Acme (YC S26) – x",
+           "url": "https://acme.com", "created_at_i": 1700000000,
+           "author": "pg", "points": 10, "num_comments": 3, "story_text": None}
+    row = HackerNewsAdapter()._to_row(hit)
+    assert row["source"] == "hackernews" and row["source_id"] == "42"
+    assert row["dedupe_key"] == "acme.com" and row["batch"] == "S26"
+    assert row["isHiring"] is False and row["source_url"].endswith("id=42")
+```
+
+- [ ] **Step 2: Run** → FAIL
+- [ ] **Step 3: Implement `base.py`**
+
+```python
+from dataclasses import dataclass, field
+
+@dataclass
+class FetchResult:
+    rows: list = field(default_factory=list)
+    cursor: str | None = None
+    removed_source_ids: list = field(default_factory=list)
+```
+(Adapters are duck-typed; no ABC needed. Document the `fetch` contract in a docstring.)
+
+- [ ] **Step 4: Implement `hackernews.py`** (ports the PR's parser; uses `to_global_id` + `dedupe_key`)
+
+```python
+import re, json, time, urllib.request
+from ingestion.base import FetchResult
+from ingestion.normalize import norm_domain, slugify, dedupe_key
+from sources import to_global_id
+
+_SEARCH = "https://hn.algolia.com/api/v1/search_by_date"
+
+def parse_title(title):
+    body = re.sub(r"^\s*(launch|show)\s+hn:\s*", "", title, flags=re.I).strip()
+    segs = re.split(r"\s+[–—-]\s+", body, maxsplit=1)
+    head = segs[0].strip()
+    blurb = segs[1].strip() if len(segs) > 1 else None
+    m = re.search(r"\(YC\s+([A-Za-z]\d{2})\)", head, re.I)
+    batch = m.group(1).upper() if m else None
+    name = re.sub(r"\s*\(YC\s+[A-Za-z]\d{2}\)\s*", "", head, flags=re.I)
+    name = re.sub(r"\s*\([^)]*\)\s*$", "", name).strip()
+    return {"name": name or head, "batch": batch, "blurb": blurb}
+
+def _get(url):
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        return json.loads(resp.read().decode())
+
+class HackerNewsAdapter:
+    key = "hackernews"
+    display_name = "Hacker News"
+
+    def _to_row(self, hit):
+        parsed = parse_title(hit.get("title", ""))
+        name = parsed["name"]
+        if not name:
+            return None
+        domain = norm_domain(hit.get("url"))
+        slug = slugify(name)
+        tag = "Launch HN" if re.match(r"^\s*launch\s+hn", hit.get("title", ""), re.I) else "Show HN"
+        # Require a domain OR a YC batch marker to count as a company (drops noise).
+        if not domain and not parsed["batch"]:
+            return None
+        native = int(hit["objectID"])
+        return {
+            "id": to_global_id("hackernews", native),
+            "source": "hackernews", "source_id": str(hit["objectID"]),
+            "source_url": f"https://news.ycombinator.com/item?id={hit['objectID']}",
+            "name": name, "slug": slug, "website": hit.get("url"),
+            "one_liner": parsed["blurb"], "long_description": hit.get("story_text"),
+            "batch": parsed["batch"], "tags": [tag], "industries": [], "regions": [],
+            "isHiring": False, "top_company": False, "nonprofit": False,
+            "dedupe_key": dedupe_key(domain, "hackernews", slug),
+            "country": None, "raw_json": hit,
+        }
+
+    def fetch(self, cursor, full=False):
+        lookback_days = 3650 if full else 30
+        since = int(cursor) if cursor else int(time.time()) - lookback_days * 86400
+        seen, rows, max_ts = set(), [], since
+        for query in ('"Launch HN"', '"Show HN"'):
+            for page in range(20):
+                url = (f"{_SEARCH}?query={urllib.parse.quote(query)}&tags=story"
+                       f"&numericFilters=created_at_i>{since}&hitsPerPage=100&page={page}")
+                data = _get(url)
+                for hit in data.get("hits", []):
+                    oid = hit.get("objectID")
+                    if oid in seen:
+                        continue
+                    seen.add(oid)
+                    ts = hit.get("created_at_i") or 0
+                    if ts > max_ts:
+                        max_ts = ts
+                    row = self._to_row(hit)
+                    if row:
+                        rows.append(row)
+                if page + 1 >= data.get("nbPages", 0):
+                    break
+        return FetchResult(rows=rows, cursor=str(max_ts), removed_source_ids=[])
+```
+(Add `import urllib.parse` at top.)
+
+- [ ] **Step 5: Implement stubs `producthunt.py` / `techstars.py`**
+
+```python
+from ingestion.base import FetchResult
+
+class ProductHuntAdapter:
+    key = "producthunt"
+    display_name = "Product Hunt"
+    def fetch(self, cursor, full=False):
+        # TODO: GraphQL https://api.producthunt.com/v2/api/graphql (needs PH_TOKEN),
+        # map posts -> rows with source='producthunt', dedupe_key from post website.
+        return FetchResult(rows=[], cursor=cursor, removed_source_ids=[])
+```
+(Techstars analogous: scrape https://www.techstars.com/portfolio; TODO fetch.)
+
+- [ ] **Step 6: Implement `registry.py`**
+
+```python
+from ingestion.hackernews import HackerNewsAdapter
+from ingestion.producthunt import ProductHuntAdapter
+from ingestion.techstars import TechstarsAdapter
+
+ADAPTERS = {a.key: a for a in (HackerNewsAdapter(), ProductHuntAdapter(), TechstarsAdapter())}
+def get_adapter(key): return ADAPTERS.get(key)
+```
+
+- [ ] **Step 7: Run** — `python -m pytest test_hackernews_adapter.py -v` → PASS
+- [ ] **Step 8: Commit** — `git commit -m "feat(sync): adapter framework + Hacker News adapter + PH/Techstars stubs"`
+
+---
+
+### Task 5: sync_service orchestrator + cron endpoint + workflow
+
+**Files:**
+- Create: `backend/ingestion/sync_service.py`
+- Modify: `backend/main.py` (new `/api/cron/sync-sources`; extend scrape source handling)
+- Modify: `.github/workflows/daily-cron.yml`
+- Test: `backend/test_sync_service.py`
+
+**Interfaces:**
+- Consumes: `registry.ADAPTERS`, `db.insert_company`, `db.get_sync_cursor`, `db.save_sync_state`, `db.backfill_dedupe_keys`, `embedding_service`, `company_cache.refresh`.
+- Produces: `run_sync(db, sources: list[str] | None = None, full=False) -> dict{source: {upserted, cursor, status}}`, and `embed_missing(db, limit=2000) -> int`.
+
+- [ ] **Step 1: Test with a fake adapter** — `backend/test_sync_service.py`
+
+```python
+from database import Database
+from ingestion import sync_service
+from ingestion.base import FetchResult
+
+class FakeAdapter:
+    key = "hackernews"; display_name = "HN"
+    def fetch(self, cursor, full=False):
+        return FetchResult(rows=[{
+            "id": 3_000_000_001, "source": "hackernews", "source_id": "1",
+            "name": "Acme", "slug": "acme", "website": "https://acme.com",
+            "dedupe_key": "acme.com", "isHiring": False, "raw_json": {"x": 1},
+            "tags": ["Launch HN"], "industries": [], "regions": [],
+        }], cursor="123", removed_source_ids=[])
+
+def test_run_sync_upserts_and_saves_cursor(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "t.db"))
+    monkeypatch.setitem(sync_service.registry.ADAPTERS, "hackernews", FakeAdapter())
+    out = sync_service.run_sync(db, sources=["hackernews"])
+    assert out["hackernews"]["upserted"] == 1
+    assert db.get_sync_cursor("hackernews") == "123"
+    assert db.get_company_by_id(3_000_000_001)["dedupe_key"] == "acme.com"
+```
+
+- [ ] **Step 2: Run** → FAIL
+- [ ] **Step 3: Implement `sync_service.py`**
+
+```python
+import logging
+from ingestion import registry
+
+logger = logging.getLogger(__name__)
+
+def run_sync(db, sources=None, full=False):
+    keys = sources or list(registry.ADAPTERS.keys())
+    results = {}
+    for key in keys:
+        adapter = registry.get_adapter(key)
+        if adapter is None:
+            continue
+        try:
+            cursor = db.get_sync_cursor(key)
+            result = adapter.fetch(cursor, full=full)
+            for row in result.rows:
+                db.insert_company(row)
+            db.save_sync_state(key, result.cursor, "ok", len(result.rows))
+            results[key] = {"upserted": len(result.rows), "cursor": result.cursor, "status": "ok"}
+            logger.info(f"sync {key}: upserted {len(result.rows)}, cursor {result.cursor}")
+        except Exception as e:
+            db.save_sync_state(key, None, "error", 0, str(e))
+            results[key] = {"upserted": 0, "cursor": None, "status": "error", "error": str(e)}
+            logger.error(f"sync {key} failed: {e}")
+    return results
+
+def embed_missing(db, limit=2000):
+    """Embed any rows (all sources) missing an embedding. No-op on SQLite."""
+    if not hasattr(db, "get_companies_for_embedding"):
+        return 0
+    from embedding_service import get_embedding_service
+    from idea_filter import get_search_text_for_embedding
+    missing = db.get_companies_for_embedding(only_missing=True, limit=limit)
+    if not missing:
+        return 0
+    svc = get_embedding_service()
+    texts = [get_search_text_for_embedding(db.build_company_embedding_text(c)) for c in missing]
+    vectors = svc.generate_embeddings_batch(texts)
+    return db.update_company_embeddings_batch([(c["id"], v) for c, v in zip(missing, vectors)])
+```
+
+- [ ] **Step 4: Run** — `python -m pytest test_sync_service.py -v` → PASS
+- [ ] **Step 5: Add cron endpoint** in `backend/main.py` (mirror `/api/cron/daily-scrape` auth at `main.py:1665`)
+
+```python
+@app.post("/api/cron/sync-sources")
+async def cron_sync_sources(request: Request, full: bool = False):
+    _require_cron_secret(request)  # same helper used by daily-scrape (extract if inline)
+    from ingestion import sync_service
+    db.backfill_dedupe_keys()
+    results = sync_service.run_sync(db, full=full)
+    embedded = sync_service.embed_missing(db)
+    company_cache.refresh(db)
+    return {"results": results, "embedded": embedded}
+```
+If daily-scrape uses inline secret check, replicate the same 3 lines here rather than refactoring.
+
+- [ ] **Step 6: Add workflow step** in `.github/workflows/daily-cron.yml` — a curl POST to `/api/cron/sync-sources` with the `CRON_SECRET` bearer, scheduled after the daily scrape. Delete the PR's `scripts/exploreyc-sync-pr/.github/workflows/sync-companies.yml`.
+
+- [ ] **Step 7: Commit** — `git commit -am "feat(sync): sync orchestrator + /api/cron/sync-sources + workflow"`
+
+---
+
+### Task 6: Embeddings + similarity across all sources (Postgres)
+
+**Files:**
+- Modify: `backend/database_postgres.py` (embedding generation + retrieval)
+- Modify: `backend/main.py` (hero/validator call sites pass `source_filter='yc'`; new `/api/companies/similar`)
+- Modify: `backend/database.py` (SQLite stubs if the methods exist there)
+- Test: `backend/test_embedding_all_sources.py` (skipped without a live PG/pgvector; assert SQL shape via string checks where possible)
+
+**Interfaces:**
+- Produces:
+  - `find_similar_companies_by_embedding(embedding, limit=10, min_similarity=0.5, source_filter=None)` — `source_filter='yc'` = YC-only (unchanged behavior); `None` = all sources deduped by `dedupe_key`.
+  - `find_companies_by_text_search(idea, limit=10, source_filter=None)` — same convention.
+  - `get_companies_for_embedding` / `get_companies_without_embeddings` / `count_companies_with_embeddings` — no longer filtered to `source='yc'`.
+  - New endpoint `POST /api/companies/similar {query: str, limit?: int}` → all-source vector matches.
+  - Unchanged: `get_yc_company_count()` (YC denominator).
+
+- [ ] **Step 1: Broaden generation** — in `get_companies_for_embedding` remove `WHERE source = 'yc'` (keep `embedding IS NULL` when `only_missing`); same for `get_companies_without_embeddings`; drop `AND source='yc'` in `count_companies_with_embeddings`.
+
+- [ ] **Step 2: Add `source_filter` to retrieval** — parametrize the two finder queries:
+
+```python
+def find_similar_companies_by_embedding(self, embedding, limit=10, min_similarity=0.5, source_filter=None):
+    embedding_str = '[' + ','.join(map(str, embedding)) + ']'
+    src_clause = "AND source = %s" if source_filter else ""
+    dedup = "" if source_filter else "DISTINCT ON (dedupe_key)"
+    order_extra = "dedupe_key," if not source_filter else ""
+    sql = f"""
+        SELECT {dedup} id, name, slug, website, one_liner, long_description,
+               industry, subindustry, tags, industries, batch, is_hiring,
+               team_size, all_locations, country, small_logo_thumb_url, source, dedupe_key,
+               (1 - (embedding <=> %s::vector)) AS similarity_score
+        FROM companies
+        WHERE embedding IS NOT NULL {src_clause}
+          AND (1 - (embedding <=> %s::vector)) >= %s
+        ORDER BY {order_extra} embedding <=> %s::vector
+        LIMIT %s
+    """
+    params = [embedding_str] + ([source_filter] if source_filter else []) + [embedding_str, min_similarity, embedding_str, limit]
+    # NOTE: with DISTINCT ON, a subquery re-sorts by similarity for final ordering.
+```
+For the all-source branch wrap in a subquery so final results order by `similarity_score DESC` after `DISTINCT ON (dedupe_key)` dedup. Round scores as before. Apply the analogous `source_filter` to `find_companies_by_text_search`.
+
+- [ ] **Step 3: Preserve the hero/validator** — at `main.py` call sites (~964, ~1063, ~1143) pass `source_filter="yc"` so the verdict/market-size stay YC-only and `hero_service.build_verdict` is unchanged.
+
+- [ ] **Step 4: New all-source endpoint** — `main.py`
+
+```python
+class SimilarQuery(BaseModel):
+    query: str
+    limit: int = 12
+
+@app.post("/api/companies/similar")
+async def companies_similar(body: SimilarQuery):
+    if db.count_companies_with_embeddings() == 0:
+        raise HTTPException(status_code=503, detail="Embeddings not generated yet")
+    text = get_search_text_for_embedding(body.query, min_length=3)
+    emb = get_embedding_service().generate_embedding_for_idea(text)
+    results = db.find_similar_companies_by_embedding(emb, limit=body.limit, min_similarity=0.3)  # source_filter=None -> all
+    return {"companies": results, "total": len(results)}
+```
+
+- [ ] **Step 5: Test** — `backend/test_embedding_all_sources.py`: unit-test that `get_companies_for_embedding`'s SQL no longer contains `source = 'yc'` (introspect via a monkeypatched cursor capturing SQL), and that `find_similar_companies_by_embedding(..., source_filter='yc')` includes `source = %s`. Guard live-PG tests behind `pytest.mark.skipif(no DATABASE_URL)`.
+
+- [ ] **Step 6: Run** — `python -m pytest test_embedding_all_sources.py -v` → PASS
+- [ ] **Step 7: Commit** — `git commit -am "feat(sync): embeddings + vector search across all sources; hero stays YC-scoped"`
+
+---
+
+### Task 7: Read-time merge grouping + `merged` flag
+
+**Files:**
+- Modify: `backend/company_cache.py` (merge grouping)
+- Modify: `backend/main.py` (`CompanyFilter.merged`; pass through `/api/companies`)
+- Test: `backend/test_merge_grouping.py`
+
+**Interfaces:**
+- Consumes: rows carry `dedupe_key`, `source`, `source_url`.
+- Produces:
+  - `CompanyCache._merge_group(rows: list[dict]) -> dict` (primary + `merged_sources`)
+  - `get_companies(..., merged: bool = False)` and `count_companies(..., merged=False)` group by `dedupe_key` when `merged=True`.
+  - `CompanyFilter.merged: bool = False` on the API model.
+- Primary priority: `yc > a16z > techstars > producthunt > hackernews`. Gap-fill `one_liner`, `small_logo_thumb_url`, `long_description` from group members; `is_hiring = any`.
+
+- [ ] **Step 1: Test** — `backend/test_merge_grouping.py`
+
+```python
+from company_cache import CompanyCache
+
+def _c(**kw):
+    base = {"id": 0, "source": "yc", "dedupe_key": "acme.com", "name": "Acme",
+            "one_liner": None, "is_hiring": False, "created_at": "2026-01-01"}
+    base.update(kw); return base
+
+def test_merge_collapses_same_domain_with_badges():
+    cache = CompanyCache()
+    cache._build_cache([
+        _c(id=1, source="yc", one_liner="YC one liner", source_url="yc/acme"),
+        _c(id=3_000_000_001, source="hackernews", one_liner=None, is_hiring=True, source_url="hn/1"),
+    ])
+    rows = cache.get_companies(merged=True, source="all")
+    acme = [r for r in rows if r["dedupe_key"] == "acme.com"]
+    assert len(acme) == 1
+    assert acme[0]["source"] == "yc"                       # yc wins primary
+    assert acme[0]["is_hiring"] is True                    # any() across group
+    assert {s["key"] for s in acme[0]["merged_sources"]} == {"yc", "hackernews"}
+
+def test_merged_false_keeps_rows_separate():
+    cache = CompanyCache()
+    cache._build_cache([_c(id=1, source="yc"), _c(id=3_000_000_001, source="hackernews")])
+    assert len(cache.get_companies(merged=False, source="all")) == 2
+```
+
+- [ ] **Step 2: Run** → FAIL
+- [ ] **Step 3: Implement merge** in `company_cache.py`:
+
+```python
+_SOURCE_PRIORITY = {"yc": 0, "a16z": 1, "techstars": 2, "producthunt": 3, "hackernews": 4}
+
+@staticmethod
+def _merge_group(rows):
+    primary = min(rows, key=lambda r: CompanyCache._SOURCE_PRIORITY.get(r.get("source") or "yc", 99))
+    merged = dict(primary)
+    for field in ("one_liner", "small_logo_thumb_url", "long_description", "country", "all_locations"):
+        if not merged.get(field):
+            for r in rows:
+                if r.get(field):
+                    merged[field] = r[field]; break
+    merged["is_hiring"] = any(r.get("is_hiring") for r in rows)
+    merged["merged_sources"] = [
+        {"key": r.get("source") or "yc", "source_url": r.get("source_url")} for r in rows
+    ]
+    return merged
+
+def _apply_merge(self, filtered):
+    groups = {}
+    for c in filtered:
+        key = c.get("dedupe_key") or f'id:{c.get("id")}'
+        groups.setdefault(key, []).append(c)
+    return [self._merge_group(g) for g in groups.values()]
+```
+Then in `get_companies`/`count_companies` add `merged: bool = False`; after `_filter_companies(...)`, if `merged`, run `filtered = self._apply_merge(filtered)` **before** slicing/counting. Preserve created_at ordering by sorting merged output with the existing sort key.
+
+- [ ] **Step 4: Add API flag** — `CompanyFilter.merged: bool = False` (`main.py:275`), and pass `merged=filters.merged` into `company_cache.get_companies(...)` / `count_companies(...)` at `main.py:551` / `:563`.
+
+- [ ] **Step 5: Run** — `python -m pytest test_merge_grouping.py -v` → PASS
+- [ ] **Step 6: Commit** — `git commit -am "feat(sync): read-time domain merge grouping behind merged flag"`
+
+---
+
+### Task 8: Frontend — badges, merged cluster, types, semantic search
+
+**Files:**
+- Modify: `frontend/src/components/ui/SourceBadge.tsx`
+- Modify: `frontend/src/lib/api.ts` (`Company`, `CompanyFilter`, `Source`, client method)
+- Modify: `frontend/src/components/CompaniesBrowser.tsx`
+- Modify: `frontend/src/components/CompanyDetailModal.tsx`
+- Modify: `frontend/src/pages/CompanyPage.tsx`
+
+**Interfaces:**
+- Consumes: API `merged_sources?: {key: string; source_url?: string}[]`, `dedupe_key?`, `/api/companies/similar`.
+- Produces: multi-badge cluster rendering; `merged` filter flag; `getSimilarCompanies(query, limit)`.
+
+- [ ] **Step 1: SourceBadge** — add branches for `hackernews` (HN orange `#FF6600` square "HN"), `producthunt` (`#DA552F` "P"), `techstars` (`#0090FF` "T"), and `sourceLabel()` cases.
+- [ ] **Step 2: api.ts types** — add `dedupe_key?: string` and `merged_sources?: {key: string; source_url?: string}[]` to `Company`; `merged?: boolean` to `CompanyFilter`; add:
+
+```ts
+getSimilarCompanies: (query: string, limit = 12) =>
+  api.post<{ companies: Company[]; total: number }>('/api/companies/similar', { query, limit }),
+```
+- [ ] **Step 3: Badge cluster component** — render `company.merged_sources` (fallback to `[{key: company.source}]`) as a row of `<SourceBadge>`s in `CompaniesBrowser` cards, `CompanyDetailModal`, and `CompanyPage`. Cards guard empty `batch`/`all_locations` (already conditional).
+- [ ] **Step 4: Merged + semantic toggles in `CompaniesBrowser`** — a "Merge sources" checkbox sets `filters.merged = true, source = 'all'`; a "Semantic search" toggle routes the search box through `getSimilarCompanies` instead of `getCompanies`.
+- [ ] **Step 5: Build check** — `cd frontend && npm run build` → succeeds (TS strict passes).
+- [ ] **Step 6: Commit** — `git commit -am "feat(sync): source badges, merged cluster, semantic search UI"`
+
+---
+
+### Task 9: Rollout & verification
+
+**Files:**
+- Modify: `scripts/exploreyc-sync-pr/` → remove (folded into platform); keep `PR_DESCRIPTION.md` notes migrated into the plan/spec.
+- Create: `backend/scripts/backfill_dedupe_and_embed.py` (one-off convenience) — optional.
+
+- [ ] **Step 1: Full backend test run** — `cd backend && python -m pytest test_ingestion_normalize.py test_sync_state.py test_sources_registry.py test_hackernews_adapter.py test_sync_service.py test_merge_grouping.py test_embedding_all_sources.py -v` → all PASS.
+- [ ] **Step 2: Local smoke (SQLite)** — start backend (`cd backend && uvicorn main:app --port 8000`), seed a few YC rows via `/api/scrape`, then `curl -X POST localhost:8000/api/cron/sync-sources -H "Authorization: Bearer $CRON_SECRET"` (set a local `CRON_SECRET`). Verify HN rows appear via `curl -X POST localhost:8000/api/companies -d '{"source":"all","merged":true}'`.
+- [ ] **Step 3: Frontend build** — `cd frontend && npm run build`.
+- [ ] **Step 4: Remove the superseded PR folder** — `git rm -r scripts/exploreyc-sync-pr` and commit.
+- [ ] **Step 5: Push branch + open PR** — `git push -u origin feat/db-feature-requests` and open a PR summarizing the meshed design (link the spec).
+- [ ] **Step 6: Production rollout handoff (user-run):** apply migration `20260711130000_multi_source_sync.sql` via `supabase db push`; trigger `/api/cron/sync-sources?full=true` once to backfill HN + `dedupe_key` + embeddings; confirm daily cron picks it up. No new secrets required (reuses `CRON_SECRET`, `SUPABASE_*`, `OPENAI_API_KEY`).
+
+---
+
+## Self-Review
+
+**Spec coverage:** §3.1 schema → T2; §3.2 registry → T3; §3.3 framework/adapters/sync_service → T1/T4/T5; §3.4 backfill → T2/T5; §3.5 merge → T7; §3.6 cron/ops → T5; §3.7 frontend → T8; §3.8 embeddings all-source + YC metric preserved → T6; testing → tests in each task + T9; rollout → T9. All covered.
+
+**Placeholder scan:** stubs (PH/Techstars `fetch`) are intentional per spec and clearly marked TODO with the concrete endpoint; no other placeholders.
+
+**Type consistency:** `FetchResult(rows, cursor, removed_source_ids)`, adapter `.key`/`.fetch`, `run_sync`/`embed_missing`, `find_similar_companies_by_embedding(..., source_filter=)`, `_merge_group`/`merged_sources`, `CompanyFilter.merged` — names consistent across tasks. `insert_company` reads `isHiring` (adapters emit `isHiring`, not `is_hiring`).

--- a/docs/superpowers/specs/2026-07-11-multi-source-company-sync-design.md
+++ b/docs/superpowers/specs/2026-07-11-multi-source-company-sync-design.md
@@ -1,0 +1,247 @@
+# Multi-source company sync — design
+
+**Date:** 2026-07-11
+**Status:** Approved for planning
+**Author:** Konstantin + Claude
+**Supersedes:** the standalone `scripts/exploreyc-sync-pr/` PR (TypeScript worker + generic schema)
+
+## 1. Problem & context
+
+ExploreYC ingests companies from two sources today (YC via the Algolia scraper in
+`scraper_service.py`, a16z via the HTML scraper in `a16z_scraper_service.py`) into a
+single `companies` table. The table already has a mature multi-source design:
+
+- **Global IDs** via `sources.py` → `to_global_id(source, native_id)`, where every
+  source gets a reserved 1e9-wide BIGINT block (`yc`=0, `a16z`=2e9). YC keeps offset 0
+  so its ids/FKs are unchanged.
+- **Per-source uniqueness**: `UNIQUE(source, slug)` and `UNIQUE(source, source_id)`.
+- **Provenance already present**: each row carries `source`, `source_id`, `source_url`,
+  and the full original payload in `raw_json`.
+- **Source-aware UI**: `SourceBadge`, source filter dropdown, `getSources()`,
+  dynamic `DatabasePage` columns, `CompanyDetailModal`.
+- **Analytics/embeddings are YC-scoped**: market-size denominator
+  (`database_postgres.py:811`), embedding backfill (`:873`), and the hero idea-validator
+  similarity search (`:944`) all filter `WHERE source = 'yc'`.
+
+A separate PR (`scripts/exploreyc-sync-pr/`) proposed a **standalone TypeScript worker
+with its own generic schema** (UUID ids, `dedupe_key`, `text[]` arrays, `logo_url`,
+`locations`, a duplicate yc-oss YC adapter). Applied as-is it would create a *second*
+companies schema and a *second* ingestion stack with a different dedup philosophy — the
+opposite of meshing. This design keeps the PR's genuinely-new ideas and drops the rest.
+
+### Goals
+
+1. Add **Hacker News** (Launch HN / Show HN) as a real new company source.
+2. Establish a **Python source-adapter framework** so new sources are one file; ship
+   **Product Hunt** and **Techstars** as stubs to prove it generalizes.
+3. **Merge on domain**: the same company appearing in multiple sources (YC + Launch HN,
+   a16z + YC, …) presents as a single card showing multiple source badges.
+4. **Incremental cursor sync** for the new sources (`sync_state`), so daily runs pull
+   deltas, not full refreshes.
+5. **Zero data loss** and **zero regression** to existing YC/a16z data, IDs, analytics,
+   embeddings, and the hero validator.
+
+### Non-goals (explicitly out of scope)
+
+- Replacing the YC Algolia scraper or adopting yc-oss's delta feed (keep current setup).
+- Physically merging rows / retiring the global-id scheme (canonical-row merge — rejected).
+- Extending embeddings or the hero idea-validator to non-YC sources (stays YC-only).
+
+## 2. Chosen approach: grouping-layer merge (option A)
+
+Every per-source row stays in `companies` exactly as it is today. "Merge" is a **read-time
+grouping** concern, not a destructive identity rewrite:
+
+- Add a `dedupe_key` column (normalized **domain** if the company has a website, else
+  `source:slug`) to every row and backfill it.
+- The API/cache groups rows sharing a `dedupe_key` into one **canonical presentation**:
+  a primary row for display + the set of contributing sources for the badge cluster.
+
+Rejected alternatives: **B) canonical-row merge** (large, risky migration reassigning
+ids/FKs, high analytics/embedding regression risk) and **C) separate `canonical_companies`
+table** (most new surface, overkill at ~6k+ rows).
+
+### Why this satisfies "no data loss" by construction
+
+- No row is ever deleted or overwritten across sources: `insert_company` upserts
+  `ON CONFLICT (id)`, and each source occupies a disjoint 1e9-wide id block, so source B
+  can never clobber source A's row.
+- Merge is purely a read-time grouping over untouched rows → fully reversible (drop the
+  column / flag and behavior returns to today's).
+- Upstream removals use **soft-delete** (never a hard delete), matching current behavior.
+- `raw_json` retains the full original payload per source row.
+- `dedupe_key` is additive; a wrong domain parse only affects grouping in the merged view,
+  never the underlying source data.
+
+## 3. Components
+
+### 3.1 Schema changes (Postgres migration + SQLite parity)
+
+Applies to **both** `supabase/migrations/` (Postgres) and `backend/database.py` (SQLite).
+
+- `companies.dedupe_key TEXT` + partial index
+  `CREATE INDEX ... ON companies (dedupe_key) WHERE dedupe_key IS NOT NULL`.
+- New `sync_state` table (per-source incremental cursor):
+  `source TEXT PK, last_run_at, last_cursor TEXT, last_status TEXT,
+   records_upserted INT DEFAULT 0, error TEXT, updated_at`.
+- **No** new `company_sources` table — existing per-row `raw_json` + `source_url` already
+  are the provenance.
+- Backfill `dedupe_key` for all existing rows (see 3.4) — authoritative pass done in
+  Python via the shared normalizer so YC/a16z/HN parse domains identically.
+
+### 3.2 Source registry (`sources.py`)
+
+Add the three new sources so IDs, badges, filters, and `getSources()` pick them up:
+
+```python
+SOURCES += {
+  "hackernews":  {"key": "hackernews",  "display_name": "Hacker News"},
+  "producthunt": {"key": "producthunt", "display_name": "Product Hunt"},
+  "techstars":   {"key": "techstars",   "display_name": "Techstars"},
+}
+SOURCE_ID_OFFSETS += {
+  "hackernews":  3_000_000_000,
+  "producthunt": 4_000_000_000,
+  "techstars":   5_000_000_000,
+}
+```
+
+HN `objectID`s are numeric and well under 1e9, satisfying `SOURCE_BLOCK_WIDTH`.
+
+### 3.3 Ingestion framework (`backend/ingestion/`)
+
+A new self-contained package (mirrors the existing flat-service style but grouped):
+
+- **`normalize.py`** — Python port of the PR's helpers: `norm_domain`, `slugify`,
+  `dedupe_key`, `country_from_locations`, plus a small **shared-host denylist**
+  (`github.io`, `notion.site`, `vercel.app`, …) so unrelated companies on a shared host
+  fall back to `source:slug` instead of false-merging.
+- **`base.py`** — the adapter contract:
+  - `SourceAdapter` protocol: `key`, `display_name`, `fetch(cursor, full) -> FetchResult`.
+  - `FetchResult`: `rows: list[dict]` (already in ExploreYC column names), `cursor: str | None`,
+    `removed_source_ids: list[str]`.
+  - Each row dict maps to real columns: `name, slug, website, one_liner, long_description,
+    small_logo_thumb_url, all_locations, batch, status, industry, subindustry, stage,
+    team_size, tags (JSON str), industries (JSON str), regions (JSON str), country,
+    is_hiring, top_company, nonprofit, source, source_id, source_url, raw_json,
+    dedupe_key, year_founded, founders`.
+- **`hackernews.py`** — ports the PR's Launch HN / Show HN title parsing
+  (`"Launch HN: Acme (YC S26) – blurb"` → name/batch/blurb), queries
+  `hn.algolia.com/api/v1/search_by_date` filtered on `created_at_i`, cursor =
+  `max(created_at_i)`. `source_id` = HN `objectID`; `source_url` = the HN item link.
+  Requires a URL/domain **or** a YC-batch marker to count as a company (drops noise).
+- **`producthunt.py`, `techstars.py`** — stub adapters implementing the protocol with a
+  documented `fetch()` TODO (endpoint + field mapping), so wiring/registry/UI are proven
+  end-to-end and filling them in later is a single file.
+- **`registry.py`** — maps source key → adapter instance; drives the orchestrator.
+- **`sync_service.py`** — orchestrator:
+  1. `cursor = sync_state[source].last_cursor`
+  2. `result = adapter.fetch(cursor, full)`
+  3. per row: `id = to_global_id(source, source_id)`; compute `dedupe_key`; `db.insert_company(row)`
+     (existing upsert on `id` + `(source, source_id)`/`(source, slug)`)
+  4. soft-mark `result.removed_source_ids` (never hard delete)
+  5. persist new cursor + status to `sync_state`
+  6. `company_cache.refresh(db)`
+  - New sources do **not** get embeddings (embeddings/hero stay YC-only); they're searchable
+    via the existing cache substring search.
+
+### 3.4 `dedupe_key` backfill
+
+- Migration adds the column + index only.
+- The **first `sync_service` run** (and a small idempotent `backfill_dedupe_keys()`
+  utility) populate `dedupe_key` for every existing YC/a16z row using
+  `normalize.norm_domain(website)` (else `source:slug`). Idempotent and re-runnable.
+
+### 3.5 Merged presentation (`company_cache.py` + API)
+
+- Add a `merged` grouping to the cache: when the caller requests the merged view, group
+  loaded rows by `dedupe_key` and emit one canonical entry per group:
+  - **Primary row** by source priority `yc > a16z > techstars > producthunt > hackernews`
+    (richest/most-geocoded first).
+  - **Gap-fill** missing display fields (`one_liner`, `small_logo_thumb_url`,
+    `long_description`) from other rows in the group — presentation-level, non-destructive.
+  - `is_hiring = any(...)` across the group.
+  - Attach `merged_sources: [{key, source_url}]` for the badge cluster.
+- **Default stays YC-only.** `CompanyFilter.source is None → YC only` is unchanged. Merging
+  is a new explicit `merged: bool = false` flag on `CompanyFilter` (**not** overloaded onto
+  `source`), so semantics are unambiguous:
+  - Card surfaces (`CompaniesBrowser`, `CompanyDetailModal`, `CompanyPage`) request
+    `merged=true` → grouped canonical entries with a badge cluster.
+  - The `DatabasePage` **table keeps flat per-source rows** (`merged=false`) with its existing
+    source-badge column, so the table's current row-level semantics are unchanged.
+  - Similarity/search results dedupe by `dedupe_key` only when `merged=true`.
+- Analytics endpoints (`/api/stats`, market-size %) keep their `WHERE source = 'yc'`
+  queries untouched → **no counting regression**.
+
+### 3.6 Scheduling / ops
+
+- New `/api/cron/sync-sources` endpoint (protected by `CRON_SECRET`, same pattern as
+  `/api/cron/daily-scrape` at `main.py:1714`) → `sync_service.run(all adapters)` →
+  `company_cache.refresh(db)`.
+- Add a step/time to `.github/workflows/daily-cron.yml` calling it.
+- Optionally let `/api/scrape` accept `source="hackernews"` to dispatch a single-source
+  manual run.
+- **Delete** the PR's standalone `sync-companies.yml`.
+
+### 3.7 Frontend (`frontend/src/`)
+
+- `components/ui/SourceBadge.tsx`: add `hackernews`, `producthunt`, `techstars` branded
+  badges + `sourceLabel()` cases.
+- Render the `merged_sources` cluster (multiple badges) on `CompaniesBrowser` cards,
+  `DatabasePage` rows, `CompanyDetailModal`, and `CompanyPage`.
+- `Company` TS interface (`lib/api.ts`): add optional `dedupe_key?` and
+  `merged_sources?: {key: string; source_url?: string}[]`.
+- Source filter dropdown + `getSources()` pick up new sources automatically once rows
+  exist; add a "merged" view affordance.
+- Cards degrade gracefully for rows lacking `batch`/`all_locations` (HN launches).
+
+## 4. What we keep vs. drop from the PR
+
+| From the PR | Disposition |
+| --- | --- |
+| HN Launch/Show parsing, cursor concept, domain dedupe | **Keep**, ported to Python |
+| Generic UUID migration, `text[]`, `logo_url`/`locations` | **Drop** (conflicts with real schema) |
+| Redundant yc-oss YC adapter | **Drop** (YC stays on Algolia) |
+| Standalone TS worker (`scripts/sync/**`) + `sync-companies.yml` | **Drop** (fold into Python cron) |
+| Separate `company_sources` provenance table | **Drop** (row `raw_json`/`source_url` suffices) |
+
+## 5. Data flow
+
+```
+daily cron ─▶ /api/cron/sync-sources ─▶ sync_service.run()
+     for each adapter (hackernews, [producthunt], [techstars]):
+        sync_state.last_cursor ─▶ adapter.fetch(cursor) ─▶ rows + new cursor
+        rows ─▶ to_global_id + dedupe_key ─▶ db.insert_company (upsert on id)
+        new cursor ─▶ sync_state
+     company_cache.refresh(db)
+
+read path (merged view):
+   cache rows ─grouped by dedupe_key─▶ primary + merged_sources[] ─▶ API ─▶ UI badge cluster
+```
+
+## 6. Testing (matches `backend/test_*.py` style)
+
+- `test_normalize.py`: `norm_domain` (www/path/port stripping, denylist), `slugify`,
+  `dedupe_key`, `country_from_locations`.
+- `test_hackernews_parse.py`: title-parsing fixtures from real Launch/Show HN titles
+  (with/without `(YC S26)`, em/en dash variants, non-company noise).
+- `test_merge_grouping.py`: rows across sources sharing a domain collapse to one canonical
+  entry with correct primary selection, gap-fill, and `merged_sources`.
+- `sync_service` dry-run against live HN (bounded lookback) as a smoke check.
+
+## 7. Risks & mitigations
+
+- **False merges on shared hosts** → domain denylist + `source:slug` fallback.
+- **HN noise (non-company Show HN posts)** → require URL/domain or YC-batch marker; source
+  tag allows later filtering.
+- **Merged-view correctness vs. YC-only analytics** → merge is read-only and opt-in;
+  analytics keep `WHERE source = 'yc'`.
+- **SQLite/Postgres drift** → schema change applied to both; tests run on SQLite locally.
+
+## 8. Rollout
+
+1. Migration (+ SQLite parity) — additive only.
+2. Register sources, ship ingestion package + HN adapter (+ stubs), backfill `dedupe_key`.
+3. Wire merged read path + cron endpoint (behind opt-in flag), keep default YC-only.
+4. Frontend badges + merged cluster.
+5. Trigger a bounded HN run, verify grouping, then enable in daily cron.

--- a/docs/superpowers/specs/2026-07-11-multi-source-company-sync-design.md
+++ b/docs/superpowers/specs/2026-07-11-multi-source-company-sync-design.md
@@ -38,14 +38,19 @@ opposite of meshing. This design keeps the PR's genuinely-new ideas and drops th
    a16z + YC, …) presents as a single card showing multiple source badges.
 4. **Incremental cursor sync** for the new sources (`sync_state`), so daily runs pull
    deltas, not full refreshes.
-5. **Zero data loss** and **zero regression** to existing YC/a16z data, IDs, analytics,
-   embeddings, and the hero validator.
+5. **Vector search covers all sources.** Every new-source company gets an embedding via
+   the existing automated backfill, and similarity retrieval searches the whole corpus
+   (deduped by `dedupe_key`) — not just YC (see §3.8).
+6. **Zero data loss** and **zero regression** to existing YC/a16z data, IDs, and the
+   YC-scoped analytics metrics (market-size %, crowding).
 
 ### Non-goals (explicitly out of scope)
 
 - Replacing the YC Algolia scraper or adopting yc-oss's delta feed (keep current setup).
 - Physically merging rows / retiring the global-id scheme (canonical-row merge — rejected).
-- Extending embeddings or the hero idea-validator to non-YC sources (stays YC-only).
+- Changing the **market-size % / crowding** metric's meaning: it stays a YC-denominated
+  metric ("% of *YC* companies similar"), computed on a separate YC-only path so broadening
+  retrieval does not reintroduce the prior over-counting bug (see §3.8).
 
 ## 2. Chosen approach: grouping-layer merge (option A)
 
@@ -141,9 +146,7 @@ A new self-contained package (mirrors the existing flat-service style but groupe
      (existing upsert on `id` + `(source, source_id)`/`(source, slug)`)
   4. soft-mark `result.removed_source_ids` (never hard delete)
   5. persist new cursor + status to `sync_state`
-  6. `company_cache.refresh(db)`
-  - New sources do **not** get embeddings (embeddings/hero stay YC-only); they're searchable
-    via the existing cache substring search.
+  6. embedding backfill for the newly-upserted rows (see §3.8), then `company_cache.refresh(db)`
 
 ### 3.4 `dedupe_key` backfill
 
@@ -195,7 +198,37 @@ A new self-contained package (mirrors the existing flat-service style but groupe
   exist; add a "merged" view affordance.
 - Cards degrade gracefully for rows lacking `batch`/`all_locations` (HN launches).
 
-## 4. What we keep vs. drop from the PR
+### 3.8 Vector embeddings across all sources (`embedding_service.py`, `database_postgres.py`)
+
+Vector search must cover the whole corpus. The pieces already exist (pgvector column,
+HNSW index, batched generation, automated daily backfill) — the change is to stop scoping
+them to YC. Three edits, plus one preservation:
+
+- **Generation — cover all sources.** `get_companies_for_embedding` (`database_postgres.py:873`)
+  and the parallel counters (`:811`/`:822`) currently hardcode `WHERE source = 'yc'`.
+  Generalize the *embedding backfill* query to return every source's rows missing an
+  `embedding` (keep it batched). `build_company_embedding_text` already uses
+  `name, one_liner, long_description, industry, subindustry, tags, industries`, which HN /
+  Product Hunt / Techstars rows populate well enough (with graceful fallback when sparse).
+  The HNSW index at `20260710…` already covers the column regardless of source, so new
+  vectors are query-visible immediately — directly avoiding the prior "new companies
+  disappeared from search" (IVFFlat) regression.
+- **Retrieval — search all sources.** `find_similar_companies_by_embedding`
+  (`database_postgres.py:944`, filters `source = 'yc'` at `:980`/`:1023`) drops the source
+  filter so similarity spans the full corpus, and **dedupes results by `dedupe_key`** (via
+  a `DISTINCT ON (dedupe_key)` / window over cosine distance) so a company present in
+  multiple sources returns once, tagged with its `merged_sources`.
+- **Backfill wiring.** `sync_service` embeds newly-upserted rows in the same run; the
+  existing daily embedding backfill (already automated) is broadened to all sources as the
+  catch-all. New sources therefore get vectors without a manual step.
+- **Preserve the YC-scoped metric.** The **market-size % / crowding** computation
+  (`database_postgres.py:842`, currently `AND source = 'yc'`) keeps its own YC-only
+  numerator+denominator path, unchanged. Broadened retrieval feeds the *similar-companies
+  list*; it does **not** feed the metric's counts. This keeps "% of YC companies" honest
+  and avoids re-triggering the market-size over-counting bug.
+
+**Cost note:** embedding the added corpus (HN + stubs) is a one-time batched backfill plus
+small daily deltas — negligible against the existing ~6k YC embeddings.
 
 | From the PR | Disposition |
 | --- | --- |
@@ -227,6 +260,9 @@ read path (merged view):
   (with/without `(YC S26)`, em/en dash variants, non-company noise).
 - `test_merge_grouping.py`: rows across sources sharing a domain collapse to one canonical
   entry with correct primary selection, gap-fill, and `merged_sources`.
+- `test_embedding_all_sources.py`: `get_companies_for_embedding` returns non-YC rows;
+  `find_similar_companies_by_embedding` returns cross-source matches deduped by `dedupe_key`;
+  and the market-size % path stays YC-only (regression guard).
 - `sync_service` dry-run against live HN (bounded lookback) as a smoke check.
 
 ## 7. Risks & mitigations
@@ -235,13 +271,22 @@ read path (merged view):
 - **HN noise (non-company Show HN posts)** → require URL/domain or YC-batch marker; source
   tag allows later filtering.
 - **Merged-view correctness vs. YC-only analytics** → merge is read-only and opt-in;
-  analytics keep `WHERE source = 'yc'`.
+  market-size %/crowding keep their separate `WHERE source = 'yc'` path (§3.8).
+- **Broadened retrieval changing hero results** → intended (search now spans all sources),
+  but the market-size metric is preserved on its own path; regression guarded by
+  `test_embedding_all_sources.py`.
+- **Sparse embedding text for HN/stub rows** → `build_company_embedding_text` fallback
+  handles missing industry/tags; embedding still keys on name + one_liner + description.
 - **SQLite/Postgres drift** → schema change applied to both; tests run on SQLite locally.
+  (Note: vector retrieval is Postgres/pgvector-only, as today.)
 
 ## 8. Rollout
 
 1. Migration (+ SQLite parity) — additive only.
 2. Register sources, ship ingestion package + HN adapter (+ stubs), backfill `dedupe_key`.
-3. Wire merged read path + cron endpoint (behind opt-in flag), keep default YC-only.
-4. Frontend badges + merged cluster.
-5. Trigger a bounded HN run, verify grouping, then enable in daily cron.
+3. Broaden embedding generation + retrieval to all sources (§3.8), keeping the YC-only
+   market-size path separate; run a one-time all-source embedding backfill.
+4. Wire merged read path + cron endpoint (behind opt-in flag), keep default YC-only.
+5. Frontend badges + merged cluster.
+6. Trigger a bounded HN run, verify grouping + cross-source vector hits, then enable in
+   daily cron.

--- a/frontend/src/components/CompaniesBrowser.tsx
+++ b/frontend/src/components/CompaniesBrowser.tsx
@@ -8,6 +8,7 @@ import { Button } from './ui/button';
 import { apiClient } from '../lib/api';
 import type { Company, CompanyFilter } from '../lib/api';
 import { formatNumber } from '../lib/utils';
+import { SourceBadge, MergedSourceBadges } from './ui/SourceBadge';
 
 interface CompaniesBrowserProps {
   refreshTrigger?: number;
@@ -22,6 +23,9 @@ export function CompaniesBrowser({ refreshTrigger }: CompaniesBrowserProps) {
   const [search, setSearch] = useState('');
   const [batchFilter, setBatchFilter] = useState('');
   const [hiringFilter, setHiringFilter] = useState<boolean | undefined>(undefined);
+  // Merge same-company rows across sources; semantic = all-source vector search.
+  const [mergeSources, setMergeSources] = useState(false);
+  const [semantic, setSemantic] = useState(false);
 
   const PAGE_SIZE = 20;
 
@@ -32,6 +36,14 @@ export function CompaniesBrowser({ refreshTrigger }: CompaniesBrowserProps) {
   const loadCompanies = async () => {
     setLoading(true);
     try {
+      // Semantic search: all-source vector search (single page of ranked matches).
+      if (semantic && search.trim()) {
+        const response = await apiClient.getSimilarCompanies(search.trim(), PAGE_SIZE);
+        setCompanies(response.data.companies);
+        setTotal(response.data.companies.length);
+        return;
+      }
+
       const filters: CompanyFilter = {
         limit: PAGE_SIZE,
         offset: currentPage * PAGE_SIZE,
@@ -40,6 +52,10 @@ export function CompaniesBrowser({ refreshTrigger }: CompaniesBrowserProps) {
       if (search) filters.search = search;
       if (batchFilter) filters.batch = batchFilter;
       if (hiringFilter !== undefined) filters.is_hiring = hiringFilter;
+      if (mergeSources) {
+        filters.merged = true;
+        filters.source = 'all';
+      }
 
       const response = await apiClient.getCompanies(filters);
       setCompanies(response.data.companies);
@@ -100,10 +116,30 @@ export function CompaniesBrowser({ refreshTrigger }: CompaniesBrowserProps) {
           </div>
 
           <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mt-4">
-            <Button onClick={handleSearch} className="bg-[#FB651E] hover:bg-[#E65C00]">
-              <Search className="mr-2 h-4 w-4" />
-              Search
-            </Button>
+            <div className="flex flex-wrap items-center gap-4">
+              <Button onClick={handleSearch} className="bg-[#FB651E] hover:bg-[#E65C00]">
+                <Search className="mr-2 h-4 w-4" />
+                Search
+              </Button>
+
+              <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={mergeSources}
+                  onChange={(e) => { setMergeSources(e.target.checked); setCurrentPage(0); }}
+                />
+                Merge sources
+              </label>
+
+              <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer" title="All-source semantic (vector) search">
+                <input
+                  type="checkbox"
+                  checked={semantic}
+                  onChange={(e) => { setSemantic(e.target.checked); setCurrentPage(0); }}
+                />
+                Semantic search
+              </label>
+            </div>
 
             <span className="text-sm text-muted-foreground">
               {formatNumber(total)} companies found
@@ -131,12 +167,19 @@ export function CompaniesBrowser({ refreshTrigger }: CompaniesBrowserProps) {
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
                       <CardTitle className="text-lg">{company.name}</CardTitle>
-                      {company.is_hiring && (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 mt-1">
-                          <Briefcase className="h-3 w-3 mr-1" />
-                          Hiring
-                        </span>
-                      )}
+                      <div className="flex items-center gap-2 mt-1">
+                        {company.merged_sources && company.merged_sources.length > 0 ? (
+                          <MergedSourceBadges sources={company.merged_sources} />
+                        ) : (
+                          <SourceBadge source={company.source} />
+                        )}
+                        {company.is_hiring && (
+                          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
+                            <Briefcase className="h-3 w-3 mr-1" />
+                            Hiring
+                          </span>
+                        )}
+                      </div>
                     </div>
                     {company.small_logo_thumb_url && (
                       <img
@@ -153,10 +196,12 @@ export function CompaniesBrowser({ refreshTrigger }: CompaniesBrowserProps) {
                   </p>
 
                   <div className="space-y-2 text-xs text-muted-foreground">
-                    <div className="flex items-center">
-                      <Calendar className="h-3 w-3 mr-2" />
-                      {company.batch}
-                    </div>
+                    {company.batch && (
+                      <div className="flex items-center">
+                        <Calendar className="h-3 w-3 mr-2" />
+                        {company.batch}
+                      </div>
+                    )}
 
                     {company.all_locations && (
                       <div className="flex items-center">

--- a/frontend/src/components/CompanyDetailModal.tsx
+++ b/frontend/src/components/CompanyDetailModal.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
 } from './ui/dialog';
 import { Button } from './ui/button';
-import { SourceBadge, sourceLabel } from './ui/SourceBadge';
+import { SourceBadge, MergedSourceBadges, sourceLabel } from './ui/SourceBadge';
 import type { Company } from '../lib/api';
 
 interface CompanyDetailModalProps {
@@ -83,10 +83,17 @@ export function CompanyDetailModal({ company, open, onClose, showViewFullPage }:
         >
           {/* Status Badges */}
           <div className="flex flex-wrap gap-2 items-center">
-            <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-border bg-muted/40">
-              <SourceBadge source={company.source} />
-              <span className="text-sm font-medium text-foreground">{sourceLabel(company.source)}</span>
-            </span>
+            {company.merged_sources && company.merged_sources.length > 1 ? (
+              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-border bg-muted/40">
+                <MergedSourceBadges sources={company.merged_sources} />
+                <span className="text-sm font-medium text-foreground">{company.merged_sources.length} sources</span>
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-border bg-muted/40">
+                <SourceBadge source={company.source} />
+                <span className="text-sm font-medium text-foreground">{sourceLabel(company.source)}</span>
+              </span>
+            )}
             {company.is_hiring && (
               <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800 border border-green-200">
                 <Briefcase className="h-4 w-4 mr-1" />

--- a/frontend/src/components/ui/SourceBadge.tsx
+++ b/frontend/src/components/ui/SourceBadge.tsx
@@ -1,9 +1,40 @@
 /**
- * Brand badge for a company's source (incubator / VC).
- * - YC   -> iconic orange "Y" square
- * - a16z -> black "a16z" wordmark
- * Add new sources here as the platform expands.
+ * Brand badge for a company's source (incubator / VC / launch platform).
+ * Add a new source = one entry in BRAND below.
  */
+
+type Brand = { bg: string; fg: string; text: string; label: string; title: string };
+
+const BRAND: Record<string, Brand> = {
+  yc: {
+    bg: 'bg-[#FB651E]', fg: 'text-white', text: 'Y',
+    label: 'Y Combinator', title: 'Y Combinator',
+  },
+  a16z: {
+    bg: 'bg-black dark:bg-white', fg: 'text-white dark:text-black', text: 'a16z',
+    label: 'Andreessen Horowitz', title: 'Andreessen Horowitz (a16z)',
+  },
+  hackernews: {
+    bg: 'bg-[#FF6600]', fg: 'text-white', text: 'HN',
+    label: 'Hacker News', title: 'Hacker News (Launch HN / Show HN)',
+  },
+  producthunt: {
+    bg: 'bg-[#DA552F]', fg: 'text-white', text: 'P',
+    label: 'Product Hunt', title: 'Product Hunt',
+  },
+  techstars: {
+    bg: 'bg-[#12B886]', fg: 'text-white', text: 'T',
+    label: 'Techstars', title: 'Techstars',
+  },
+};
+
+function brandFor(source?: string): Brand {
+  return BRAND[(source || 'yc').toLowerCase()] ?? {
+    bg: 'bg-muted', fg: 'text-foreground', text: (source || '?').slice(0, 2).toUpperCase(),
+    label: source || 'Unknown', title: source || 'Unknown',
+  };
+}
+
 export function SourceBadge({
   source,
   showLabel = false,
@@ -15,44 +46,53 @@ export function SourceBadge({
   size?: 'sm' | 'md';
   className?: string;
 }) {
-  const src = (source || 'yc').toLowerCase();
-  const box = size === 'md' ? 'h-6 text-[13px]' : 'h-5 text-[11px]';
-  const ySquare = size === 'md' ? 'w-6 h-6 text-[15px]' : 'w-5 h-5 text-[13px]';
+  const brand = brandFor(source);
+  const isWordmark = brand.text.length > 2; // a16z-style wordmark vs single-square
+  const square = size === 'md' ? 'w-6 h-6 text-[15px]' : 'w-5 h-5 text-[13px]';
+  const wordmark = size === 'md' ? 'h-6 px-1.5 text-[13px]' : 'h-5 px-1.5 text-[11px]';
 
-  if (src === 'a16z') {
-    return (
-      <span className={`inline-flex items-center gap-1.5 ${className}`} title="Andreessen Horowitz (a16z)">
-        <span
-          className={`inline-flex items-center justify-center px-1.5 ${box} rounded-sm bg-black dark:bg-white text-white dark:text-black font-bold tracking-tight leading-none`}
-        >
-          a16z
-        </span>
-        {showLabel && <span className="text-xs text-muted-foreground">Andreessen Horowitz</span>}
-      </span>
-    );
-  }
-
-  // Default: Y Combinator
   return (
-    <span className={`inline-flex items-center gap-1.5 ${className}`} title="Y Combinator">
+    <span className={`inline-flex items-center gap-1.5 ${className}`} title={brand.title}>
       <span
-        className={`inline-flex items-center justify-center ${ySquare} rounded-sm bg-[#FB651E] text-white font-bold leading-none`}
+        className={`inline-flex items-center justify-center rounded-sm font-bold leading-none tracking-tight ${brand.bg} ${brand.fg} ${isWordmark ? wordmark : square}`}
       >
-        Y
+        {brand.text}
       </span>
-      {showLabel && <span className="text-xs text-muted-foreground">Y Combinator</span>}
+      {showLabel && <span className="text-xs text-muted-foreground">{brand.label}</span>}
+    </span>
+  );
+}
+
+/** A row of badges for a company merged across multiple sources. Deduped by key. */
+export function MergedSourceBadges({
+  sources,
+  size = 'sm',
+  className = '',
+}: {
+  sources?: { key: string; source_url?: string }[];
+  size?: 'sm' | 'md';
+  className?: string;
+}) {
+  if (!sources || sources.length === 0) return null;
+  const seen = new Set<string>();
+  const uniq = sources.filter((s) => {
+    const k = (s.key || 'yc').toLowerCase();
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+  return (
+    <span className={`inline-flex items-center gap-1 ${className}`}>
+      {uniq.map((s) => (
+        <SourceBadge key={s.key} source={s.key} size={size} />
+      ))}
     </span>
   );
 }
 
 /** Display name for a source key. */
 export function sourceLabel(source?: string): string {
-  switch ((source || 'yc').toLowerCase()) {
-    case 'a16z':
-      return 'a16z';
-    case 'yc':
-      return 'Y Combinator';
-    default:
-      return source || 'Y Combinator';
-  }
+  const key = (source || 'yc').toLowerCase();
+  if (key === 'a16z') return 'a16z';
+  return BRAND[key]?.label ?? source ?? 'Y Combinator';
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -29,6 +29,11 @@ export interface Company {
   id: number
   source?: string
   source_id?: string
+  dedupe_key?: string
+  // Present when a company was merged across sources (source=all&merged=true)
+  merged_sources?: { key: string; source_url?: string }[]
+  // Present on semantic-search results (/api/companies/similar)
+  similarity_score?: number
   name: string
   slug: string
   website: string
@@ -96,6 +101,7 @@ export interface CompanyFilter {
   search?: string
   top_company?: boolean
   source?: string // undefined -> YC only; 'all' -> every source; or a source key like 'a16z'
+  merged?: boolean // collapse same-domain rows across sources into one card
 }
 
 export interface Source {
@@ -205,6 +211,9 @@ export const apiClient = {
     api.post<{ companies: Company[]; total: number; has_more: boolean }>('/api/companies', filters),
   getCompany: (id: number) => api.get<Company>(`/api/companies/${id}`),
   getCompanyBySlug: (slug: string) => api.get<Company>(`/api/company/slug/${slug}`),
+  // All-source semantic search (vector search across YC + Hacker News + a16z + ...)
+  getSimilarCompanies: (query: string, limit = 12) =>
+    api.post<{ companies: Company[]; total: number }>('/api/companies/similar', { query, limit }),
 
   // Stats
   getStats: () => api.get<Stats>('/api/stats'),

--- a/frontend/src/pages/CompanyPage.tsx
+++ b/frontend/src/pages/CompanyPage.tsx
@@ -22,7 +22,7 @@ import { apiClient, type Company } from '../lib/api';
 import { Button } from '../components/ui/button';
 import { AnnouncementBanner } from '../components/AnnouncementBanner';
 import { CompanyResearch } from '../components/CompanyResearch';
-import { SourceBadge, sourceLabel } from '../components/ui/SourceBadge';
+import { SourceBadge, MergedSourceBadges, sourceLabel } from '../components/ui/SourceBadge';
 
 function formatLocations(allLocations: string, maxShow = 2): string {
   if (!allLocations?.trim()) return '';
@@ -171,11 +171,18 @@ export function CompanyPage() {
 
               {/* Status Badges */}
               <div className="flex flex-wrap gap-2 items-center">
-                {/* Source (incubator / VC) brand */}
-                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-border bg-muted/40">
-                  <SourceBadge source={company.source} />
-                  <span className="text-sm font-medium text-foreground">{sourceLabel(company.source)}</span>
-                </span>
+                {/* Source (incubator / VC / launch platform) brand — cluster when merged */}
+                {company.merged_sources && company.merged_sources.length > 1 ? (
+                  <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-border bg-muted/40">
+                    <MergedSourceBadges sources={company.merged_sources} />
+                    <span className="text-sm font-medium text-foreground">{company.merged_sources.length} sources</span>
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-border bg-muted/40">
+                    <SourceBadge source={company.source} />
+                    <span className="text-sm font-medium text-foreground">{sourceLabel(company.source)}</span>
+                  </span>
+                )}
                 {company.is_hiring && (
                   <span className="inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium bg-green-100 text-green-800 border border-green-200">
                     <Briefcase className="h-4 w-4 mr-1.5" />

--- a/supabase/migrations/20260711130000_multi_source_sync.sql
+++ b/supabase/migrations/20260711130000_multi_source_sync.sql
@@ -1,0 +1,28 @@
+-- =============================================================================
+-- Multi-source company sync — dedupe_key merge column + per-source cursor.
+-- NON-DESTRUCTIVE and IDEMPOTENT. Additive DDL only.
+--   * dedupe_key: normalized domain (else source:slug) used for read-time merge
+--     of the same company across sources (YC + Launch HN + a16z ...).
+--   * sync_state: per-source incremental cursor for the daily sync worker.
+-- No existing rows/ids/FKs are changed. Backfill of dedupe_key is done by the
+-- app (backfill_dedupe_keys) using the same normalizer the adapters use.
+-- =============================================================================
+
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS dedupe_key TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_companies_dedupe_key
+  ON companies (dedupe_key) WHERE dedupe_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS sync_state (
+  source           TEXT PRIMARY KEY,
+  last_run_at      TIMESTAMPTZ,
+  last_cursor      TEXT,
+  last_status      TEXT,
+  records_upserted INTEGER DEFAULT 0,
+  error            TEXT,
+  updated_at       TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Service-role-only, like the app's other operational tables. The sync worker
+-- uses the service key (bypasses RLS); no anon/authenticated policies added.
+ALTER TABLE sync_state ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Redefines the standalone `scripts/exploreyc-sync-pr/` PR to **mesh with ExploreYC's existing schema, ingestion, and source-aware UI** — instead of bolting on a parallel TypeScript worker with its own generic UUID schema.

## What this does
- **Hacker News as a native source** (Launch HN / Show HN), added the same way a16z was: a Python adapter reusing `to_global_id`, `insert_company`, cursor state, cache refresh. Product Hunt + Techstars ship as contract-complete stubs so the framework generalizes (one file per source).
- **Merge-on-domain, non-destructive.** A new `dedupe_key` column (normalized domain, else `source:slug`) groups the *same* company across sources into one card with a multi-source badge cluster. Merge is a **read-time** concern behind an opt-in `merged` flag — every per-source row stays intact, so **no data loss** and it's fully reversible.
- **Vector search across all sources.** Embedding generation + `find_similar_companies_by_embedding` are no longer YC-only, so semantic search spans the whole corpus (deduped by domain). New `POST /api/companies/similar` surfaces it. The hero idea-validator explicitly passes `source_filter="yc"` so its market-size % / "N YC companies overlap" verdict is **unchanged** (no re-trigger of the market-size over-counting bug).
- **Incremental cursor sync** via a new `sync_state` table + `/api/cron/sync-sources` (wired into `daily-cron.yml` at 2:30 AM UTC). YC stays on the existing Algolia scraper.
- **UI**: source badges for HN/PH/Techstars, merged badge cluster on cards/detail/modal, "Merge sources" + "Semantic search" toggles in the browser.

## Safety / no-data-loss
- Only additive DDL (`ADD COLUMN`, new `sync_state` table, indexes). Each source keeps a disjoint 1e9 id block; `insert_company` upserts `ON CONFLICT (id)`, so no source can overwrite another's row.
- `WHERE source='yc'` analytics (market-size %, crowding) are untouched; default `source=None` view stays YC-only.
- A **shared-host denylist** (github.com, vercel.app, google.com, marketplaces, …) prevents false merges — caught live during smoke testing when 167 `github.com/<repo>` Show HN posts collapsed into one card.

## Testing
- 34 backend unit tests (normalize, HN parser, sync_state, sync orchestrator, merge grouping, embedding/vector-scope regression guards).
- Live end-to-end smoke: real HN sync → 456 rows upserted → 452 merged cards (3 genuine multi-source) → default YC-only view intact.
- `tsc -b && vite build` passes.

## Rollout (after merge)
1. Apply `supabase/migrations/20260711130000_multi_source_sync.sql` (`supabase db push`) — additive only.
2. Trigger `POST /api/cron/sync-sources?full=true&sync=1` once (backfills `dedupe_key` + HN + embeddings). Reuses existing `CRON_SECRET` / `SUPABASE_*` / `OPENAI_API_KEY` — no new secrets.
3. Daily cron takes over at 2:30 AM UTC.

Design + implementation plan: `docs/superpowers/specs/2026-07-11-multi-source-company-sync-design.md`, `docs/superpowers/plans/2026-07-11-multi-source-company-sync.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)