### PR TITLE
No broken logos + showcase only companies with a real logo (/ and /database)

### DIFF
--- a/backend/company_cache.py
+++ b/backend/company_cache.py
@@ -159,12 +159,18 @@ class CompanyCache:
         return str(created) if not hasattr(created, "isoformat") else created.isoformat()
 
     @staticmethod
+    def _has_usable_logo(c: Dict) -> bool:
+        """True only when the company has a real, renderable logo. Clearbit URLs
+        are treated as no-logo: they were a fallback that mostly 404'd (broken
+        images), so they must not count as a logo for sorting/filtering."""
+        url = (c.get("small_logo_thumb_url") or "").strip()
+        return bool(url) and "clearbit.com" not in url
+
+    @staticmethod
     def _priority_sort_key(c: Dict):
-        """Sort key (used with reverse=True): logo-having companies first, then
-        newest-first. A real logo (non-empty small_logo_thumb_url) ranks a row
-        ahead of logo-less ones so image-rich companies lead every list view."""
-        has_logo = 1 if (c.get("small_logo_thumb_url") or "").strip() else 0
-        return (has_logo, CompanyCache._created_sort_key(c))
+        """Sort key (used with reverse=True): companies with a real logo first,
+        then newest-first, so image-rich companies lead every list view."""
+        return (1 if CompanyCache._has_usable_logo(c) else 0, CompanyCache._created_sort_key(c))
 
     @staticmethod
     def _merge_group(rows: List[Dict]) -> Dict:
@@ -175,8 +181,13 @@ class CompanyCache:
             rows, key=lambda r: CompanyCache._SOURCE_PRIORITY.get(r.get("source") or "yc", 99)
         )
         merged = dict(primary)
-        for field in ("one_liner", "small_logo_thumb_url", "long_description",
-                      "country", "all_locations", "website"):
+        # Prefer a real (non-Clearbit) logo from ANY source in the group.
+        if not CompanyCache._has_usable_logo(merged):
+            for r in rows:
+                if CompanyCache._has_usable_logo(r):
+                    merged["small_logo_thumb_url"] = r["small_logo_thumb_url"]
+                    break
+        for field in ("one_liner", "long_description", "country", "all_locations", "website"):
             if not merged.get(field):
                 for r in rows:
                     if r.get(field):
@@ -210,6 +221,7 @@ class CompanyCache:
         search: Optional[str] = None,
         top_company: Optional[bool] = None,
         source: Optional[str] = None,
+        has_logo: bool = False,
     ) -> List[Dict]:
         """Apply filters to companies list."""
         result = [c for c in self._companies if self._source_matches(c, source)]
@@ -225,6 +237,8 @@ class CompanyCache:
             result = [c for c in result if self._matches_search(c, search)]
         if top_company is not None:
             result = [c for c in result if c.get("top_company") == top_company]
+        if has_logo:
+            result = [c for c in result if self._has_usable_logo(c)]
         return result
 
     def get_companies(
@@ -239,15 +253,23 @@ class CompanyCache:
         top_company: Optional[bool] = None,
         source: Optional[str] = None,
         merged: bool = False,
+        has_logo: bool = False,
     ) -> List[Dict]:
         """Get companies with filters and pagination.
 
         When merged=True, rows sharing a dedupe_key are collapsed into one
         canonical entry (with a merged_sources badge cluster) before pagination.
+        has_logo=True keeps only companies with a real, renderable logo (applied
+        after merge so a merged card inherits a logo from any of its sources).
         """
-        filtered = self._filter_companies(batch, is_hiring, industry, country, search, top_company, source)
+        filtered = self._filter_companies(
+            batch, is_hiring, industry, country, search, top_company, source,
+            has_logo=has_logo and not merged,
+        )
         if merged:
             filtered = self._apply_merge(filtered)
+            if has_logo:
+                filtered = [c for c in filtered if self._has_usable_logo(c)]
         return filtered[offset : offset + limit]
 
     def count_companies(
@@ -260,11 +282,17 @@ class CompanyCache:
         top_company: Optional[bool] = None,
         source: Optional[str] = None,
         merged: bool = False,
+        has_logo: bool = False,
     ) -> int:
         """Count companies matching filters (post-merge count when merged=True)."""
-        filtered = self._filter_companies(batch, is_hiring, industry, country, search, top_company, source)
+        filtered = self._filter_companies(
+            batch, is_hiring, industry, country, search, top_company, source,
+            has_logo=has_logo and not merged,
+        )
         if merged:
             filtered = self._apply_merge(filtered)
+            if has_logo:
+                filtered = [c for c in filtered if self._has_usable_logo(c)]
         return len(filtered)
 
     def get_company_by_id(self, company_id: int) -> Optional[Dict]:

--- a/backend/database.py
+++ b/backend/database.py
@@ -680,6 +680,16 @@ class Database:
             )
             return cursor.rowcount
 
+    def clear_broken_logos(self) -> int:
+        """Null out known-broken logo URLs (Clearbit fallbacks that mostly 404'd)."""
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE companies SET small_logo_thumb_url = NULL "
+                "WHERE small_logo_thumb_url LIKE '%clearbit.com%'"
+            )
+            return cursor.rowcount
+
     def record_feature_interest(self, feature: str, user_identifier: Optional[str] = None,
                                 email: Optional[str] = None) -> Dict:
         """Record interest in a currently-unavailable feature.

--- a/backend/database_postgres.py
+++ b/backend/database_postgres.py
@@ -298,6 +298,20 @@ class DatabasePostgres:
             conn.commit()
         return n
 
+    def clear_broken_logos(self) -> int:
+        """Null out known-broken logo URLs (Clearbit fallbacks that mostly 404'd)
+        so they stop rendering as broken images and don't count as a logo. Safe to
+        run repeatedly / on a schedule."""
+        with self.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE companies SET small_logo_thumb_url = NULL "
+                    "WHERE small_logo_thumb_url ILIKE '%clearbit.com%'"
+                )
+                n = cur.rowcount
+            conn.commit()
+        return n
+
     def get_companies(
         self,
         limit: int = 100,

--- a/backend/main.py
+++ b/backend/main.py
@@ -283,6 +283,7 @@ class CompanyFilter(BaseModel):
     top_company: Optional[bool] = None
     source: Optional[str] = None  # None -> YC only, 'all' -> every source, or a source key
     merged: bool = False  # collapse same-domain rows across sources into one card
+    has_logo: bool = False  # only companies with a real, renderable logo
 
 
 # Background task storage
@@ -560,6 +561,7 @@ async def get_companies(filters: CompanyFilter):
         top_company=filters.top_company,
         source=filters.source,
         merged=filters.merged,
+        has_logo=filters.has_logo,
     )
 
     total = company_cache.count_companies(
@@ -571,6 +573,7 @@ async def get_companies(filters: CompanyFilter):
         top_company=filters.top_company,
         source=filters.source,
         merged=filters.merged,
+        has_logo=filters.has_logo,
     )
 
     return {
@@ -1840,9 +1843,17 @@ async def _run_source_sync(full: bool = False):
             db.delete_source_companies_with_batch()
             if hasattr(db, "delete_source_companies_with_batch") else 0
         )
+        # Null out broken Clearbit logo URLs so they stop rendering as broken images.
+        cleaned_logos = (
+            db.clear_broken_logos() if hasattr(db, "clear_broken_logos") else 0
+        )
         company_cache.refresh(db)
-        logger.info(f"Source sync completed: {results}, embedded {embedded}, deduped {deduped}")
-        return {"results": results, "embedded": embedded, "deduped": deduped}
+        logger.info(
+            f"Source sync completed: {results}, embedded {embedded}, "
+            f"deduped {deduped}, cleaned_logos {cleaned_logos}"
+        )
+        return {"results": results, "embedded": embedded, "deduped": deduped,
+                "cleaned_logos": cleaned_logos}
     except Exception as e:
         logger.error(f"Source sync error: {e}")
         raise
@@ -2430,9 +2441,11 @@ async def enrich_companies_bulk(
                 WHERE 1=1
             """
             params = []
+            is_postgres = 'Postgres' in db.__class__.__name__
+            ph = "%s" if is_postgres else "?"
 
             if batch:
-                query += " AND batch = ?"
+                query += f" AND batch = {ph}"
                 params.append(batch)
 
             if top_only:
@@ -2453,26 +2466,52 @@ async def enrich_companies_bulk(
             # Prioritize NEWER companies first (newest batches = more viewer interest)
             # Parse batch into sortable format: W25 → 202501, S24 → 202406
             # This ensures chronological ordering: W25 > S24 > W24 > S23
-            query += """
-                ORDER BY
-                    CASE WHEN coresignal_last_updated IS NULL THEN 0 ELSE 1 END,
-                    (
-                        CASE
-                            -- Short format: W25, S24, etc. (2-3 char length)
-                            WHEN batch GLOB '[WS][0-9][0-9]' THEN
-                                (2000 + CAST(SUBSTR(batch, 2, 2) AS INTEGER)) * 100 +
-                                CASE WHEN batch LIKE 'W%' THEN 1 ELSE 6 END
-                            -- Long format: Winter 2025, Summer 2024, etc.
-                            WHEN batch LIKE 'Winter%' THEN
-                                CAST(REPLACE(REPLACE(batch, 'Winter ', ''), ' ', '') AS INTEGER) * 100 + 1
-                            WHEN batch LIKE 'Summer%' THEN
-                                CAST(REPLACE(REPLACE(batch, 'Summer ', ''), ' ', '') AS INTEGER) * 100 + 6
-                            ELSE 0
-                        END
-                    ) DESC,
-                    CASE WHEN funding_total_usd IS NULL THEN 0 ELSE 1 END,
-                    CASE WHEN team_size IS NOT NULL THEN team_size ELSE 0 END DESC
-            """
+            if is_postgres:
+                # On Postgres (psycopg2), literal % must be doubled to %% because
+                # the query is mogrified against `params` — a bare % is parsed as a
+                # placeholder and raises "list index out of range". GLOB is SQLite-only,
+                # so use a POSIX regex (~) for the short-format check.
+                query += """
+                    ORDER BY
+                        CASE WHEN coresignal_last_updated IS NULL THEN 0 ELSE 1 END,
+                        (
+                            CASE
+                                -- Short format: W25, S24, etc.
+                                WHEN batch ~ '^[WS][0-9][0-9]$' THEN
+                                    (2000 + CAST(SUBSTR(batch, 2, 2) AS INTEGER)) * 100 +
+                                    CASE WHEN batch LIKE 'W%%' THEN 1 ELSE 6 END
+                                -- Long format: Winter 2025, Summer 2024, etc.
+                                WHEN batch LIKE 'Winter%%' THEN
+                                    CAST(REPLACE(REPLACE(batch, 'Winter ', ''), ' ', '') AS INTEGER) * 100 + 1
+                                WHEN batch LIKE 'Summer%%' THEN
+                                    CAST(REPLACE(REPLACE(batch, 'Summer ', ''), ' ', '') AS INTEGER) * 100 + 6
+                                ELSE 0
+                            END
+                        ) DESC,
+                        CASE WHEN funding_total_usd IS NULL THEN 0 ELSE 1 END,
+                        CASE WHEN team_size IS NOT NULL THEN team_size ELSE 0 END DESC
+                """
+            else:
+                query += """
+                    ORDER BY
+                        CASE WHEN coresignal_last_updated IS NULL THEN 0 ELSE 1 END,
+                        (
+                            CASE
+                                -- Short format: W25, S24, etc.
+                                WHEN batch GLOB '[WS][0-9][0-9]' THEN
+                                    (2000 + CAST(SUBSTR(batch, 2, 2) AS INTEGER)) * 100 +
+                                    CASE WHEN batch LIKE 'W%' THEN 1 ELSE 6 END
+                                -- Long format: Winter 2025, Summer 2024, etc.
+                                WHEN batch LIKE 'Winter%' THEN
+                                    CAST(REPLACE(REPLACE(batch, 'Winter ', ''), ' ', '') AS INTEGER) * 100 + 1
+                                WHEN batch LIKE 'Summer%' THEN
+                                    CAST(REPLACE(REPLACE(batch, 'Summer ', ''), ' ', '') AS INTEGER) * 100 + 6
+                                ELSE 0
+                            END
+                        ) DESC,
+                        CASE WHEN funding_total_usd IS NULL THEN 0 ELSE 1 END,
+                        CASE WHEN team_size IS NOT NULL THEN team_size ELSE 0 END DESC
+                """
             query += f" LIMIT {limit}"
 
             logger.info("📊 Enrichment priority: Unenriched companies → Newest batches → Companies without funding → Larger teams")

--- a/backend/test_merge_grouping.py
+++ b/backend/test_merge_grouping.py
@@ -79,6 +79,20 @@ def test_count_companies_merged():
     assert cache.count_companies(merged=False, source="all") == 2
 
 
+def test_has_logo_filter_excludes_clearbit_and_empty():
+    cache = CompanyCache()
+    cache._build_cache([
+        _c(id=1, source="yc", dedupe_key="a.com",
+           small_logo_thumb_url="https://bookface/logo.png"),
+        _c(id=2, source="hackernews", dedupe_key="b.com", small_logo_thumb_url=None),
+        _c(id=3, source="hackernews", dedupe_key="c.com",
+           small_logo_thumb_url="https://logo.clearbit.com/x.github.io"),
+    ])
+    rows = cache.get_companies(source="all", has_logo=True)
+    assert [r["id"] for r in rows] == [1]  # only the real logo (clearbit + null excluded)
+    assert cache.count_companies(source="all", has_logo=True) == 1
+
+
 def test_logo_having_companies_sort_first():
     cache = CompanyCache()
     cache._build_cache([

--- a/frontend/src/components/CompaniesBrowser.tsx
+++ b/frontend/src/components/CompaniesBrowser.tsx
@@ -9,6 +9,7 @@ import { apiClient } from '../lib/api';
 import type { Company, CompanyFilter } from '../lib/api';
 import { formatNumber } from '../lib/utils';
 import { SourceBadge, MergedSourceBadges } from './ui/SourceBadge';
+import { CompanyLogo } from './ui/CompanyLogo';
 
 interface CompaniesBrowserProps {
   refreshTrigger?: number;
@@ -27,12 +28,15 @@ export function CompaniesBrowser({ refreshTrigger }: CompaniesBrowserProps) {
   // users can uncheck to return to per-source rows. Semantic = all-source vector search.
   const [mergeSources, setMergeSources] = useState(true);
   const [semantic, setSemantic] = useState(false);
+  // Showcase only companies with a real logo by default (hides logo-less rows).
+  const [logoOnly, setLogoOnly] = useState(true);
 
   const PAGE_SIZE = 20;
 
   useEffect(() => {
     loadCompanies();
-  }, [currentPage, refreshTrigger]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentPage, refreshTrigger, mergeSources, semantic, logoOnly]);
 
   const loadCompanies = async () => {
     setLoading(true);
@@ -57,6 +61,7 @@ export function CompaniesBrowser({ refreshTrigger }: CompaniesBrowserProps) {
         filters.merged = true;
         filters.source = 'all';
       }
+      if (logoOnly) filters.has_logo = true;
 
       const response = await apiClient.getCompanies(filters);
       setCompanies(response.data.companies);
@@ -140,6 +145,15 @@ export function CompaniesBrowser({ refreshTrigger }: CompaniesBrowserProps) {
                 />
                 Semantic search
               </label>
+
+              <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer" title="Only show companies that have a real logo">
+                <input
+                  type="checkbox"
+                  checked={logoOnly}
+                  onChange={(e) => { setLogoOnly(e.target.checked); setCurrentPage(0); }}
+                />
+                With logo
+              </label>
             </div>
 
             <span className="text-sm text-muted-foreground">
@@ -182,13 +196,12 @@ export function CompaniesBrowser({ refreshTrigger }: CompaniesBrowserProps) {
                         )}
                       </div>
                     </div>
-                    {company.small_logo_thumb_url && (
-                      <img
-                        src={company.small_logo_thumb_url}
-                        alt={company.name}
-                        className="w-12 h-12 rounded"
-                      />
-                    )}
+                    <CompanyLogo
+                      src={company.small_logo_thumb_url}
+                      name={company.name}
+                      className="w-12 h-12"
+                      letterClass="text-lg"
+                    />
                   </div>
                 </CardHeader>
                 <CardContent>

--- a/frontend/src/components/CompanyDetailModal.tsx
+++ b/frontend/src/components/CompanyDetailModal.tsx
@@ -10,6 +10,7 @@ import {
 } from './ui/dialog';
 import { Button } from './ui/button';
 import { SourceBadge, MergedSourceBadges, sourceLabel } from './ui/SourceBadge';
+import { CompanyLogo } from './ui/CompanyLogo';
 import type { Company } from '../lib/api';
 
 interface CompanyDetailModalProps {
@@ -58,13 +59,13 @@ export function CompanyDetailModal({ company, open, onClose, showViewFullPage }:
       <DialogContent className="max-w-2xl w-[95vw] sm:w-full max-h-[90vh] overflow-y-auto p-4 sm:p-6">
         <DialogHeader>
           <div className="flex items-start gap-4">
-            {company.small_logo_thumb_url && (
-              <img
-                src={company.small_logo_thumb_url}
-                alt={company.name}
-                className="w-16 h-16 rounded-lg border"
-              />
-            )}
+            <CompanyLogo
+              src={company.small_logo_thumb_url}
+              name={company.name}
+              className="w-16 h-16"
+              rounded="rounded-lg"
+              letterClass="text-2xl"
+            />
             <div className="flex-1">
               <DialogTitle className="text-2xl font-bold text-[#FB651E]">
                 {company.name}

--- a/frontend/src/components/ui/CompanyLogo.tsx
+++ b/frontend/src/components/ui/CompanyLogo.tsx
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Company logo with a safe fallback. Renders the logo image when the URL is
+ * usable, and a clean letter-avatar otherwise — on empty/Clearbit URLs (the old
+ * fallback mostly 404'd) or when the image fails to load. Never shows a browser
+ * "broken image" icon.
+ */
+export function CompanyLogo({
+  src,
+  name,
+  className = 'w-10 h-10',
+  rounded = 'rounded',
+  letterClass = 'text-sm',
+}: {
+  src?: string | null;
+  name: string;
+  className?: string;
+  rounded?: string;
+  letterClass?: string;
+}) {
+  const usable = !!src && !src.includes('clearbit.com');
+  const [failed, setFailed] = useState(false);
+  // Reset the failed flag if the src changes (e.g. list re-renders with new data).
+  useEffect(() => setFailed(false), [src]);
+
+  if (!usable || failed) {
+    return (
+      <div
+        className={`${className} ${rounded} bg-[#FB651E]/20 flex items-center justify-center flex-shrink-0`}
+        aria-hidden="true"
+      >
+        <span className={`font-bold text-[#FB651E] ${letterClass}`}>
+          {(name || '?').charAt(0).toUpperCase()}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src as string}
+      alt={name}
+      loading="lazy"
+      onError={() => setFailed(true)}
+      className={`${className} ${rounded} object-contain flex-shrink-0 bg-muted`}
+    />
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -102,6 +102,7 @@ export interface CompanyFilter {
   top_company?: boolean
   source?: string // undefined -> YC only; 'all' -> every source; or a source key like 'a16z'
   merged?: boolean // collapse same-domain rows across sources into one card
+  has_logo?: boolean // only companies with a real, renderable logo
 }
 
 export interface Source {

--- a/frontend/src/pages/CompanyPage.tsx
+++ b/frontend/src/pages/CompanyPage.tsx
@@ -23,6 +23,7 @@ import { Button } from '../components/ui/button';
 import { AnnouncementBanner } from '../components/AnnouncementBanner';
 import { CompanyResearch } from '../components/CompanyResearch';
 import { SourceBadge, MergedSourceBadges, sourceLabel } from '../components/ui/SourceBadge';
+import { CompanyLogo } from '../components/ui/CompanyLogo';
 
 function formatLocations(allLocations: string, maxShow = 2): string {
   if (!allLocations?.trim()) return '';
@@ -154,13 +155,13 @@ export function CompanyPage() {
           className="mb-8"
         >
           <div className="flex items-start gap-6 mb-6">
-            {company.small_logo_thumb_url && (
-              <img
-                src={company.small_logo_thumb_url}
-                alt={company.name}
-                className="w-24 h-24 rounded-xl border border-border shadow-lg flex-shrink-0"
-              />
-            )}
+            <CompanyLogo
+              src={company.small_logo_thumb_url}
+              name={company.name}
+              className="w-24 h-24"
+              rounded="rounded-xl"
+              letterClass="text-4xl"
+            />
             <div className="flex-1 min-w-0">
               <h1 className="text-4xl font-bold text-[#FB651E] mb-2 break-words">
                 {company.name}

--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -36,6 +36,7 @@ import {
 } from 'lucide-react';
 import { apiClient, type Company, type CompanyFilter } from '../lib/api';
 import { SourceBadge, sourceLabel } from '../components/ui/SourceBadge';
+import { CompanyLogo } from '../components/ui/CompanyLogo';
 import { PageHeader } from '../components/ui/PageHeader';
 import { useApp } from '../contexts/AppContext';
 import { HackerCard } from '../components/ui/hacker-card';
@@ -109,23 +110,13 @@ const columns: ColumnDef<Company, any>[] = [
           to={`/company/${company.slug}`}
           className="flex items-center gap-2 min-w-0 group"
         >
-          {company.small_logo_thumb_url ? (
-            <img
-              src={company.small_logo_thumb_url}
-              alt=""
-              className="w-5 h-5 rounded-sm object-contain flex-shrink-0 bg-muted"
-              loading="lazy"
-              onError={(e) => {
-                (e.target as HTMLImageElement).style.display = 'none';
-              }}
-            />
-          ) : (
-            <div className="w-5 h-5 rounded-sm bg-[#FB651E]/20 flex items-center justify-center flex-shrink-0">
-              <span className="text-[8px] font-bold text-[#FB651E]">
-                {company.name.charAt(0)}
-              </span>
-            </div>
-          )}
+          <CompanyLogo
+            src={company.small_logo_thumb_url}
+            name={company.name}
+            className="w-5 h-5"
+            rounded="rounded-sm"
+            letterClass="text-[8px]"
+          />
           <span className="font-medium text-xs truncate group-hover:text-[#FB651E] transition-colors max-w-[160px]">
             {info.getValue() as string}
           </span>
@@ -558,6 +549,7 @@ export function DatabasePage() {
   const [isHiring, setIsHiring] = useState(false);
   const [topOnly, setTopOnly] = useState(false);
   const [source, setSource] = useState('all'); // 'all' (default) | 'yc' | 'a16z' | 'hackernews' | ...
+  const [logoOnly, setLogoOnly] = useState(true); // showcase only companies with a real logo
   const [currentPage, setCurrentPage] = useState(1);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [exportOpen, setExportOpen] = useState(false);
@@ -594,8 +586,9 @@ export function DatabasePage() {
       ...(isHiring && { is_hiring: true }),
       ...(topOnly && { top_company: true }),
       ...(source !== 'yc' && { source }),
+      ...(logoOnly && { has_logo: true }),
     }),
-    [currentPage, debouncedSearch, batch, industry, country, isHiring, topOnly, source],
+    [currentPage, debouncedSearch, batch, industry, country, isHiring, topOnly, source, logoOnly],
   );
 
   const { data, isLoading, isFetching } = useQuery({
@@ -857,6 +850,19 @@ export function DatabasePage() {
               >
                 <Star className="w-3 h-3 inline-block mr-1 mb-0.5" />
                 Top Co.
+              </button>
+
+              {/* Toggle: only companies with a real logo */}
+              <button
+                onClick={() => { setLogoOnly(!logoOnly); resetPage(); }}
+                title="Only show companies that have a real logo"
+                className={`h-8 px-3 text-xs font-mono border rounded-sm transition-colors whitespace-nowrap ${
+                  logoOnly
+                    ? 'bg-[#FB651E]/10 border-[#FB651E]/50 text-[#FB651E]'
+                    : 'border-border text-muted-foreground hover:text-foreground hover:border-border/80'
+                }`}
+              >
+                With logo
               </button>
 
               {/* Clear filters */}


### PR DESCRIPTION
Fixes the broken images from leftover Clearbit URLs and showcases logo-having companies.

**No more broken images**
- New `<CompanyLogo>` component renders a clean letter-avatar instead of a broken `<img>` — on empty/Clearbit URLs or any load error (`onError`). Wired into the cards, database table, detail modal, and company page.

**Only companies with a real logo on / and /database**
- Backend treats Clearbit/empty URLs as "no logo" (`_has_usable_logo`) for both the logo-priority sort and a new `has_logo` filter on `/api/companies`.
- `CompaniesBrowser` and `DatabasePage` default to **"With logo"** (a toggle lets you show all), so the browse + database surfaces lead with — and by default only show — companies that have a real, renderable logo.
- Merge gap-fill prefers a real logo from any source in a group.

**Data cleanup**
- The daily sync now nulls stored `logo.clearbit.com` URLs (`clear_broken_logos`), so existing broken rows are fixed on the next run.

Backend tests (adds a `has_logo` test) + `tsc -b && vite build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)