### PR TITLE
fix(database): default table to YC-only source on initial load

### DIFF
--- a/frontend/src/pages/DatabasePage.tsx
+++ b/frontend/src/pages/DatabasePage.tsx
@@ -548,7 +548,7 @@ export function DatabasePage() {
   const [country, setCountry] = useState('');
   const [isHiring, setIsHiring] = useState(false);
   const [topOnly, setTopOnly] = useState(false);
-  const [source, setSource] = useState('all'); // 'all' (default) | 'yc' | 'a16z' | 'hackernews' | ...
+  const [source, setSource] = useState('yc'); // 'yc' (default) | 'all' | 'a16z' | 'hackernews' | ...
   const [logoOnly, setLogoOnly] = useState(true); // showcase only companies with a real logo
   const [currentPage, setCurrentPage] = useState(1);
   const [sorting, setSorting] = useState<SortingState>([]);


### PR DESCRIPTION
## Summary

The `/database` page now opens filtered to **Y Combinator companies only**, instead of all sources.

## Why

The `source` filter state initialized to `'all'`, but the rest of the page was already built around `'yc'` being the default:
- `clearFilters()` resets `source` to `'yc'`
- `hasFilters` treats `source !== 'yc'` as an active filter
- The page heading/subtitle default to the YC-framed copy ("YC Companies Database")

So the initial `useState('all')` was the lone inconsistency. This one-line change makes the initial load match the intended default.

## Behavior
- Opens showing "Y Combinator (6,049)" selected, YC-framed heading, ~6k filtered results (not the 8.6k all-source total)
- Users can still switch the Source dropdown to "All sources" / a16z / etc. — only the initial value changed
- Backend already returns YC-only when no `source` param is sent (`source !== 'yc'` gates the param), so no API change needed

## Test plan
- `npm run build` + `tsc` pass
- Verified in browser: `/database` loads with YC-only default (screenshot confirms heading, dropdown, and 6,048 filtered results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4B1pcs7619oF8o4jn3PZF