### PR TITLE
fix(deps): declare httpx explicitly — prod deploy crashed on import

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ pgvector>=0.2.0
 numpy>=1.24.0
 playwright>=1.40.0
 stripe>=8.0.0
+httpx>=0.24.0


### PR DESCRIPTION
Prod backend (Railway) fails to boot: `ModuleNotFoundError: No module named 'httpx'` from `coresignal_service.py:11`. `httpx` was only present transitively via `openai`; the fresh rebuild resolved to a version without it. Declares it explicitly in `backend/requirements.txt`.

Audited all other backend imports (top-level and lazy) against requirements — httpx was the only undeclared package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeRXaT82XErS7R8YURYg5N