### PR TITLE
feat(home): capabilities grid + animated API showcase

### DIFF
--- a/frontend/src/components/ApiShowcase.tsx
+++ b/frontend/src/components/ApiShowcase.tsx
@@ -1,0 +1,386 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { Terminal, KeyRound, ArrowRight, Copy, Check, Zap } from 'lucide-react';
+
+// Real ExploreYC public API surface (mirrors /api-docs).
+const API_BASE = 'https://api.exploreyc.com/api/v1';
+
+interface ApiExample {
+  method: string;
+  path: string;
+  cmd: string;
+  response: string[];
+}
+
+const EXAMPLES: ApiExample[] = [
+  {
+    method: 'GET',
+    path: '/companies',
+    cmd: `curl -H "Authorization: Bearer eyc_live_…" \\\n  "${API_BASE}/companies?source=yc&limit=2"`,
+    response: [
+      '{',
+      '  "companies": [',
+      '    { "id": 15231, "name": "Stripe",',
+      '      "one_liner": "Payments infrastructure for the internet.",',
+      '      "batch": "Summer 2009", "industry": "Fintech",',
+      '      "status": "Active", "is_hiring": true },',
+      '    { "id": 18442, "name": "Airbnb",',
+      '      "batch": "Winter 2009", "industry": "Consumer" }',
+      '  ],',
+      '  "total": 6049,',
+      '  "has_more": true',
+      '}',
+    ],
+  },
+  {
+    method: 'GET',
+    path: '/search',
+    cmd: `curl -H "Authorization: Bearer eyc_live_…" \\\n  "${API_BASE}/search?q=fintech&limit=2"`,
+    response: [
+      '{',
+      '  "companies": [',
+      '    { "id": 15231, "name": "Stripe",',
+      '      "industry": "Fintech", "batch": "Summer 2009" },',
+      '    { "id": 20817, "name": "Brex",',
+      '      "industry": "Fintech", "batch": "Winter 2017" }',
+      '  ],',
+      '  "total": 214,',
+      '  "has_more": true',
+      '}',
+    ],
+  },
+  {
+    method: 'GET',
+    path: '/stats',
+    cmd: `curl -H "Authorization: Bearer eyc_live_…" \\\n  "${API_BASE}/stats"`,
+    response: [
+      '{',
+      '  "total_companies": 6049,',
+      '  "hiring": 1530,',
+      '  "top_industry": "B2B",',
+      '  "top_country": "United States",',
+      '  "batches": 50',
+      '}',
+    ],
+  },
+];
+
+const ENDPOINT_CHIPS = [
+  '/companies',
+  '/search',
+  '/stats',
+  '/map',
+  '/batches',
+  '/industries',
+  '/countries',
+];
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const onChange = () => setReduced(mq.matches);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+  return reduced;
+}
+
+// Minimal JSON syntax highlighter → colored spans matching the platform palette.
+function highlight(line: string): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  const re = /("(?:[^"\\]|\\.)*")(\s*:)?|(-?\d+\.?\d*)|(true|false|null)|([{}[\],:])/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  let key = 0;
+  while ((m = re.exec(line))) {
+    if (m.index > last) nodes.push(line.slice(last, m.index));
+    if (m[1]) {
+      const isKey = !!m[2];
+      nodes.push(
+        <span key={key++} className={isKey ? 'text-[#FB651E]' : 'text-emerald-400'}>
+          {m[1]}
+        </span>
+      );
+      if (m[2]) nodes.push(<span key={key++} className="text-white/30">{m[2]}</span>);
+    } else if (m[3]) {
+      nodes.push(<span key={key++} className="text-sky-400">{m[3]}</span>);
+    } else if (m[4]) {
+      nodes.push(<span key={key++} className="text-violet-400">{m[4]}</span>);
+    } else if (m[5]) {
+      nodes.push(<span key={key++} className="text-white/30">{m[5]}</span>);
+    }
+    last = re.lastIndex;
+  }
+  if (last < line.length) nodes.push(line.slice(last));
+  return nodes;
+}
+
+type Phase = 'typing' | 'fetching' | 'responding' | 'hold';
+
+export function ApiShowcase() {
+  const reduced = usePrefersReducedMotion();
+  const [idx, setIdx] = useState(0);
+  const [typed, setTyped] = useState(0);
+  const [lines, setLines] = useState(0);
+  const [phase, setPhase] = useState<Phase>('typing');
+  const [copied, setCopied] = useState(false);
+  const timers = useRef<number[]>([]);
+
+  const ex = EXAMPLES[idx];
+
+  // Drive the typewriter → fetch → stream-response → hold state machine.
+  useEffect(() => {
+    if (reduced) {
+      // Skip animation: show the full request + response, cycle slowly.
+      setTyped(ex.cmd.length);
+      setLines(ex.response.length);
+      const t = window.setTimeout(() => setIdx((i) => (i + 1) % EXAMPLES.length), 6000);
+      return () => window.clearTimeout(t);
+    }
+
+    let cancelled = false;
+    const clearAll = () => timers.current.forEach((t) => window.clearTimeout(t));
+
+    if (phase === 'typing') {
+      if (typed < ex.cmd.length) {
+        const t = window.setTimeout(() => !cancelled && setTyped((n) => n + 1), 16);
+        timers.current.push(t);
+      } else {
+        const t = window.setTimeout(() => !cancelled && setPhase('fetching'), 450);
+        timers.current.push(t);
+      }
+    } else if (phase === 'fetching') {
+      const t = window.setTimeout(() => !cancelled && setPhase('responding'), 650);
+      timers.current.push(t);
+    } else if (phase === 'responding') {
+      if (lines < ex.response.length) {
+        const t = window.setTimeout(() => !cancelled && setLines((n) => n + 1), 80);
+        timers.current.push(t);
+      } else {
+        const t = window.setTimeout(() => !cancelled && setPhase('hold'), 2800);
+        timers.current.push(t);
+      }
+    } else if (phase === 'hold') {
+      const t = window.setTimeout(() => {
+        if (cancelled) return;
+        setTyped(0);
+        setLines(0);
+        setPhase('typing');
+        setIdx((i) => (i + 1) % EXAMPLES.length);
+      }, 200);
+      timers.current.push(t);
+    }
+
+    return () => {
+      cancelled = true;
+      clearAll();
+    };
+  }, [phase, typed, lines, idx, reduced, ex.cmd.length, ex.response.length]);
+
+  const typedCmd = ex.cmd.slice(0, typed);
+  const showResponse = phase === 'responding' || phase === 'hold' || reduced;
+  const fetching = phase === 'fetching';
+
+  const copyCmd = async () => {
+    try {
+      await navigator.clipboard.writeText(ex.cmd.replace('eyc_live_…', 'eyc_live_your_key'));
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1400);
+    } catch {
+      /* clipboard blocked — no-op */
+    }
+  };
+
+  const steps = useMemo(
+    () => [
+      {
+        n: '01',
+        title: 'Grab a key',
+        body: 'Create a free developer account and generate an API key from the dashboard.',
+        code: 'eyc_live_••••••••',
+        to: '/signup',
+        cta: 'Get a key',
+      },
+      {
+        n: '02',
+        title: 'Send a request',
+        body: 'Pass your key as a bearer token. Filter by batch, industry, country, hiring & more.',
+        code: 'Authorization: Bearer eyc_live_…',
+        to: '/api-docs',
+        cta: 'See params',
+      },
+      {
+        n: '03',
+        title: 'Get YC data',
+        body: 'Clean JSON across YC + a16z — companies, search, stats, maps, batch wrapped.',
+        code: '200 OK · application/json',
+        to: '/database',
+        cta: 'Browse data',
+      },
+    ],
+    []
+  );
+
+  return (
+    <div className="relative">
+      {/* Section heading */}
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-8">
+        <div>
+          <div className="flex items-center gap-2 font-mono text-sm text-muted-foreground mb-2">
+            <Terminal className="h-4 w-4 text-[#FB651E]" />
+            <span>$ curl api.exploreyc.com/api/v1</span>
+          </div>
+          <h2 className="text-2xl md:text-3xl font-bold font-mono">
+            <span className="text-[#FB651E]">&gt;</span> YC data, one request away
+          </h2>
+          <p className="text-muted-foreground font-mono text-sm mt-2 max-w-xl">
+            A public REST API over every company we track — YC &amp; a16z. Authenticate, query,
+            and get structured JSON back. No scraping.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 flex-shrink-0">
+          <Link
+            to="/signup"
+            className="group inline-flex items-center gap-2 px-4 py-2.5 bg-[#FB651E] hover:bg-[#E65C00] text-white text-sm font-semibold font-mono transition-colors rounded-sm"
+          >
+            <KeyRound className="h-4 w-4" />
+            Get your API key
+            <ArrowRight className="h-4 w-4 group-hover:translate-x-0.5 transition-transform" />
+          </Link>
+          <Link
+            to="/api-docs"
+            className="inline-flex items-center gap-2 px-4 py-2.5 border border-border hover:border-[#FB651E]/50 text-sm font-mono bg-background/50 transition-colors rounded-sm"
+          >
+            Read the docs
+          </Link>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-4 items-stretch">
+        {/* Terminal window — always dark so it reads as a real console in both themes */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-60px' }}
+          transition={{ duration: 0.5 }}
+          className="lg:col-span-3 relative flex flex-col overflow-hidden rounded-lg border border-[#FB651E]/25 bg-[#0a0c11] shadow-[0_0_40px_rgba(251,101,30,0.08)]"
+        >
+          {/* window chrome */}
+          <div className="flex items-center gap-2 px-4 py-2.5 border-b border-white/[0.06] bg-white/[0.02]">
+            <span className="w-2.5 h-2.5 rounded-full bg-white/15" />
+            <span className="w-2.5 h-2.5 rounded-full bg-white/15" />
+            <span className="w-2.5 h-2.5 rounded-full bg-white/15" />
+            <span className="ml-2 font-mono text-[11px] text-white/40 truncate">
+              exploreyc — api — curl
+            </span>
+            <div className="ml-auto flex items-center gap-2">
+              <span className="font-mono text-[10px] px-1.5 py-0.5 rounded-sm bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">
+                {ex.method} {ex.path}
+              </span>
+              <button
+                onClick={copyCmd}
+                className="text-white/40 hover:text-white transition-colors"
+                title="Copy request"
+              >
+                {copied ? <Check className="h-3.5 w-3.5 text-emerald-400" /> : <Copy className="h-3.5 w-3.5" />}
+              </button>
+            </div>
+          </div>
+
+          {/* terminal body */}
+          <div className="flex-1 p-4 font-mono text-[12px] sm:text-[13px] leading-relaxed min-h-[340px]">
+            {/* request */}
+            <div className="text-white/85 whitespace-pre-wrap break-all">
+              <span className="text-[#FB651E]">$ </span>
+              {typedCmd}
+              {phase === 'typing' && !reduced && (
+                <span className="inline-block w-[7px] h-[15px] -mb-0.5 bg-[#FB651E] animate-pulse" />
+              )}
+            </div>
+
+            {/* fetching spinner */}
+            {fetching && (
+              <div className="mt-3 text-white/50 flex items-center gap-2">
+                <span className="inline-block w-3 h-3 rounded-full border-2 border-[#FB651E]/40 border-t-[#FB651E] animate-spin" />
+                fetching…
+              </div>
+            )}
+
+            {/* response */}
+            {showResponse && (
+              <div className="mt-3">
+                <div className="text-white/30 mb-1">↳ 200 OK · application/json</div>
+                <pre className="whitespace-pre-wrap break-all text-white/80">
+                  {ex.response.slice(0, reduced ? ex.response.length : lines).map((ln, i) => (
+                    <motion.div
+                      key={`${idx}-${i}`}
+                      initial={reduced ? false : { opacity: 0, x: -6 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      transition={{ duration: 0.18 }}
+                    >
+                      {highlight(ln)}
+                    </motion.div>
+                  ))}
+                </pre>
+              </div>
+            )}
+          </div>
+
+          {/* endpoint chips */}
+          <div className="px-4 py-3 border-t border-white/[0.06] bg-white/[0.02] flex flex-wrap gap-1.5">
+            {ENDPOINT_CHIPS.map((chip) => (
+              <Link
+                key={chip}
+                to="/api-docs"
+                className="font-mono text-[11px] px-2 py-1 rounded-sm border border-white/10 text-white/50 hover:text-[#FB651E] hover:border-[#FB651E]/40 transition-colors"
+              >
+                {chip}
+              </Link>
+            ))}
+          </div>
+        </motion.div>
+
+        {/* Connect steps */}
+        <div className="lg:col-span-2 flex flex-col gap-3">
+          {steps.map((s, i) => (
+            <motion.div
+              key={s.n}
+              initial={{ opacity: 0, x: 20 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              viewport={{ once: true, margin: '-40px' }}
+              transition={{ duration: 0.45, delay: 0.1 + i * 0.08 }}
+              className="group relative flex-1 rounded-lg border border-border/80 bg-card/50 dark:border-white/5 dark:bg-white/[0.02] p-4 hover:border-[#FB651E]/40 transition-colors"
+            >
+              <div className="flex items-start gap-3">
+                <span className="font-mono text-lg font-bold text-[#FB651E]/40 group-hover:text-[#FB651E] transition-colors tabular-nums">
+                  {s.n}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <h3 className="font-mono font-bold text-sm mb-1">{s.title}</h3>
+                  <p className="text-xs text-muted-foreground leading-relaxed mb-2">{s.body}</p>
+                  <code className="block text-[11px] font-mono text-[#FB651E]/90 bg-[#FB651E]/[0.06] border border-[#FB651E]/15 rounded-sm px-2 py-1 mb-2 truncate">
+                    {s.code}
+                  </code>
+                  <Link
+                    to={s.to}
+                    className="inline-flex items-center gap-1 text-xs font-mono text-[#FB651E] hover:underline"
+                  >
+                    {s.cta} <ArrowRight className="h-3 w-3" />
+                  </Link>
+                </div>
+              </div>
+            </motion.div>
+          ))}
+          <div className="rounded-lg border border-[#FB651E]/20 bg-[#FB651E]/[0.04] p-3 flex items-center gap-2 font-mono text-xs text-muted-foreground">
+            <Zap className="h-3.5 w-3.5 text-[#FB651E] flex-shrink-0" />
+            Free tier available · rate-limited · no credit card
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PlatformCapabilities.tsx
+++ b/frontend/src/components/PlatformCapabilities.tsx
@@ -1,0 +1,170 @@
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import {
+  Database, Globe2, BarChart3, Briefcase, BookOpen, Wrench, ArrowRight, Sparkles,
+} from 'lucide-react';
+import { useApp } from '../contexts/AppContext';
+
+interface Capability {
+  cmd: string;
+  title: string;
+  desc: string;
+  to: string;
+  icon: React.ComponentType<{ className?: string }>;
+  accent: string; // text/border accent
+  glow: string; // hover shadow
+}
+
+const CAPABILITIES: Capability[] = [
+  {
+    cmd: '$ db --companies',
+    title: 'Companies Database',
+    desc: 'Every YC & a16z company in one sortable, filterable table — batch, industry, funding, team.',
+    to: '/database',
+    icon: Database,
+    accent: 'text-[#FB651E] group-hover:border-[#FB651E]/50',
+    glow: 'group-hover:shadow-[0_0_24px_rgba(251,101,30,0.15)]',
+  },
+  {
+    cmd: '$ map --world',
+    title: 'Interactive World Map',
+    desc: 'Watch YC spread across the globe — 2D map, 3D globe, density hotspots, batch timeline.',
+    to: '/map',
+    icon: Globe2,
+    accent: 'text-sky-400 group-hover:border-sky-400/50',
+    glow: 'group-hover:shadow-[0_0_24px_rgba(56,189,248,0.15)]',
+  },
+  {
+    cmd: '$ analytics',
+    title: 'Analytics & Charts',
+    desc: 'Batches, industries, geography and hiring trends — the shape of Y Combinator over time.',
+    to: '/analytics',
+    icon: BarChart3,
+    accent: 'text-blue-400 group-hover:border-blue-400/50',
+    glow: 'group-hover:shadow-[0_0_24px_rgba(96,165,250,0.15)]',
+  },
+  {
+    cmd: '$ jobs --hiring',
+    title: 'Hiring Board',
+    desc: 'Open roles across every company that is actively hiring, refreshed daily.',
+    to: '/hiring',
+    icon: Briefcase,
+    accent: 'text-emerald-400 group-hover:border-emerald-400/50',
+    glow: 'group-hover:shadow-[0_0_24px_rgba(52,211,153,0.15)]',
+  },
+  {
+    cmd: '$ founders',
+    title: 'For Founders',
+    desc: 'PG essays, daily YC updates, and the playbook — everything a founder actually reads.',
+    to: '/founders',
+    icon: BookOpen,
+    accent: 'text-violet-400 group-hover:border-violet-400/50',
+    glow: 'group-hover:shadow-[0_0_24px_rgba(167,139,250,0.15)]',
+  },
+  {
+    cmd: '$ tools --launch',
+    title: 'Founder Tools',
+    desc: 'Idea validator, success predictor, batch wrapped and a fundraising tracker.',
+    to: '/tools',
+    icon: Wrench,
+    accent: 'text-amber-400 group-hover:border-amber-400/50',
+    glow: 'group-hover:shadow-[0_0_24px_rgba(251,191,36,0.15)]',
+  },
+];
+
+export function PlatformCapabilities() {
+  const { stats } = useApp();
+
+  const total = (stats?.total_all_companies ?? stats?.total_companies)?.toLocaleString() ?? '—';
+  const active = stats?.by_status?.['Active']?.toLocaleString() ?? '—';
+  const hiring = stats?.hiring?.toLocaleString() ?? '—';
+  const topIndustry =
+    stats?.by_industry
+      ? Object.entries(stats.by_industry).sort(([, a], [, b]) => b - a)[0]?.[0]
+      : undefined;
+  const topCountry =
+    stats?.by_country
+      ? Object.entries(stats.by_country).sort(([, a], [, b]) => b - a)[0]?.[0]
+      : undefined;
+
+  const statStrip = [
+    { label: 'companies tracked', value: total },
+    { label: 'active', value: active },
+    { label: 'hiring now', value: hiring },
+    { label: 'top industry', value: topIndustry ?? '—' },
+    { label: 'top country', value: topCountry ?? '—' },
+  ];
+
+  return (
+    <div>
+      {/* Heading */}
+      <div className="mb-6">
+        <div className="flex items-center gap-2 font-mono text-sm text-muted-foreground mb-2">
+          <Sparkles className="h-4 w-4 text-[#FB651E]" />
+          <span>$ explore --all</span>
+        </div>
+        <h2 className="text-2xl md:text-3xl font-bold font-mono">
+          <span className="text-[#FB651E]">&gt;</span> Everything you can explore
+        </h2>
+      </div>
+
+      {/* Live stat strip */}
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: '-40px' }}
+        transition={{ duration: 0.4 }}
+        className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-px mb-6 rounded-lg overflow-hidden border border-border/70 bg-border/40"
+      >
+        {statStrip.map((s) => (
+          <div key={s.label} className="bg-card/60 dark:bg-white/[0.02] px-4 py-3">
+            <div className="text-lg font-bold font-mono text-[#FB651E] truncate">{s.value}</div>
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground font-mono">
+              {s.label}
+            </div>
+          </div>
+        ))}
+      </motion.div>
+
+      {/* Capability grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {CAPABILITIES.map((c, i) => {
+          const Icon = c.icon;
+          return (
+            <motion.div
+              key={c.to}
+              initial={{ opacity: 0, y: 18 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, margin: '-40px' }}
+              transition={{ duration: 0.45, delay: (i % 3) * 0.06 }}
+            >
+              <Link to={c.to} className="group block h-full">
+                <div
+                  className={`relative h-full overflow-hidden rounded-lg border border-border/80 bg-card/50 dark:border-white/5 dark:bg-white/[0.02] p-5 transition-all duration-300 ${c.glow}`}
+                >
+                  <div className="flex items-center justify-between mb-4">
+                    <div className={`p-2 rounded-md bg-current/10 ${c.accent.split(' ')[0]}`}>
+                      <Icon className="h-5 w-5" />
+                    </div>
+                    <span className="font-mono text-[11px] text-muted-foreground/70">{c.cmd}</span>
+                  </div>
+                  <h3 className="font-mono font-bold text-base mb-1.5">{c.title}</h3>
+                  <p className="text-sm text-muted-foreground leading-relaxed">{c.desc}</p>
+                  <span
+                    className={`inline-flex items-center gap-1 mt-4 text-xs font-mono ${c.accent.split(' ')[0]} opacity-0 -translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-300`}
+                  >
+                    open <ArrowRight className="h-3 w-3" />
+                  </span>
+                  {/* corner sweep on hover */}
+                  <div
+                    className={`absolute -right-8 -top-8 w-16 h-16 rounded-full blur-2xl opacity-0 group-hover:opacity-30 transition-opacity duration-500 ${c.accent.split(' ')[0]} bg-current`}
+                  />
+                </div>
+              </Link>
+            </motion.div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,11 +5,12 @@ import { useApp } from '../contexts/AppContext';
 import { apiClient, type Source } from '../lib/api';
 import { SourceBadge } from '../components/ui/SourceBadge';
 import { getSecondMostRecentBatch, batchToShortFormat as batchToShort } from '../lib/batchUtils';
-import { Map, BarChart3, Wrench, TrendingUp, Building2, Globe2, Sparkles, ArrowRight, BookOpen, Terminal, ChevronUp } from 'lucide-react';
+import { Globe2, Sparkles, ArrowRight, Terminal, ChevronUp } from 'lucide-react';
 import { HeroAnswerBox } from '../components/HeroAnswerBox';
 import { DatabasePreview } from '../components/DatabasePreview';
+import { PlatformCapabilities } from '../components/PlatformCapabilities';
+import { ApiShowcase } from '../components/ApiShowcase';
 import { EmailSubscription } from '../components/EmailSubscription';
-import { CompaniesBrowser } from '../components/CompaniesBrowser';
 import { CompanyDetailModal } from '../components/CompanyDetailModal';
 import { HackerCard } from '../components/ui/hacker-card';
 import { DotPattern } from '../components/ui/dot-pattern';
@@ -303,20 +304,15 @@ export function HomePage() {
           <EmailSubscription />
         </motion.section>
 
-        {/* Companies List */}
+        {/* Platform capabilities — anchors into every data surface */}
         <motion.section
           initial={{ opacity: 0, y: 24 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true, margin: '-50px' }}
           transition={{ duration: 0.5 }}
-          className="py-12"
+          className="border-t border-border py-14"
         >
-          <div className="flex items-center gap-2 mb-6 font-mono">
-            <span className="text-muted-foreground">$</span>
-            <h2 className="text-xl font-bold">Browse All Companies</h2>
-            <span className="text-muted-foreground text-sm">({(stats?.total_companies ?? 0).toLocaleString()} startups)</span>
-          </div>
-          <CompaniesBrowser refreshTrigger={stats?.total_companies || 0} />
+          <PlatformCapabilities />
         </motion.section>
 
         {selectedCompany && (
@@ -327,121 +323,16 @@ export function HomePage() {
           />
         )}
 
-        {/* Bento-style feature grid */}
-        <motion.div
-          variants={container}
-          initial="hidden"
-          whileInView="show"
-          viewport={{ once: true, margin: '-80px' }}
-          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 max-w-6xl mx-auto"
+        {/* API access showcase */}
+        <motion.section
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: '-50px' }}
+          transition={{ duration: 0.5 }}
+          className="border-t border-border py-14"
         >
-          <Link to="/map" className="group">
-            <HackerCard glowColor="orange" delay={0} className="p-5 h-full">
-              <Map className="h-8 w-8 text-[#FB651E] mb-3 group-hover:scale-110 transition-transform" />
-              <h3 className="font-bold font-mono mb-1">Interactive Map</h3>
-              <p className="text-sm text-muted-foreground">
-                Explore companies by location on a global map
-              </p>
-              <span className="inline-flex items-center gap-1 mt-3 text-xs text-[#FB651E] font-mono opacity-0 group-hover:opacity-100 transition-opacity">
-                view <ArrowRight className="h-3 w-3" />
-              </span>
-            </HackerCard>
-          </Link>
-
-          <Link to="/analytics" className="group">
-            <HackerCard glowColor="blue" delay={0.05} className="p-5 h-full">
-              <BarChart3 className="h-8 w-8 text-blue-500 mb-3 group-hover:scale-110 transition-transform" />
-              <h3 className="font-bold font-mono mb-1">Analytics</h3>
-              <p className="text-sm text-muted-foreground">
-                Batches, industries, hiring trends
-              </p>
-              <span className="inline-flex items-center gap-1 mt-3 text-xs text-blue-500 font-mono opacity-0 group-hover:opacity-100 transition-opacity">
-                open <ArrowRight className="h-3 w-3" />
-              </span>
-            </HackerCard>
-          </Link>
-
-          <Link to="/founders" className="group">
-            <HackerCard glowColor="green" delay={0.1} className="p-5 h-full">
-              <BookOpen className="h-8 w-8 text-emerald-500 mb-3 group-hover:scale-110 transition-transform" />
-              <h3 className="font-bold font-mono mb-1">For Founders</h3>
-              <p className="text-sm text-muted-foreground">
-                PG essays, daily YC updates
-              </p>
-              <span className="inline-flex items-center gap-1 mt-3 text-xs text-emerald-500 font-mono opacity-0 group-hover:opacity-100 transition-opacity">
-                read <ArrowRight className="h-3 w-3" />
-              </span>
-            </HackerCard>
-          </Link>
-
-          <Link to="/tools" className="group">
-            <HackerCard glowColor="purple" delay={0.15} className="p-5 h-full">
-              <Wrench className="h-8 w-8 text-violet-500 mb-3 group-hover:scale-110 transition-transform" />
-              <h3 className="font-bold font-mono mb-1">Founder Tools</h3>
-              <p className="text-sm text-muted-foreground">
-                Idea validator, batch wrapped, fundraising tracker
-              </p>
-              <span className="inline-flex items-center gap-1 mt-3 text-xs text-violet-500 font-mono opacity-0 group-hover:opacity-100 transition-opacity">
-                launch <ArrowRight className="h-3 w-3" />
-              </span>
-            </HackerCard>
-          </Link>
-
-          {/* Stats cards - compact */}
-          {stats?.by_status && (
-            <HackerCard glowColor="green" delay={0.2} className="p-5 col-span-1">
-              <TrendingUp className="h-6 w-6 text-emerald-500 mb-2" />
-              <div className="text-2xl font-bold font-mono text-emerald-500">
-                {stats.by_status['Active']?.toLocaleString() || 0}
-              </div>
-              <div className="text-xs text-muted-foreground font-mono">Active</div>
-            </HackerCard>
-          )}
-          {stats?.by_industry && (
-            <HackerCard glowColor="orange" delay={0.25} className="p-5 col-span-1">
-              <Building2 className="h-6 w-6 text-[#FB651E] mb-2" />
-              <div className="text-xl font-bold font-mono text-[#FB651E] truncate">
-                {Object.entries(stats.by_industry).sort(([, a], [, b]) => b - a)[0]?.[0] || 'N/A'}
-              </div>
-              <div className="text-xs text-muted-foreground font-mono">Top Industry</div>
-            </HackerCard>
-          )}
-          {stats?.by_country && (
-            <HackerCard glowColor="purple" delay={0.3} className="p-5 col-span-1">
-              <Globe2 className="h-6 w-6 text-violet-500 mb-2" />
-              <div className="text-lg font-bold font-mono text-violet-500 truncate">
-                {Object.entries(stats.by_country).sort(([, a], [, b]) => b - a)[0]?.[0] || 'N/A'}
-              </div>
-              <div className="text-xs text-muted-foreground font-mono">Top Country</div>
-            </HackerCard>
-          )}
-        </motion.div>
-
-        {/* Terminal footer */}
-        <motion.div
-          initial={{ opacity: 0 }}
-          whileInView={{ opacity: 1 }}
-          viewport={{ once: true }}
-          className="mt-16 max-w-4xl mx-auto border border-border p-6 bg-card/30"
-        >
-          <div className="font-mono text-sm">
-            <div className="flex items-center gap-2 mb-3">
-              <span className="text-[#FB651E]">&gt;</span>
-              <span className="text-muted-foreground">Ready to explore?</span>
-            </div>
-            <div className="flex flex-wrap gap-4">
-              <Link to="/map" className="text-[#FB651E] hover:underline font-mono">
-                $ view map
-              </Link>
-              <Link to="/analytics" className="text-[#FB651E] hover:underline font-mono">
-                $ see charts
-              </Link>
-              <Link to="/validator" className="text-[#FB651E] hover:underline font-mono">
-                $ validate idea
-              </Link>
-            </div>
-          </div>
-        </motion.div>
+          <ApiShowcase />
+        </motion.section>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Redesigns the lower half of the homepage. Replaces the old "Browse All Companies" browser, the bento feature grid, the stat cards, and the "Ready to explore?" footer with two designed, animated sections.

### "Everything you can explore" — `PlatformCapabilities`
A live stat strip (companies tracked / active / hiring / top industry / top country from real stats) above a 6-card anchor grid pointing to Database, World Map, Analytics, Hiring, Founders, and Tools — each with an accent color, a terminal command label, staggered scroll reveal, and hover glow.

### "YC data, one request away" — `ApiShowcase`
A live terminal that types a real `curl` request, shows a fetching spinner, then streams syntax-highlighted JSON back — cycling through `/companies`, `/search`, and `/stats` on the real `api.exploreyc.com/api/v1` surface with Bearer auth. Paired with a 3-step connect guide, clickable endpoint chips into `/api-docs`, and CTAs to `/signup` and the docs. Terminal stays dark in both themes; respects `prefers-reduced-motion`.

Removes the now-unused CompaniesBrowser / bento imports from HomePage.

## Test plan
- `tsc` + `npm run build` pass
- Verified in browser (desktop, light + dark): both sections render, stat strip pulls real numbers, API terminal animates and cycles endpoints, terminal chips pin to the card bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4B1pcs7619oF8o4jn3PZF