### PR TITLE
feat(map): /map page + homepage database preview + fix zoom-out gap

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,7 @@ import { CompanyCardPage } from './pages/CompanyCardPage';
 import { HiringBoardPagePaginated } from './pages/HiringBoardPagePaginated';
 import { HiringAnalyticsPage } from './pages/HiringAnalyticsPage';
 import { DatabasePage } from './pages/DatabasePage';
+import { MapPage } from './pages/MapPage';
 import { PageTitleManager } from './components/PageTitleManager';
 import { DevAuthProvider } from './contexts/DevAuthContext';
 import { SignupPage } from './pages/SignupPage';
@@ -197,6 +198,7 @@ function AnimatedRoutes() {
         <Route path="hiring" element={<HiringBoardPagePaginated />} />
         <Route path="hiring/analytics" element={<HiringAnalyticsPage />} />
         <Route path="database" element={<DatabasePage />} />
+        <Route path="map" element={<MapPage />} />
         <Route path="founders" element={<FoundersPage />} />
         <Route path="roadmap" element={<RoadmapPage />} />
         <Route path="share" element={<ShareHub />} />

--- a/frontend/src/components/DatabasePreview.tsx
+++ b/frontend/src/components/DatabasePreview.tsx
@@ -1,0 +1,129 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { ArrowRight, Database, ExternalLink, CheckCircle2 } from 'lucide-react';
+import { apiClient, type Company } from '../lib/api';
+import { CompanyLogo } from './ui/CompanyLogo';
+import { HackerCard } from './ui/hacker-card';
+
+const PREVIEW_LIMIT = 8;
+
+// A lean, non-interactive teaser of the /database table — most recent YC
+// companies. No filters or pagination; the CTA drives users to the full page.
+export function DatabasePreview() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['database-preview'],
+    // No `source` param => YC-only (backend default); has_logo keeps rows tidy.
+    queryFn: () =>
+      apiClient.getCompanies({ limit: PREVIEW_LIMIT, has_logo: true }).then((r) => r.data),
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const companies: Company[] = data?.companies ?? [];
+  const total = data?.total ?? 0;
+
+  return (
+    <HackerCard className="overflow-hidden" glowColor="orange">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-b border-border bg-muted/20">
+        <div className="flex items-center gap-2 font-mono text-sm">
+          <Database className="w-4 h-4 text-[#FB651E]" />
+          <span className="font-semibold">Latest YC companies</span>
+          {total > 0 && (
+            <span className="text-muted-foreground text-xs">
+              {total.toLocaleString()} total
+            </span>
+          )}
+        </div>
+        <Link
+          to="/database"
+          className="group inline-flex items-center gap-1.5 text-xs font-mono text-[#FB651E] hover:underline"
+        >
+          Open full database
+          <ArrowRight className="w-3 h-3 group-hover:translate-x-0.5 transition-transform" />
+        </Link>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto" style={{ WebkitOverflowScrolling: 'touch' }}>
+        <table className="w-full text-xs font-mono border-collapse" style={{ minWidth: 'max-content' }}>
+          <thead>
+            <tr className="border-b border-border bg-muted/30 text-[10px] uppercase tracking-wider text-muted-foreground">
+              <th className="px-3 py-2.5 text-left font-semibold">Company</th>
+              <th className="px-3 py-2.5 text-left font-semibold">Batch</th>
+              <th className="px-3 py-2.5 text-left font-semibold hidden sm:table-cell">Industry</th>
+              <th className="px-3 py-2.5 text-left font-semibold hidden md:table-cell">Location</th>
+              <th className="px-3 py-2.5 text-right font-semibold hidden md:table-cell">Team</th>
+              <th className="px-3 py-2.5 text-center font-semibold">Hiring</th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading && companies.length === 0
+              ? Array.from({ length: PREVIEW_LIMIT }).map((_, i) => (
+                  <tr key={i} className="border-b border-border/50">
+                    <td className="px-3 py-2.5" colSpan={6}>
+                      <div className="h-4 bg-muted/40 rounded animate-pulse" />
+                    </td>
+                  </tr>
+                ))
+              : companies.map((c, i) => (
+                  <tr
+                    key={c.id}
+                    className={`border-b border-border/50 hover:bg-muted/20 transition-colors ${
+                      i % 2 === 0 ? '' : 'bg-muted/5'
+                    }`}
+                  >
+                    <td className="px-3 py-2">
+                      <Link to={`/company/${c.slug}`} className="flex items-center gap-2 min-w-0 group">
+                        <CompanyLogo
+                          src={c.small_logo_thumb_url}
+                          name={c.name}
+                          className="w-5 h-5"
+                          rounded="rounded-sm"
+                          letterClass="text-[8px]"
+                        />
+                        <span className="font-medium truncate group-hover:text-[#FB651E] transition-colors max-w-[160px]">
+                          {c.name}
+                        </span>
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground whitespace-nowrap">{c.batch || '—'}</td>
+                    <td className="px-3 py-2 text-muted-foreground hidden sm:table-cell">
+                      <span className="truncate block max-w-[130px]">{c.industry || '—'}</span>
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground hidden md:table-cell">
+                      <span className="truncate block max-w-[120px]">
+                        {c.all_locations ? c.all_locations.split(';')[0].trim() : '—'}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums hidden md:table-cell">
+                      {c.team_size ? c.team_size.toLocaleString() : '—'}
+                    </td>
+                    <td className="px-3 py-2 text-center">
+                      {c.is_hiring ? (
+                        <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500 mx-auto" />
+                      ) : (
+                        <span className="text-muted-foreground/40">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Footer CTA */}
+      <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 border-t border-border bg-muted/10">
+        <span className="text-xs text-muted-foreground font-mono">
+          Sortable, filterable, {total > 0 ? total.toLocaleString() : ''} companies — batch, industry, funding & more.
+        </span>
+        <Link
+          to="/database"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-[#FB651E] hover:bg-[#E65C00] text-white text-xs font-semibold font-mono transition-colors rounded-sm"
+        >
+          <ExternalLink className="w-3.5 h-3.5" />
+          Explore the database
+        </Link>
+      </div>
+    </HackerCard>
+  );
+}

--- a/frontend/src/components/MobileBottomNav.tsx
+++ b/frontend/src/components/MobileBottomNav.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-  Home, BarChart3, Wrench, BookOpen, Map as MapIcon, DollarSign, Share2, Briefcase,
+  Home, BarChart3, Wrench, BookOpen, Map as MapIcon, Globe2, DollarSign, Share2, Briefcase,
   Mail, Database, Terminal, Menu, X, Moon, Sun, Command, LogOut, LayoutDashboard,
 } from 'lucide-react';
 import { useApp } from '../contexts/AppContext';
@@ -28,6 +28,7 @@ const groups: { title: string; items: Item[] }[] = [
   {
     title: 'More',
     items: [
+      { label: 'World Map', icon: Globe2, path: '/map' },
       { label: 'Tools', icon: Wrench, path: '/tools' },
       { label: 'Founders', icon: BookOpen, path: '/founders' },
       { label: 'Roadmap', icon: MapIcon, path: '/roadmap' },

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
-  Home, BarChart3, Wrench, BookOpen, Map as MapIcon, DollarSign, Share2,
+  Home, BarChart3, Wrench, BookOpen, Map as MapIcon, Globe2, DollarSign, Share2,
   Moon, Sun, Command, Briefcase, Mail, Database, Terminal, ChevronDown,
   LayoutDashboard, LogOut, KeyRound,
 } from 'lucide-react';
@@ -27,6 +27,7 @@ const primaryTabs: NavTab[] = [
 const showShareNav = import.meta.env.VITE_SHOW_SHARE_NAV === 'true' || import.meta.env.VITE_SHOW_SHARE_NAV === '1';
 
 const moreTabs: NavTab[] = [
+  { id: 'map', label: 'World Map', icon: Globe2, path: '/map' },
   { id: 'funding', label: 'Funding', icon: DollarSign, path: '/funding' },
   { id: 'tools', label: 'Tools', icon: Wrench, path: '/tools' },
   { id: 'founders', label: 'Founders', icon: BookOpen, path: '/founders' },

--- a/frontend/src/components/WorldMap/DeckMap.tsx
+++ b/frontend/src/components/WorldMap/DeckMap.tsx
@@ -129,6 +129,32 @@ function quantize(v: number): number {
   return Math.round(v * 20) / 20;
 }
 
+const TILE_SIZE = 512;
+
+function latToMercY(lat: number): number {
+  const s = Math.sin((lat * Math.PI) / 180);
+  return 0.5 - (0.25 * Math.log((1 + s) / (1 - s))) / Math.PI;
+}
+function mercYToLat(y: number): number {
+  const n = Math.PI - 2 * Math.PI * y;
+  return (Math.atan(Math.sinh(n)) * 180) / Math.PI;
+}
+
+// Keep the Web Mercator world covering the whole viewport so no background gap
+// (the "blue band") can ever show. Enforces a minimum zoom where the world spans
+// the larger viewport dimension, then clamps the center latitude so the poles
+// can't be panned into view. 2D only — GlobeView has no such gap.
+function clampToWorld(vs: MapViewState, width: number, height: number): MapViewState {
+  if (!width || !height) return vs;
+  const minZoom = Math.log2(Math.max(width, height) / TILE_SIZE);
+  const zoom = Math.max(typeof vs.zoom === 'number' ? vs.zoom : 0, minZoom);
+  const worldPx = TILE_SIZE * Math.pow(2, zoom);
+  const halfFrac = Math.min(0.5, height / 2 / worldPx);
+  let y = latToMercY(typeof vs.latitude === 'number' ? vs.latitude : 0);
+  y = Math.min(1 - halfFrac, Math.max(halfFrac, y));
+  return { ...vs, zoom, latitude: mercYToLat(y) };
+}
+
 interface LogoMarker {
   company: Company;
   x: number;
@@ -408,10 +434,13 @@ export function DeckMap({
     <div ref={wrapRef} className="absolute inset-0">
       <DeckGL
         views={view}
-        viewState={viewState}
+        viewState={is3D ? viewState : clampToWorld(viewState, size.w, size.h)}
         pickingRadius={8}
         onViewStateChange={({ viewState: vs, interactionState }) => {
-          onViewStateChange(vs as MapViewState);
+          const next = is3D
+            ? (vs as MapViewState)
+            : clampToWorld(vs as MapViewState, size.w, size.h);
+          onViewStateChange(next);
           if (
             interactionState &&
             (interactionState.isDragging || interactionState.isPanning || interactionState.isZooming)

--- a/frontend/src/components/WorldMap/WorldMap.tsx
+++ b/frontend/src/components/WorldMap/WorldMap.tsx
@@ -433,8 +433,9 @@ export function WorldMap() {
         <CardContent className="p-0">
           <div className="h-[350px] sm:h-[500px] md:h-[600px] lg:h-[700px] min-h-[300px] relative rounded-b-lg overflow-hidden border-t"
             style={{
-              // 3D globe floats in dark space regardless of theme.
-              background: is3D ? '#04070e' : darkMode ? '#0a0f1a' : '#aad3df',
+              // 3D globe floats in dark space; 2D falls back to the basemap water
+              // color so any sub-pixel edge blends (the view is clamped to fill).
+              background: is3D ? '#04070e' : darkMode ? '#0b0e13' : '#d4d8db',
             }}
           >
             <DeckMap

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, lazy, Suspense } from 'react';
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useApp } from '../contexts/AppContext';
@@ -7,7 +7,7 @@ import { SourceBadge } from '../components/ui/SourceBadge';
 import { getSecondMostRecentBatch, batchToShortFormat as batchToShort } from '../lib/batchUtils';
 import { Map, BarChart3, Wrench, TrendingUp, Building2, Globe2, Sparkles, ArrowRight, BookOpen, Terminal, ChevronUp } from 'lucide-react';
 import { HeroAnswerBox } from '../components/HeroAnswerBox';
-const WorldMap = lazy(() => import('../components/WorldMap'));
+import { DatabasePreview } from '../components/DatabasePreview';
 import { EmailSubscription } from '../components/EmailSubscription';
 import { CompaniesBrowser } from '../components/CompaniesBrowser';
 import { CompanyDetailModal } from '../components/CompanyDetailModal';
@@ -160,7 +160,7 @@ export function HomePage() {
               className="mt-8 flex flex-wrap items-center justify-center gap-3"
             >
               <a
-                href="#map"
+                href="#database-preview"
                 className="group inline-flex items-center gap-2 px-5 py-2.5 bg-[#FB651E] hover:bg-[#E65C00] text-white font-mono text-sm border border-[#FB651E]/50 transition-all duration-200 hover:shadow-[0_0_20px_rgba(251,101,30,0.3)]"
               >
                 Start Exploring
@@ -264,29 +264,32 @@ export function HomePage() {
           </motion.div>
         )}
 
-        {/* Map Section */}
+        {/* Database Preview Section */}
         <motion.section
-          id="map"
+          id="database-preview"
           initial={{ opacity: 0, y: 24 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true, margin: '-50px' }}
           transition={{ duration: 0.5 }}
           className="border-t border-border py-12"
         >
-          <div className="flex items-center gap-2 mb-6 font-mono">
-            <Map className="h-5 w-5 text-[#FB651E]" />
-            <span className="text-muted-foreground">$</span>
-            <h2 className="text-xl font-bold">Interactive World Map</h2>
+          <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
+            <div className="flex items-center gap-2 font-mono">
+              <Terminal className="h-5 w-5 text-[#FB651E]" />
+              <span className="text-muted-foreground">$</span>
+              <h2 className="text-xl font-bold">Companies Database</h2>
+            </div>
+            {/* The interactive map now lives on its own page */}
+            <Link
+              to="/map"
+              className="group inline-flex items-center gap-2 px-4 py-2 border border-border hover:border-[#FB651E]/50 font-mono text-xs bg-background/50 transition-all duration-200 rounded-sm"
+            >
+              <Globe2 className="h-4 w-4 text-[#FB651E]" />
+              Explore the interactive world map
+              <ArrowRight className="h-3.5 w-3.5 group-hover:translate-x-0.5 transition-transform" />
+            </Link>
           </div>
-          <Suspense
-            fallback={
-              <div className="h-[350px] sm:h-[500px] md:h-[600px] lg:h-[700px] rounded-lg border bg-muted/40 animate-pulse flex items-center justify-center font-mono text-sm text-muted-foreground">
-                Loading world map…
-              </div>
-            }
-          >
-            <WorldMap />
-          </Suspense>
+          <DatabasePreview />
         </motion.section>
 
         {/* Daily YC Updates */}
@@ -332,7 +335,7 @@ export function HomePage() {
           viewport={{ once: true, margin: '-80px' }}
           className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 max-w-6xl mx-auto"
         >
-          <Link to="#map" className="group">
+          <Link to="/map" className="group">
             <HackerCard glowColor="orange" delay={0} className="p-5 h-full">
               <Map className="h-8 w-8 text-[#FB651E] mb-3 group-hover:scale-110 transition-transform" />
               <h3 className="font-bold font-mono mb-1">Interactive Map</h3>
@@ -427,9 +430,9 @@ export function HomePage() {
               <span className="text-muted-foreground">Ready to explore?</span>
             </div>
             <div className="flex flex-wrap gap-4">
-              <a href="#map" className="text-[#FB651E] hover:underline font-mono">
+              <Link to="/map" className="text-[#FB651E] hover:underline font-mono">
                 $ view map
-              </a>
+              </Link>
               <Link to="/analytics" className="text-[#FB651E] hover:underline font-mono">
                 $ see charts
               </Link>

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -1,0 +1,55 @@
+import { lazy, Suspense } from 'react';
+import { motion } from 'framer-motion';
+import { Helmet } from 'react-helmet-async';
+import { PageHeader } from '../components/ui/PageHeader';
+import { DotPattern } from '../components/ui/dot-pattern';
+import { CompanyDetailModal } from '../components/CompanyDetailModal';
+import { useApp } from '../contexts/AppContext';
+
+const WorldMap = lazy(() => import('../components/WorldMap'));
+
+export function MapPage() {
+  const { selectedCompany, setSelectedCompany } = useApp();
+
+  return (
+    <div className="relative min-h-screen bg-background overflow-x-hidden">
+      <Helmet>
+        <title>Interactive World Map | ExploreYC</title>
+        <meta
+          name="description"
+          content="Explore Y Combinator companies across the globe on an interactive 2D map and 3D globe — density hotspots, batch timeline, and a fly-to tour of the top startup hubs."
+        />
+      </Helmet>
+
+      <DotPattern color="hsl(var(--primary) / 0.12)" size={24} radius={0.5} />
+
+      <div className="container relative mx-auto px-4 py-8 max-w-[1600px]">
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }}>
+          <PageHeader
+            command="$ map --world --interactive"
+            title="Interactive World Map"
+            subtitle="Every Y Combinator company on the map — toggle the 3D globe, scrub the batch timeline, or take a tour of the top startup hubs."
+          />
+        </motion.div>
+
+        <Suspense
+          fallback={
+            <div className="h-[350px] sm:h-[500px] md:h-[600px] lg:h-[720px] rounded-lg border bg-muted/40 animate-pulse flex items-center justify-center font-mono text-sm text-muted-foreground">
+              Loading world map…
+            </div>
+          }
+        >
+          <WorldMap />
+        </Suspense>
+      </div>
+
+      {selectedCompany && (
+        <CompanyDetailModal
+          company={selectedCompany}
+          open={true}
+          onClose={() => setSelectedCompany(null)}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Three changes, all from live feedback:

### 1. Dedicated `/map` page
The interactive world map now has its own route (`/map`, `MapPage`) where it's showcased full-width with a page header. Added to the desktop **More** menu and the mobile nav as **World Map** (globe icon).

### 2. Homepage shows a database preview instead of the map
The `/` map section is replaced by a compact, non-interactive **database preview** (`DatabasePreview`) — the latest YC companies in a clean table with a CTA to `/database`. A prominent **"Explore the interactive world map"** link points to the new `/map` page, so the map is still surfaced from home. The bento "Interactive Map" card and `$ view map` link now go to `/map`; the hero "Start Exploring" scrolls to the preview.

### 3. Fix the blue/navy band at the top when zoomed out
The gap was the map container background showing beyond the Web Mercator edge at low zoom (both themes). Fixed geometrically rather than by color: the 2D view is now **clamped** so the world always covers the viewport — a minimum zoom that fills the larger viewport dimension, plus a center-latitude clamp so the poles can't be panned into view. No gap in light, dark, or mobile. The container background is also matched to the basemap water color as a sub-pixel backup.

## Test plan
- `tsc` + `npm run build` pass
- Verified in browser: `/map` (light/dark/mobile) fills fully at max zoom-out (gap gone); homepage preview renders 8 YC companies + working CTAs; nav links resolve

## Notes
- `/api/map` payload additions from the prior map PR are already merged; no backend change here.
- Map is in the **More** menu, not the primary tabs (to avoid crowding) — easy to promote if you'd prefer it top-level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4B1pcs7619oF8o4jn3PZF