### PR TITLE
Hero: replace Open Source banner with Product Hunt #1-of-the-day badge

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -208,31 +208,21 @@ export function HomePage() {
               />
             </motion.a>
 
-            {/* Open Source / GitHub banner */}
+            {/* Product Hunt — #1 Product of the Day badge (proof we ranked first) */}
             <a
-              href="https://github.com/KonstantinMB/exploreyc"
+              href="https://www.producthunt.com/products/yc-company-explorer?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-exploreyc-2"
               target="_blank"
               rel="noopener noreferrer"
-              className="group inline-flex items-center gap-2.5 px-4 py-2 font-mono text-sm border border-border bg-background/50 hover:border-[#FB651E]/50 hover:bg-[#FB651E]/5 transition-all duration-200"
+              aria-label="ExploreYC — #1 Product of the Day on Product Hunt"
+              className="group shrink-0 inline-flex items-center"
             >
-              <svg
-                viewBox="0 0 24 24"
-                className="h-5 w-5 fill-current text-foreground group-hover:text-[#FB651E] transition-colors"
-                aria-hidden="true"
-              >
-                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
-              </svg>
-              <span className="text-muted-foreground group-hover:text-foreground transition-colors">
-                Open Source —{' '}
-              </span>
-              <span className="text-foreground font-semibold">Star &amp; Contribute</span>
-              <svg
-                viewBox="0 0 24 24"
-                className="h-3.5 w-3.5 fill-current text-[#FB651E]"
-                aria-hidden="true"
-              >
-                <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-              </svg>
+              <img
+                src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1190010&theme=light&period=daily&t=1783772611367"
+                alt="ExploreYC — Open-source API for Y Combinator &amp; a16z company data | Product Hunt"
+                width={250}
+                height={54}
+                className="h-[54px] w-auto max-w-full rounded-md transition-shadow duration-200 group-hover:shadow-[0_0_22px_rgba(251,101,30,0.35)]"
+              />
             </a>
             </motion.div>
           </motion.div>


### PR DESCRIPTION
Removes the "Open Source — Star & Contribute" GitHub banner from the hero and adds the Product Hunt **top-post badge** next to the existing PH badge, showing ExploreYC ranked #1 Product of the Day. Open-source is still stated in the subline + PH badge alt text.

`vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)