### PR TITLE
Multi-source sync follow-ups: defaults, fail-soft prewarm, Product Hunt adapter

### DIFF
--- a/backend/ingestion/producthunt.py
+++ b/backend/ingestion/producthunt.py
@@ -1,14 +1,100 @@
-"""Product Hunt source adapter (STUB).
+"""Product Hunt source adapter.
 
-Framework proof — implements the adapter contract but returns no rows yet.
-To finish: use the Product Hunt GraphQL API
-(https://api.producthunt.com/v2/api/graphql, needs a PH_TOKEN), page over
-`posts` by `postedAfter` (cursor = last posted-at), and map each post to a row
-with source='producthunt', website -> dedupe_key, tagline -> one_liner,
-topics -> industries, and to_global_id('producthunt', post_numeric_id).
+Pulls newly-launched products from the Product Hunt GraphQL API v2 and maps them
+into ExploreYC company rows. Requires a developer token in the PH_TOKEN env var
+(create one at https://www.producthunt.com/v2/oauth/applications — "developer
+token" is enough for read-only queries). Without a token this adapter is a safe
+no-op so the sync run doesn't fail.
+
+Incremental: the cursor is the ISO timestamp of the newest product seen; the next
+run only asks for products `postedAfter` that time.
 """
 
+import json
+import logging
+import os
+import time
+import urllib.request
+
 from ingestion.base import FetchResult
+from ingestion.normalize import norm_domain, slugify, dedupe_key
+from sources import to_global_id
+
+logger = logging.getLogger(__name__)
+
+_GRAPHQL = "https://api.producthunt.com/v2/api/graphql"
+_PAGE_SIZE = 50
+_MAX_PAGES = 10  # cap per run to respect PON complexity/rate limits
+
+_QUERY = """
+query($after: String, $postedAfter: DateTime) {
+  posts(order: NEWEST, first: %d, after: $after, postedAfter: $postedAfter) {
+    pageInfo { hasNextPage endCursor }
+    edges {
+      node {
+        id name tagline description url website slug createdAt
+        thumbnail { url }
+        topics(first: 5) { edges { node { name } } }
+      }
+    }
+  }
+}
+""" % _PAGE_SIZE
+
+
+def _graphql(token, variables):
+    body = json.dumps({"query": _QUERY, "variables": variables}).encode()
+    req = urllib.request.Request(
+        _GRAPHQL,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        payload = json.loads(resp.read().decode())
+    if payload.get("errors"):
+        raise RuntimeError(f"Product Hunt GraphQL errors: {payload['errors']}")
+    return payload["data"]["posts"]
+
+
+def _to_row(node):
+    name = (node.get("name") or "").strip()
+    if not name:
+        return None
+    slug = node.get("slug") or slugify(name)
+    domain = norm_domain(node.get("website"))
+    topics = [
+        e["node"]["name"]
+        for e in (node.get("topics", {}) or {}).get("edges", [])
+        if e.get("node", {}).get("name")
+    ]
+    thumb = (node.get("thumbnail") or {}).get("url")
+    return {
+        "id": to_global_id("producthunt", int(node["id"])),
+        "source": "producthunt",
+        "source_id": str(node["id"]),
+        "source_url": node.get("url"),
+        "name": name,
+        "slug": slug,
+        "website": node.get("website"),
+        "one_liner": node.get("tagline"),
+        "long_description": node.get("description"),
+        "batch": None,
+        "tags": ["Product Hunt"],
+        "industries": topics,
+        "regions": [],
+        "isHiring": False,
+        "top_company": False,
+        "nonprofit": False,
+        "country": None,
+        "small_logo_thumb_url": thumb,
+        "launched_at": node.get("createdAt"),
+        "dedupe_key": dedupe_key(domain, "producthunt", slug),
+        "raw_json": node,
+    }
 
 
 class ProductHuntAdapter:
@@ -16,5 +102,33 @@ class ProductHuntAdapter:
     display_name = "Product Hunt"
 
     def fetch(self, cursor, full=False):
-        # TODO: fetch from the Product Hunt GraphQL API and map posts -> rows.
-        return FetchResult(rows=[], cursor=cursor, removed_source_ids=[])
+        token = (os.environ.get("PH_TOKEN") or "").strip()
+        if not token:
+            logger.warning("PH_TOKEN not set — skipping Product Hunt sync (no-op).")
+            return FetchResult(rows=[], cursor=cursor, removed_source_ids=[])
+
+        # First run (or full): look back a bounded window; else only new since cursor.
+        posted_after = None if (full or not cursor) else cursor
+        if posted_after is None and not full:
+            lookback_days = 30
+            posted_after = time.strftime(
+                "%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - lookback_days * 86400)
+            )
+
+        rows, after, newest = [], None, cursor
+        for _ in range(_MAX_PAGES):
+            posts = _graphql(token, {"after": after, "postedAfter": posted_after})
+            for edge in posts.get("edges", []):
+                node = edge.get("node") or {}
+                created = node.get("createdAt")
+                if created and (newest is None or created > newest):
+                    newest = created
+                row = _to_row(node)
+                if row:
+                    rows.append(row)
+            page = posts.get("pageInfo", {})
+            if not page.get("hasNextPage"):
+                break
+            after = page.get("endCursor")
+
+        return FetchResult(rows=rows, cursor=newest, removed_source_ids=[])

--- a/backend/ingestion/techstars.py
+++ b/backend/ingestion/techstars.py
@@ -1,14 +1,26 @@
-"""Techstars source adapter (STUB).
+"""Techstars source adapter (STUB — no stable public data source found).
 
-Framework proof — implements the adapter contract but returns no rows yet.
-To finish: scrape the Techstars portfolio (https://www.techstars.com/portfolio,
-which hydrates from a JSON payload), map each company to a row with
-source='techstars', website -> dedupe_key, program/batch -> batch, and
-to_global_id('techstars', native_id). No incremental cursor upstream, so a
-periodic full pull (full=True) is the expected mode.
+Investigated 2026-07-11: https://www.techstars.com/portfolio is a Next.js app
+that renders the company grid CLIENT-SIDE. The portfolio companies are NOT in
+the initial `__NEXT_DATA__` payload, there is no public JSON/GraphQL API or
+Algolia index exposed in the HTML, and there is no portfolio sitemap to
+enumerate `/portfolio/<slug>` pages. The fetch happens from a minified webpack
+bundle against an endpoint we could not pin down without reverse-engineering.
+
+Rather than ship a fragile scraper that breaks on the next site deploy, this is
+left as a graceful no-op. To finish, EITHER:
+  * discover the XHR the `[slug]` bundle calls (Network tab) and query it here, OR
+  * render the page with a headless browser and read the hydrated grid, OR
+  * ingest a maintained Techstars dataset (e.g. a periodic CSV export).
+Then map each company to a row with source='techstars', website -> dedupe_key,
+program/batch -> batch, and to_global_id('techstars', native_id).
 """
 
+import logging
+
 from ingestion.base import FetchResult
+
+logger = logging.getLogger(__name__)
 
 
 class TechstarsAdapter:
@@ -16,5 +28,5 @@ class TechstarsAdapter:
     display_name = "Techstars"
 
     def fetch(self, cursor, full=False):
-        # TODO: fetch the Techstars portfolio payload and map companies -> rows.
+        logger.info("Techstars adapter has no data source wired yet — skipping (no-op).")
         return FetchResult(rows=[], cursor=cursor, removed_source_ids=[])

--- a/backend/main.py
+++ b/backend/main.py
@@ -1811,6 +1811,20 @@ async def daily_scrape(request: Request, background_tasks: BackgroundTasks):
 async def _run_source_sync(full: bool = False):
     """Background task: pull new companies from all registered sources, embed, refresh."""
     from ingestion import sync_service
+    # Guard: the multi-source migration must be applied first. Probe the sync_state
+    # table so a missing migration surfaces a clear, actionable message rather than a
+    # cryptic 500 mid-sync.
+    try:
+        db.get_sync_cursor("__schema_probe__")
+    except Exception as e:
+        msg = (
+            "Multi-source schema not found — apply migration "
+            "supabase/migrations/20260711130000_multi_source_sync.sql "
+            "(adds companies.dedupe_key + the sync_state table) before syncing. "
+            f"Underlying error: {e}"
+        )
+        logger.error(f"Source sync blocked: {msg}")
+        raise HTTPException(status_code=503, detail=msg)
     try:
         db.backfill_dedupe_keys()
         results = sync_service.run_sync(db, full=full)

--- a/backend/test_producthunt_adapter.py
+++ b/backend/test_producthunt_adapter.py
@@ -1,0 +1,50 @@
+import os
+
+from ingestion.producthunt import ProductHuntAdapter, _to_row
+from ingestion import registry
+
+
+def test_no_token_is_graceful_noop(monkeypatch):
+    monkeypatch.delenv("PH_TOKEN", raising=False)
+    result = ProductHuntAdapter().fetch(None)
+    assert result.rows == []
+    assert result.removed_source_ids == []
+
+
+def _node(**kw):
+    base = {
+        "id": "455900", "name": "Acme AI", "tagline": "AI for dentists",
+        "description": "Longer description", "url": "https://www.producthunt.com/posts/acme-ai",
+        "website": "https://acme.ai", "slug": "acme-ai", "createdAt": "2026-07-10T12:00:00Z",
+        "thumbnail": {"url": "https://ph/logo.png"},
+        "topics": {"edges": [{"node": {"name": "Artificial Intelligence"}}]},
+    }
+    base.update(kw)
+    return base
+
+
+def test_maps_node_to_row():
+    row = _to_row(_node())
+    assert row["id"] == 4_000_455_900
+    assert row["source"] == "producthunt"
+    assert row["source_id"] == "455900"
+    assert row["name"] == "Acme AI"
+    assert row["dedupe_key"] == "acme.ai"           # merges with YC/HN on domain
+    assert row["one_liner"] == "AI for dentists"
+    assert row["industries"] == ["Artificial Intelligence"]
+    assert row["small_logo_thumb_url"] == "https://ph/logo.png"
+    assert row["tags"] == ["Product Hunt"]
+
+
+def test_maps_ph_redirect_website_falls_back_to_source_slug():
+    # PH sometimes returns its own redirect URL as the website -> denylisted host.
+    row = _to_row(_node(website="https://www.producthunt.com/r/abc123", slug="acme-ai"))
+    assert row["dedupe_key"] == "producthunt:acme-ai"
+
+
+def test_node_without_name_is_dropped():
+    assert _to_row(_node(name="")) is None
+
+
+def test_registry_still_resolves_producthunt():
+    assert registry.get_adapter("producthunt") is not None

--- a/frontend/src/components/CompaniesBrowser.tsx
+++ b/frontend/src/components/CompaniesBrowser.tsx
@@ -23,8 +23,9 @@ export function CompaniesBrowser({ refreshTrigger }: CompaniesBrowserProps) {
   const [search, setSearch] = useState('');
   const [batchFilter, setBatchFilter] = useState('');
   const [hiringFilter, setHiringFilter] = useState<boolean | undefined>(undefined);
-  // Merge same-company rows across sources; semantic = all-source vector search.
-  const [mergeSources, setMergeSources] = useState(false);
+  // Show all sources merged by default (same company across YC/HN/a16z = one card);
+  // users can uncheck to return to per-source rows. Semantic = all-source vector search.
+  const [mergeSources, setMergeSources] = useState(true);
   const [semantic, setSemantic] = useState(false);
 
   const PAGE_SIZE = 20;

--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -557,7 +557,7 @@ export function DatabasePage() {
   const [country, setCountry] = useState('');
   const [isHiring, setIsHiring] = useState(false);
   const [topOnly, setTopOnly] = useState(false);
-  const [source, setSource] = useState('yc'); // 'yc' (default) | 'a16z' | 'all'
+  const [source, setSource] = useState('all'); // 'all' (default) | 'yc' | 'a16z' | 'hackernews' | ...
   const [currentPage, setCurrentPage] = useState(1);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [exportOpen, setExportOpen] = useState(false);

--- a/scripts/prewarm_hero.py
+++ b/scripts/prewarm_hero.py
@@ -113,7 +113,25 @@ def make_cache_key(idea: str) -> str:
 
 
 def main() -> None:
+    # Fail-soft: skip cleanly (exit 0) on config gaps so the daily workflow doesn't
+    # go red. Pre-warming is a nice-to-have — the live /api/hero-answer still works.
+    if not (os.environ.get("OPENAI_API_KEY") or "").strip():
+        logger.warning("OPENAI_API_KEY not set — skipping hero pre-warm (no-op).")
+        return
+
     db = get_database()
+    # Vector search is Postgres/pgvector-only. Running against SQLite (DATABASE_URL
+    # unset) has no find_similar_companies_by_embedding — skip instead of erroring
+    # once per seed idea.
+    if not hasattr(db, "find_similar_companies_by_embedding"):
+        logger.warning(
+            "DB has no vector search (SQLite / DATABASE_URL unset) — skipping hero pre-warm (no-op)."
+        )
+        return
+    if hasattr(db, "count_companies_with_embeddings") and db.count_companies_with_embeddings() == 0:
+        logger.warning("No company embeddings present yet — skipping hero pre-warm (no-op).")
+        return
+
     emb = get_embedding_service()
     client = OpenAI()  # reads OPENAI_API_KEY from env
 


### PR DESCRIPTION
Follow-ups to #52 based on rollout feedback.

## Changes
- **Show all sources merged by default** — `CompaniesBrowser` defaults to `merged=true` + `source=all`; `DatabasePage` table defaults to `source=all`. (Re-applies the change that was dropped when #52 was squash-merged.)
- **Fail-soft hero pre-warm** — `scripts/prewarm_hero.py` now exits 0 (skips) instead of erroring when `OPENAI_API_KEY` is unset, the DB has no vector search (SQLite / `DATABASE_URL` unset → the `'Database' has no attribute 'find_similar_companies_by_embedding'` spam), or no embeddings exist yet. Stops the daily workflow going red on config gaps.
- **Clear migration error on sync** — `/api/cron/sync-sources` probes `sync_state` first and returns a `503` with *"apply migration 20260711130000_multi_source_sync.sql"* instead of a cryptic 500 when the multi-source migration hasn't been applied.
- **Real Product Hunt adapter** — pulls newest products from the PH GraphQL v2 API (needs a `PH_TOKEN` dev token; safe no-op without one), maps tagline/description/topics/thumbnail/website into company rows with domain `dedupe_key` and incremental `createdAt` cursor.
- **Techstars** — investigated; the portfolio is a client-rendered Next.js grid with no public API/sitemap/Algolia index, so it stays a documented graceful no-op rather than a fragile scraper. (Finishing it needs the discovered XHR endpoint or a headless render.)

## Testing
- 39 backend unit tests pass (adds `test_producthunt_adapter.py`).
- `tsc -b && vite build` passes.
- PH no-token no-op + node→row mapping verified.

## Note
This does **not** apply the production migration or trigger the first sync — those are still the two manual rollout steps (apply `20260711130000_multi_source_sync.sql`, then `POST /api/cron/sync-sources?full=true&sync=1`). Also: set the `OPENAI_API_KEY` GitHub Actions secret if you want hero pre-warming to actually run (it now skips cleanly instead of failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)