### PR TITLE
Source data quality: clean HN descriptions, logos, all-source DB total, dedup YC-batch rows

### DIFF
--- a/backend/company_cache.py
+++ b/backend/company_cache.py
@@ -102,7 +102,8 @@ class CompanyCache:
                 by_batch_industry[b][ind] = by_batch_industry[b].get(ind, 0) + 1
 
         self._stats = {
-            "total_companies": total,
+            "total_companies": total,               # YC-only (hero / YC-facing views)
+            "total_all_companies": len(companies),  # every source (Database page)
             "hiring": hiring,
             "by_batch": by_batch,
             "by_industry": by_industry,

--- a/backend/database.py
+++ b/backend/database.py
@@ -667,6 +667,19 @@ class Database:
                 )
             return len(rows)
 
+    def delete_source_companies_with_batch(self, sources=("hackernews", "producthunt")) -> int:
+        """Delete rows from the given non-YC sources that carry a YC batch (they
+        duplicate the canonical source='yc' row). Never touches source='yc'."""
+        placeholders = ",".join("?" for _ in sources)
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"DELETE FROM companies WHERE source IN ({placeholders}) "
+                f"AND source <> 'yc' AND batch IS NOT NULL AND batch <> ''",
+                tuple(sources),
+            )
+            return cursor.rowcount
+
     def record_feature_interest(self, feature: str, user_identifier: Optional[str] = None,
                                 email: Optional[str] = None) -> Dict:
         """Record interest in a currently-unavailable feature.

--- a/backend/database_postgres.py
+++ b/backend/database_postgres.py
@@ -281,6 +281,23 @@ class DatabasePostgres:
             conn.commit()
         return len(rows)
 
+    def delete_source_companies_with_batch(self, sources=("hackernews", "producthunt")) -> int:
+        """Delete rows from the given non-YC sources that carry a YC batch (e.g. a
+        Launch HN advertising '(YC W26)'). A batch means the company is a YC company
+        that already exists as the canonical source='yc' row, so the duplicate is
+        removed. Never touches source='yc'. Safe to run repeatedly / on a schedule."""
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM companies "
+                    "WHERE source = ANY(%s) AND source <> 'yc' "
+                    "AND batch IS NOT NULL AND batch <> ''",
+                    (list(sources),),
+                )
+                n = cur.rowcount
+            conn.commit()
+        return n
+
     def get_companies(
         self,
         limit: int = 100,

--- a/backend/ingestion/hackernews.py
+++ b/backend/ingestion/hackernews.py
@@ -4,6 +4,7 @@ Ports the sync-PR's HN parsing into a native Python adapter. Uses the HN Algolia
 search_by_date endpoint (no key) filtered on created_at_i for incremental pulls.
 """
 
+import html
 import json
 import re
 import time
@@ -17,6 +18,22 @@ from sources import to_global_id
 _SEARCH = "https://hn.algolia.com/api/v1/search_by_date"
 _MAX_PAGES = 20
 _HITS_PER_PAGE = 100
+
+
+def clean_hn_text(text):
+    """HN story_text is HTML (paragraph <p>, <a href> links, entities like
+    &#x27; / &#x2F;). Convert it to clean, readable plain text with paragraph
+    breaks so the company page (which renders text, whitespace-pre-wrap) doesn't
+    show raw tags/entities."""
+    if not text:
+        return None
+    t = re.sub(r"<p>", "\n\n", text, flags=re.I)
+    # Links: keep the visible label (HN's label is usually the URL itself).
+    t = re.sub(r'<a\s+[^>]*href="([^"]*)"[^>]*>(.*?)</a>', r"\2", t, flags=re.I | re.S)
+    t = re.sub(r"<[^>]+>", "", t)          # strip any remaining tags
+    t = html.unescape(t)                    # decode &#x27; &#x2F; &quot; &amp; ...
+    t = re.sub(r"\n{3,}", "\n\n", t)        # collapse excess blank lines
+    return t.strip() or None
 
 
 def parse_title(title):
@@ -67,11 +84,11 @@ class HackerNewsAdapter:
             "source": "hackernews",
             "source_id": object_id,
             "source_url": f"https://news.ycombinator.com/item?id={object_id}",
-            "name": name,
+            "name": html.unescape(name),
             "slug": slug,
             "website": hit.get("url"),
-            "one_liner": parsed["blurb"],
-            "long_description": hit.get("story_text"),
+            "one_liner": html.unescape(parsed["blurb"]) if parsed["blurb"] else None,
+            "long_description": clean_hn_text(hit.get("story_text")),
             "batch": parsed["batch"],
             "tags": [tag],
             "industries": [],
@@ -80,6 +97,9 @@ class HackerNewsAdapter:
             "top_company": False,
             "nonprofit": False,
             "country": None,
+            # HN gives no logo; fall back to a Clearbit logo keyed on the domain
+            # (allowlisted in the logo proxy; the UI hides it gracefully on 404).
+            "small_logo_thumb_url": f"https://logo.clearbit.com/{domain}" if domain else None,
             # Merge on domain when present; otherwise keep each post distinct (by id) —
             # domainless posts can't be reliably merged by name without false positives.
             "dedupe_key": dedupe_key(domain, "hackernews", object_id),

--- a/backend/ingestion/producthunt.py
+++ b/backend/ingestion/producthunt.py
@@ -72,6 +72,8 @@ def _to_row(node):
         if e.get("node", {}).get("name")
     ]
     thumb = (node.get("thumbnail") or {}).get("url")
+    if not thumb and domain:
+        thumb = f"https://logo.clearbit.com/{domain}"
     return {
         "id": to_global_id("producthunt", int(node["id"])),
         "source": "producthunt",

--- a/backend/main.py
+++ b/backend/main.py
@@ -1829,9 +1829,14 @@ async def _run_source_sync(full: bool = False):
         db.backfill_dedupe_keys()
         results = sync_service.run_sync(db, full=full)
         embedded = sync_service.embed_missing(db)
+        # Drop HN/PH rows that carry a YC batch — they duplicate the canonical YC row.
+        deduped = (
+            db.delete_source_companies_with_batch()
+            if hasattr(db, "delete_source_companies_with_batch") else 0
+        )
         company_cache.refresh(db)
-        logger.info(f"Source sync completed: {results}, embedded {embedded}")
-        return {"results": results, "embedded": embedded}
+        logger.info(f"Source sync completed: {results}, embedded {embedded}, deduped {deduped}")
+        return {"results": results, "embedded": embedded, "deduped": deduped}
     except Exception as e:
         logger.error(f"Source sync error: {e}")
         raise

--- a/backend/test_hackernews_adapter.py
+++ b/backend/test_hackernews_adapter.py
@@ -1,5 +1,18 @@
-from ingestion.hackernews import parse_title, HackerNewsAdapter
+from ingestion.hackernews import parse_title, HackerNewsAdapter, clean_hn_text
 from ingestion import registry
+
+
+def test_clean_hn_text_decodes_entities_and_strips_tags():
+    raw = ('Hey, we&#x27;re building '
+           '<a href="https:&#x2F;&#x2F;sonarly.com" rel="nofollow">https:&#x2F;&#x2F;sonarly.com</a>.'
+           '<p>Second paragraph.')
+    out = clean_hn_text(raw)
+    assert "<a" not in out and "<p>" not in out
+    assert "&#x27;" not in out and "&#x2F;" not in out
+    assert "we're building https://sonarly.com." in out
+    assert "\n\nSecond paragraph." in out
+    assert clean_hn_text(None) is None
+    assert clean_hn_text("") is None
 
 
 def test_parse_launch_with_yc_batch():
@@ -72,6 +85,14 @@ def test_same_name_posts_get_unique_slugs_no_collision():
     assert a["slug"] != b["slug"]                 # unique -> no UNIQUE(source, slug) violation
     assert a["slug"] == "inconvo-100" and b["slug"] == "inconvo-200"
     assert a["dedupe_key"] == b["dedupe_key"] == "inconvo.com"  # same domain still merges
+
+
+def test_to_row_sets_clearbit_logo_and_cleans_description():
+    row = HackerNewsAdapter()._to_row(_hit(
+        story_text="We&#x27;re here.<p>Line two.",
+    ))
+    assert row["small_logo_thumb_url"] == "https://logo.clearbit.com/acme.com"
+    assert row["long_description"] == "We're here.\n\nLine two."
 
 
 def test_registry_has_all_adapters():

--- a/backend/test_sync_state.py
+++ b/backend/test_sync_state.py
@@ -35,6 +35,24 @@ def test_backfill_dedupe_keys(tmp_path):
     assert db.backfill_dedupe_keys() == 0
 
 
+def test_delete_source_companies_with_batch(tmp_path):
+    db = Database(str(tmp_path / "t.db"))
+    db.insert_company({"id": 1, "source": "yc", "slug": "yc-acme", "name": "Acme",
+                       "batch": "W26", "isHiring": False})               # YC — keep
+    db.insert_company({"id": 3_000_000_001, "source": "hackernews", "slug": "hn-acme",
+                       "name": "Acme", "batch": "W26", "isHiring": False})  # HN+batch — delete
+    db.insert_company({"id": 3_000_000_002, "source": "hackernews", "slug": "hn-nb",
+                       "name": "NoBatch", "batch": None, "isHiring": False})  # HN, no batch — keep
+    db.insert_company({"id": 4_000_000_001, "source": "producthunt", "slug": "ph-x",
+                       "name": "X", "batch": "S25", "isHiring": False})   # PH+batch — delete
+    n = db.delete_source_companies_with_batch()
+    assert n == 2
+    assert db.get_company_by_id(1) is not None                # YC untouched
+    assert db.get_company_by_id(3_000_000_002) is not None    # HN no-batch untouched
+    assert db.get_company_by_id(3_000_000_001) is None        # HN+batch removed
+    assert db.get_company_by_id(4_000_000_001) is None        # PH+batch removed
+
+
 def test_insert_company_persists_dedupe_key(tmp_path):
     db = Database(str(tmp_path / "t.db"))
     db.insert_company({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -160,7 +160,8 @@ export interface UsageStats {
 }
 
 export interface Stats {
-  total_companies: number
+  total_companies: number          // YC-only
+  total_all_companies?: number     // every source (YC + Hacker News + a16z + ...)
   hiring: number
   by_batch: Record<string, number>
   by_industry: Record<string, number>

--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -707,7 +707,7 @@ export function DatabasePage() {
           {[
             {
               label: 'Total Companies',
-              value: stats?.total_companies?.toLocaleString() ?? '—',
+              value: (stats?.total_all_companies ?? stats?.total_companies)?.toLocaleString() ?? '—',
               icon: Building2,
               color: 'text-[#FB651E]',
             },

--- a/scripts/dedupe_source_companies.py
+++ b/scripts/dedupe_source_companies.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Delete Hacker News / Product Hunt companies that carry a YC batch.
+
+A batch on a non-YC source row (e.g. a Launch HN titled "... (YC W26)") means the
+company is a YC company that already exists as the canonical source='yc' row, so
+the duplicate is removed. Never touches source='yc'. Idempotent — safe to run
+repeatedly. The daily /api/cron/sync-sources runs this automatically after each
+sync; this script is for manual/one-off runs.
+
+Usage:
+    python scripts/dedupe_source_companies.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+from database_factory import get_database  # noqa: E402
+
+
+def main() -> None:
+    db = get_database()
+    if not hasattr(db, "delete_source_companies_with_batch"):
+        print("This database backend does not support source dedup — nothing to do.")
+        return
+    n = db.delete_source_companies_with_batch()
+    print(f"Deleted {n} batch-carrying HN/Product Hunt row(s) that duplicate YC companies.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes from live testing of the new sources.

1. **HN descriptions rendered raw HTML** (`<a href="https:&#x2F;&#x2F;...">`, `&#x27;`, `<p>`) on `/company/<name>`. `clean_hn_text()` decodes entities and strips/normalizes tags into readable text with paragraph breaks (the page already renders `whitespace-pre-wrap`). Names/blurbs are html-unescaped too.
2. **No logo for HN companies** → Clearbit logo from the domain (`logo.clearbit.com/<domain>`, already allowlisted; the UI hides it on 404). Product Hunt gets the same fallback when it has no thumbnail.
3. **Database page showed the YC-only total** → new `stats.total_all_companies` (every source) powers the "Total Companies" card; the YC-only `total_companies` stays for the hero/market-size stats.
4. **Dedup YC-batch duplicates** → `delete_source_companies_with_batch()` removes HN/PH rows that carry a YC batch (a Launch HN advertising `(YC W26)` = a YC company that already exists as the canonical `source='yc'` row). It runs after **every** `/api/cron/sync-sources` (so it's on the daily schedule) and as `scripts/dedupe_source_companies.py` for manual runs. Never touches `source='yc'`.

Existing HN rows with raw HTML/no logo are corrected on the next full re-sync.

43 backend tests pass (adds HTML-clean, logo, and delete tests); `tsc -b && vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)