### PR TITLE
Fix HN slug collision (uq_companies_source_slug) + PH_TOKEN doc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,12 @@ FRONTEND_URL=http://localhost:5173
 # Shared secret required as a Bearer token on /api/cron/* endpoints.
 CRON_SECRET=generate-a-long-random-string
 
+# --- Multi-source sync (optional) ------------------------------------------
+# Product Hunt developer token — enables the Product Hunt source in the daily
+# sync. Create one at https://www.producthunt.com/v2/oauth/applications
+# ("Create Token"). Absent => Product Hunt is skipped (Hacker News still syncs).
+PH_TOKEN=your-product-hunt-developer-token
+
 # =============================================================================
 # Docker Compose
 # =============================================================================

--- a/backend/ingestion/hackernews.py
+++ b/backend/ingestion/hackernews.py
@@ -54,12 +54,14 @@ class HackerNewsAdapter:
         # Require a real domain OR a YC-batch marker to count as a company (drops noise).
         if not domain and not parsed["batch"]:
             return None
-        slug = slugify(name)
-        if not slug:
-            return None
+        object_id = str(hit["objectID"])
+        # slugify(name) is NOT unique across posts (two products can share a name, or
+        # the same one is reposted), but the DB enforces UNIQUE(source, slug). Suffix
+        # the unique HN item id so distinct posts never collide on (source, slug).
+        base_slug = slugify(name) or object_id
+        slug = f"{base_slug}-{object_id}"
         is_launch = bool(re.match(r"^\s*launch\s+hn", hit.get("title", ""), re.I))
         tag = "Launch HN" if is_launch else "Show HN"
-        object_id = str(hit["objectID"])
         return {
             "id": to_global_id("hackernews", int(object_id)),
             "source": "hackernews",
@@ -78,7 +80,9 @@ class HackerNewsAdapter:
             "top_company": False,
             "nonprofit": False,
             "country": None,
-            "dedupe_key": dedupe_key(domain, "hackernews", slug),
+            # Merge on domain when present; otherwise keep each post distinct (by id) —
+            # domainless posts can't be reliably merged by name without false positives.
+            "dedupe_key": dedupe_key(domain, "hackernews", object_id),
             "raw_json": hit,
         }
 

--- a/backend/ingestion/sync_service.py
+++ b/backend/ingestion/sync_service.py
@@ -26,13 +26,26 @@ def run_sync(db, sources=None, full=False):
         try:
             cursor = db.get_sync_cursor(key)
             result = adapter.fetch(cursor, full=full)
+            # Per-row resilience: a single bad row (e.g. an unexpected constraint
+            # violation) is skipped and logged, never aborting the whole source or
+            # losing the cursor progress.
+            upserted, failed = 0, 0
             for row in result.rows:
-                db.insert_company(row)
+                try:
+                    db.insert_company(row)
+                    upserted += 1
+                except Exception as row_err:  # noqa: BLE001
+                    failed += 1
+                    logger.warning(
+                        "sync %s: skipped row source_id=%s slug=%s: %s",
+                        key, row.get("source_id"), row.get("slug"), row_err,
+                    )
             _soft_remove(db, key, result.removed_source_ids)
-            db.save_sync_state(key, result.cursor, "ok", len(result.rows))
-            results[key] = {"upserted": len(result.rows), "cursor": result.cursor,
-                            "status": "ok"}
-            logger.info("sync %s: upserted %d, cursor %s", key, len(result.rows), result.cursor)
+            db.save_sync_state(key, result.cursor, "ok", upserted)
+            results[key] = {"upserted": upserted, "failed": failed,
+                            "cursor": result.cursor, "status": "ok"}
+            logger.info("sync %s: upserted %d, failed %d, cursor %s",
+                        key, upserted, failed, result.cursor)
         except Exception as e:  # noqa: BLE001 — one bad source must not sink the rest
             db.save_sync_state(key, None, "error", 0, str(e))
             results[key] = {"upserted": 0, "cursor": None, "status": "error", "error": str(e)}

--- a/backend/test_hackernews_adapter.py
+++ b/backend/test_hackernews_adapter.py
@@ -37,7 +37,8 @@ def test_to_row_sets_source_and_key():
     assert row["source"] == "hackernews"
     assert row["source_id"] == "42"
     assert row["id"] == 3_000_000_042
-    assert row["dedupe_key"] == "acme.com"
+    assert row["dedupe_key"] == "acme.com"       # merges on domain when present
+    assert row["slug"] == "acme-42"              # slug is unique (name + HN id)
     assert row["batch"] == "S26"
     assert row["isHiring"] is False
     assert row["tags"] == ["Launch HN"]
@@ -52,11 +53,25 @@ def test_to_row_drops_noise_without_domain_or_batch():
     assert row is None
 
 
-def test_to_row_shared_host_falls_back_to_source_slug():
+def test_to_row_shared_host_stays_distinct_by_id():
+    # A shared host (github.io) can't merge, so each post is distinct by its id.
     row = HackerNewsAdapter()._to_row(_hit(
         title="Show HN: MyProj – a tool", url="https://myproj.github.io", objectID="7",
     ))
-    assert row["dedupe_key"] == "hackernews:myproj"
+    assert row["dedupe_key"] == "hackernews:7"
+
+
+def test_same_name_posts_get_unique_slugs_no_collision():
+    # Regression: two different posts named "Inconvo" must NOT collide on (source, slug).
+    a = HackerNewsAdapter()._to_row(_hit(
+        title="Launch HN: Inconvo (YC S26) – a", url="https://inconvo.com", objectID="100",
+    ))
+    b = HackerNewsAdapter()._to_row(_hit(
+        title="Show HN: Inconvo – b", url="https://inconvo.com", objectID="200",
+    ))
+    assert a["slug"] != b["slug"]                 # unique -> no UNIQUE(source, slug) violation
+    assert a["slug"] == "inconvo-100" and b["slug"] == "inconvo-200"
+    assert a["dedupe_key"] == b["dedupe_key"] == "inconvo.com"  # same domain still merges
 
 
 def test_registry_has_all_adapters():


### PR DESCRIPTION
The two commits that the #54 squash-merge dropped (it captured a snapshot before they were pushed). **The HN slug fix is the important one** — without it the deployed HN sync still aborts on `(source, slug)=(hackernews, inconvo) already exists`.

- **Unique HN slugs**: `slugify(name)` isn't unique across posts; suffix the HN item id (`name-<id>`) so distinct posts can't violate `UNIQUE(source, slug)`. Merge still keys on domain; domainless posts stay distinct by id.
- **Per-row resilience** in `run_sync`: one bad row is skipped/logged instead of aborting the whole source (and the cursor still advances).
- Documents `PH_TOKEN` in `.env.example`.

Verified on live HN: 764 rows, 0 duplicate slugs (6 repeated names). 40 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)