### PR TITLE
fix(api): health check with DB probe and version

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -298,8 +298,29 @@ async def root():
 
 @app.get("/api/health")
 async def health():
-    """Health check endpoint"""
-    return {"status": "healthy", "timestamp": datetime.utcnow().isoformat()}
+    """
+    Uptime / load-balancer health check.
+    Not rate-limited — monitoring tools poll frequently.
+    """
+    version = getattr(app, "version", None) or "1.0.0"
+    database = "disconnected"
+    try:
+        with db.get_connection() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT 1")
+            cur.fetchone()
+            database = "connected"
+    except Exception:
+        database = "disconnected"
+
+    body = {
+        "status": "ok",
+        "version": version,
+        "database": database,
+    }
+    if database != "connected":
+        return JSONResponse(status_code=503, content=body)
+    return body
 
 
 # Admin Authentication Endpoints


### PR DESCRIPTION
## Summary
Upgrade existing `/api/health` to match uptime-monitoring needs (issue #3).

## Changes
- Return `{ status, version, database }` JSON
- `SELECT 1` DB probe via `db.get_connection()`
- `503` when database unreachable; `200` when connected
- Not rate-limited (no limiter on this route)
- No new imports

## Notes
A minimal `/api/health` already returned `healthy` + timestamp without version/DB. This completes the acceptance criteria.

## Test plan
- [ ] Local: `curl http://localhost:8000/api/health` → 200 + `database: connected` with SQLite
- [ ] Force DB failure path → 503 + `database: disconnected`
- [ ] Confirms not behind research rate limiter

Fixes #3