### PR TITLE
Hero headline + loading copy reflect all sources (not just YC & a16z)

### DIFF
--- a/frontend/src/components/LoadingScreen.tsx
+++ b/frontend/src/components/LoadingScreen.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Logo } from './ui/Logo';
 
 const LOADING_TIPS = [
-  'Discovering startups across YC & a16z...',
+  'Discovering startups across YC, Hacker News, Product Hunt & a16z...',
   'Mapping companies across the globe...',
   'Indexing industries and hiring status...',
   'Building your explorer view...',

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -92,7 +92,7 @@ export function HomePage() {
             >
               <span className="text-[#FB651E]">&gt;</span>{' '}
               <span className="bg-gradient-to-br from-foreground via-foreground to-foreground/60 bg-clip-text text-transparent">
-                Explore YC &amp; a16z startups
+                Explore YC, a16z &amp; top startups
               </span>
             </motion.h1>
 


### PR DESCRIPTION
The H1 still said "Explore YC & a16z startups" while the subline already listed all sources. Updated the headline to "Explore YC, a16z & top startups" and the loading tip to name Hacker News + Product Hunt too.

`vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)