### PR TITLE
Logo-priority ordering + remove broken logos + fix world map gray banners

### DIFF
--- a/backend/company_cache.py
+++ b/backend/company_cache.py
@@ -31,14 +31,10 @@ class CompanyCache:
 
     def _build_cache(self, companies: List[Dict]) -> None:
         """Build indices and derived data from company list."""
-        # Sort by created_at DESC (newest first) for get_companies pagination
-        def sort_key(c):
-            created = c.get("created_at")
-            if created is None:
-                return ""
-            return str(created) if not hasattr(created, "isoformat") else created.isoformat()
-
-        self._companies = sorted(companies, key=sort_key, reverse=True)
+        # Order: companies WITH a real logo first, then newest-first. Keeps the
+        # image-rich YC/a16z/Product Hunt rows ahead of logo-less Hacker News rows
+        # across every list view (browse, database, map subset).
+        self._companies = sorted(companies, key=self._priority_sort_key, reverse=True)
         self._companies_by_id = {c["id"]: c for c in companies if c.get("id") is not None}
 
         # Source breakdown (all sources) for /api/filters/sources
@@ -163,6 +159,14 @@ class CompanyCache:
         return str(created) if not hasattr(created, "isoformat") else created.isoformat()
 
     @staticmethod
+    def _priority_sort_key(c: Dict):
+        """Sort key (used with reverse=True): logo-having companies first, then
+        newest-first. A real logo (non-empty small_logo_thumb_url) ranks a row
+        ahead of logo-less ones so image-rich companies lead every list view."""
+        has_logo = 1 if (c.get("small_logo_thumb_url") or "").strip() else 0
+        return (has_logo, CompanyCache._created_sort_key(c))
+
+    @staticmethod
     def _merge_group(rows: List[Dict]) -> Dict:
         """Collapse rows sharing a dedupe_key into one canonical presentation:
         the highest-priority source is the primary; missing display fields are
@@ -194,7 +198,7 @@ class CompanyCache:
             key = c.get("dedupe_key") or f'id:{c.get("id")}'
             groups.setdefault(key, []).append(c)
         merged = [self._merge_group(g) for g in groups.values()]
-        merged.sort(key=self._created_sort_key, reverse=True)
+        merged.sort(key=self._priority_sort_key, reverse=True)
         return merged
 
     def _filter_companies(

--- a/backend/ingestion/hackernews.py
+++ b/backend/ingestion/hackernews.py
@@ -97,9 +97,10 @@ class HackerNewsAdapter:
             "top_company": False,
             "nonprofit": False,
             "country": None,
-            # HN gives no logo; fall back to a Clearbit logo keyed on the domain
-            # (allowlisted in the logo proxy; the UI hides it gracefully on 404).
-            "small_logo_thumb_url": f"https://logo.clearbit.com/{domain}" if domain else None,
+            # No logo — HN provides none, and Clearbit fallbacks were mostly broken
+            # (404). Leave null so the UI shows a clean letter-avatar and these rows
+            # sort AFTER companies that have a real logo (see company_cache ordering).
+            "small_logo_thumb_url": None,
             # Merge on domain when present; otherwise keep each post distinct (by id) —
             # domainless posts can't be reliably merged by name without false positives.
             "dedupe_key": dedupe_key(domain, "hackernews", object_id),

--- a/backend/ingestion/producthunt.py
+++ b/backend/ingestion/producthunt.py
@@ -71,9 +71,9 @@ def _to_row(node):
         for e in (node.get("topics", {}) or {}).get("edges", [])
         if e.get("node", {}).get("name")
     ]
+    # Product Hunt provides a real thumbnail; if absent, leave null (no broken
+    # Clearbit fallback) so the row sorts after logo-having companies.
     thumb = (node.get("thumbnail") or {}).get("url")
-    if not thumb and domain:
-        thumb = f"https://logo.clearbit.com/{domain}"
     return {
         "id": to_global_id("producthunt", int(node["id"])),
         "source": "producthunt",

--- a/backend/test_hackernews_adapter.py
+++ b/backend/test_hackernews_adapter.py
@@ -87,11 +87,12 @@ def test_same_name_posts_get_unique_slugs_no_collision():
     assert a["dedupe_key"] == b["dedupe_key"] == "inconvo.com"  # same domain still merges
 
 
-def test_to_row_sets_clearbit_logo_and_cleans_description():
+def test_to_row_has_no_logo_and_cleans_description():
     row = HackerNewsAdapter()._to_row(_hit(
         story_text="We&#x27;re here.<p>Line two.",
     ))
-    assert row["small_logo_thumb_url"] == "https://logo.clearbit.com/acme.com"
+    # No fake logo (Clearbit was broken) — HN rows sort after logo-having companies.
+    assert row["small_logo_thumb_url"] is None
     assert row["long_description"] == "We're here.\n\nLine two."
 
 

--- a/backend/test_merge_grouping.py
+++ b/backend/test_merge_grouping.py
@@ -77,3 +77,29 @@ def test_count_companies_merged():
     ])
     assert cache.count_companies(merged=True, source="all") == 1
     assert cache.count_companies(merged=False, source="all") == 2
+
+
+def test_logo_having_companies_sort_first():
+    cache = CompanyCache()
+    cache._build_cache([
+        # newer, but NO logo (Hacker News)
+        _c(id=1, source="hackernews", dedupe_key="a.com",
+           small_logo_thumb_url=None, created_at="2026-05-01"),
+        # older, but HAS a logo (YC)
+        _c(id=2, source="yc", dedupe_key="b.com",
+           small_logo_thumb_url="https://logo.png", created_at="2026-01-01"),
+    ])
+    rows = cache.get_companies(source="all")
+    assert [r["id"] for r in rows] == [2, 1]  # logo-having first despite being older
+
+
+def test_logo_priority_holds_in_merged_view():
+    cache = CompanyCache()
+    cache._build_cache([
+        _c(id=1, source="hackernews", dedupe_key="a.com",
+           small_logo_thumb_url=None, created_at="2026-05-01", source_url="hn/1"),
+        _c(id=2, source="yc", dedupe_key="b.com",
+           small_logo_thumb_url="https://logo.png", created_at="2026-01-01", source_url="yc/2"),
+    ])
+    rows = cache.get_companies(source="all", merged=True)
+    assert rows[0]["dedupe_key"] == "b.com"  # the logo-having canonical row leads

--- a/frontend/src/components/OptimizedMap.tsx
+++ b/frontend/src/components/OptimizedMap.tsx
@@ -270,13 +270,19 @@ export function OptimizedMap() {
             <MapContainer
               center={mapCenter}
               zoom={mapZoom}
-              style={{ height: '100%', width: '100%' }}
+              minZoom={2}
+              maxBounds={[[-85, -180], [85, 180]]}
+              maxBoundsViscosity={1.0}
+              worldCopyJump={true}
+              // Ocean-blue container so the poles/edges read as sea, not gray banners
+              style={{ height: '100%', width: '100%', background: '#aad3df' }}
               scrollWheelZoom={true}
               className="z-0"
             >
               <TileLayer
                 attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
                 url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                noWrap={false}
               />
 
               <MapUpdater center={mapCenter} zoom={mapZoom} />


### PR DESCRIPTION
Two issues from live browsing.

**1. Prioritize companies with logos; kill broken images.**
- New `company_cache._priority_sort_key`: companies **with a real logo sort first**, then newest-first — applied in both the plain and merged list paths, so browse + database lead with image-rich YC/a16z/Product Hunt rows and push logo-less Hacker News rows to the end. (YC-only default view is unaffected — all YC rows have logos.)
- Removed the Clearbit logo fallback from the HN/PH adapters (it 404'd → broken images). Logo-less rows now render a clean letter-avatar and sort last. Existing HN rows fix on the next re-sync.
- Analytics/hiring are aggregate/YC-only surfaces (HN/PH don't feed the hiring board), so they're unaffected.

**2. World map gray banners when zoomed out.**
- Clamp the view: `minZoom={2}`, `maxBounds` (±85/±180), `maxBoundsViscosity={1}`, `worldCopyJump`.
- Color the Leaflet container ocean-blue (`#aad3df`) so the poles/edges (Web Mercator has no tiles beyond ±85°) read as sea instead of gray banners.

28 backend tests pass (adds logo-ordering tests); `tsc -b && vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)