### PR TITLE
chore(seo): Bing Webmaster site verification file

### DIFF
--- a/frontend/public/BingSiteAuth.xml
+++ b/frontend/public/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>989368A87E84FCE89C815C8740FE123D</user>
+</users>


### PR DESCRIPTION
Adds `public/BingSiteAuth.xml` so it serves at https://exploreyc.com/BingSiteAuth.xml for Bing Webmaster Tools domain verification. Public asset — passes straight through to the build output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4B1pcs7619oF8o4jn3PZF