### PR TITLE
fix(dashboard): mobile header layout, unlimited-plan usage card, dev proxy

### DIFF
--- a/frontend/src/pages/DeveloperDashboard.tsx
+++ b/frontend/src/pages/DeveloperDashboard.tsx
@@ -161,7 +161,7 @@ export function DeveloperDashboard() {
       <div className="min-h-screen bg-background p-4 md:p-8">
         <div className="max-w-4xl mx-auto">
           {/* Header */}
-          <div className="flex items-center justify-between mb-8">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
             <div>
               <div className="flex items-center gap-2 mb-2 font-mono text-sm text-muted-foreground">
                 <Terminal className="h-4 w-4 text-[#FB651E]" />
@@ -244,9 +244,11 @@ export function DeveloperDashboard() {
               <div className="text-2xl font-bold font-mono">
                 {usage?.used_24h ?? 0}<span className="text-sm text-muted-foreground"> / {limit == null ? '∞' : limit}</span>
               </div>
-              <div className="mt-3 h-2 w-full rounded-full bg-muted overflow-hidden">
-                <div className={`h-full ${pct >= 100 ? 'bg-red-500' : 'bg-emerald-500'}`} style={{ width: `${pct}%` }} />
-              </div>
+              {limit != null && (
+                <div className="mt-3 h-2 w-full rounded-full bg-muted overflow-hidden">
+                  <div className={`h-full ${pct >= 100 ? 'bg-red-500' : 'bg-emerald-500'}`} style={{ width: `${pct}%` }} />
+                </div>
+              )}
               <p className="text-xs text-muted-foreground font-mono mt-2">
                 {limit == null ? 'No cap on this plan' : `${usage?.remaining ?? '—'} remaining`}
               </p>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,7 +9,8 @@ export default defineConfig({
   server: {
     host: true,
     proxy: {
-      '/api': {
+      // '^/api/' (not '/api') so SPA routes like /api-docs aren't swallowed by the proxy
+      '^/api/': {
         target: backendUrl,
         changeOrigin: true,
       },


### PR DESCRIPTION
Screenshot-verified the new billing UI (headless Chromium against the real frontend + a stub API) across all plan states — free, pro-subscribed, unlimited, and post-checkout success — at 1440×900 and iPhone 13 viewports. Everything renders correctly; three fixes came out of it:

1. **Mobile header collision** — the dashboard title overlapped the Docs/Logout buttons on phones; header now stacks vertically below `sm`.
2. **Unlimited plan usage card** — showed an empty progress bar with no cap to fill; the bar is hidden when `limit == null` (∞ display and "No cap on this plan" remain).
3. **Vite dev proxy** — `'/api'` prefix-matched `/api-docs` and proxied the SPA route to the backend (404 in local dev only; production Vercel rewrites use `/api/:path*` and were never affected). Key changed to `'^/api/'`.

`npm run build` and `tsc` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeRXaT82XErS7R8YURYg5N