### PR TITLE
feat(ui): terminal-cranked dashboard + api-docs with clearer IA

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,35 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Developers — indie hackers, founders, data teams — who consume the ExploreYC dataset (YC + a16z + Product Hunt companies, founders, funding) through the public REST API, plus curious YC-watchers using the free web tools (validator, maps, analytics). API users are in a task: get a key, make calls, watch quota, upgrade when they hit the cap.
+
+## Product Purpose
+
+ExploreYC is a startup-intelligence platform over scraped YC/a16z data. The public API is the monetized surface: free 5 req/day → Pro $50/mo (500/day) → Max $500/mo (5,000/day), billed via Stripe; `unlimited` is an admin grant. Success = a developer goes from signup → first API call → paid plan without ever needing support.
+
+## Brand Personality
+
+Terminal-native, confident, hacker-craft. The interface talks like a shell (`$ exploreyc --api`) and looks like a beautifully tuned terminal — monospace, YC orange `#FF6600` on near-black/near-white. For billing and docs the bar is Stripe-level clarity: pricing, quota, and keys must be legible at a glance even while the chrome stays playful.
+
+## Anti-references
+
+- Generic SaaS gradient-hero look (purple gradients, glassmorphism, hero-metric cards).
+- Any palette pivot away from YC orange as the single brand anchor.
+- Corporate-bland developer portals where the terminal identity is sanded off.
+
+## Design Principles
+
+1. **Terminal-native, cranked** — lean into prompt/console metaphors as structure (blocks, prompts, monospace data), never as noise over the task.
+2. **Stripe-clear where money moves** — plans, quota, usage, and errors are explicit, numeric, and self-explanatory.
+3. **One path, visible** — signup → key → first call → upgrade is always discoverable from any API surface.
+4. **Orange is a signal** — YC orange marks actions, current state, and live data; it is never decoration.
+5. **Both themes are first-class** — every surface ships tested in light and dark.
+
+## Accessibility & Inclusion
+
+WCAG AA contrast (≥4.5:1 body text) in both themes; `prefers-reduced-motion` alternatives for all animation; keyboard-reachable interactive elements.

--- a/frontend/src/pages/ApiDocsPage.tsx
+++ b/frontend/src/pages/ApiDocsPage.tsx
@@ -432,11 +432,26 @@ export function ApiDocsPage() {
                   founders, and more. JSON over HTTPS. Free tier is 5 requests/day.
                 </p>
                 <div className="flex flex-wrap gap-2">
+                  <Link to={user ? '/dashboard' : '/signup'}
+                        className="inline-flex items-center gap-2 px-4 py-2 bg-[#FB651E] hover:bg-[#E65C00] text-white text-sm font-semibold rounded-sm transition-colors font-mono shadow-[0_0_16px_rgba(251,101,30,0.3)]">
+                    <KeyRound className="h-4 w-4" /> {user ? 'Your dashboard — keys & usage' : 'Get your free API key'}
+                  </Link>
                   <a href={`${API_BASE}/docs`} target="_blank" rel="noopener noreferrer"
                      className="inline-flex items-center gap-2 px-3 py-2 border border-border text-sm rounded-sm hover:border-[#FB651E]/50 transition-colors font-mono">
                     <BookOpen className="h-4 w-4" /> Interactive Swagger <ExternalLink className="h-3 w-3" />
                   </a>
                 </div>
+                {user && (
+                  <div className="mt-3 inline-flex flex-wrap items-center gap-x-4 gap-y-1 rounded-sm border border-border px-3 py-2 font-mono text-xs text-muted-foreground">
+                    <span className="flex items-center gap-1.5">
+                      <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                      {user.email}
+                    </span>
+                    <span>plan: <span className="text-[#FB651E] capitalize">{user.plan}</span></span>
+                    <span>quota: {user.daily_limit == null ? '∞' : `${user.daily_limit.toLocaleString()}/day`}</span>
+                    <Link to="/dashboard" className="text-[#FB651E] hover:underline">usage →</Link>
+                  </div>
+                )}
                 <div className="mt-4">
                   <Terminal title="base url">
                     <div className="flex items-center justify-between gap-2">
@@ -448,7 +463,7 @@ export function ApiDocsPage() {
                 {/* New: founder leaderboards anchor */}
                 <Link
                   to="/founders/leaderboard"
-                  className="mt-4 group flex flex-wrap items-center gap-3 rounded-md border border-[#FB651E]/30 bg-[#FB651E]/[0.05] px-4 py-3 transition-colors hover:border-[#FB651E]/60"
+                  className="mt-4 group flex flex-col sm:flex-row sm:items-center items-start gap-3 rounded-md border border-[#FB651E]/30 bg-[#FB651E]/[0.05] px-4 py-3 transition-colors hover:border-[#FB651E]/60"
                 >
                   <img src="/yc-logo.png" alt="Y Combinator" className="h-9 w-9 shrink-0 rounded-md" />
                   <div className="min-w-0 flex-1">

--- a/frontend/src/pages/DeveloperDashboard.tsx
+++ b/frontend/src/pages/DeveloperDashboard.tsx
@@ -173,8 +173,42 @@ export function DeveloperDashboard() {
               <p className="text-sm text-muted-foreground font-mono mt-1">{user.email}</p>
             </div>
             <div className="flex items-center gap-2">
-              <Link to="/api-docs"><Button variant="outline" className="font-mono"><BookOpen className="h-4 w-4 mr-2" />Docs</Button></Link>
+              <Link to="/api-docs">
+                <Button className="font-mono bg-[#FB651E] hover:bg-[#E65C00] text-white shadow-[0_0_16px_rgba(251,101,30,0.35)]">
+                  <BookOpen className="h-4 w-4 mr-2" />API Docs
+                </Button>
+              </Link>
               <Button variant="outline" className="font-mono" onClick={logout}><LogOut className="h-4 w-4 mr-2" />Logout</Button>
+            </div>
+          </div>
+
+          {/* Quick start — the one path: key → call → quota */}
+          <div className="mb-6 rounded-md border border-border overflow-hidden font-mono text-sm">
+            <div className="flex items-center gap-1.5 bg-[#0a0c11] px-3 py-2 border-b border-white/10">
+              <span className="h-2.5 w-2.5 rounded-full bg-red-500/80" />
+              <span className="h-2.5 w-2.5 rounded-full bg-yellow-500/80" />
+              <span className="h-2.5 w-2.5 rounded-full bg-emerald-500/80" />
+              <span className="ml-2 text-[11px] text-white/40">quick start</span>
+            </div>
+            <div className="bg-[#0a0c11] text-white/85 px-4 py-3 grid grid-cols-1 md:grid-cols-3 gap-x-6 gap-y-2">
+              <a href="#keys" className="group flex items-baseline gap-2 hover:text-white transition-colors">
+                <span className="text-[#FB651E]">$</span>
+                <span>create-key<span className="hidden lg:inline text-white/35"> — mint your eyc_live_… token below</span></span>
+              </a>
+              <div className="flex items-baseline gap-2 min-w-0">
+                <span className="text-[#FB651E]">$</span>
+                <span className="truncate">curl api.exploreyc.com/api/v1/companies</span>
+                <button
+                  onClick={() => navigator.clipboard.writeText('curl -H "Authorization: Bearer YOUR_KEY" https://api.exploreyc.com/api/v1/companies')}
+                  className="text-white/40 hover:text-[#FB651E] transition-colors flex-shrink-0" title="Copy example request"
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                </button>
+              </div>
+              <Link to="/api-docs" className="group flex items-baseline gap-2 hover:text-white transition-colors">
+                <span className="text-[#FB651E]">$</span>
+                <span>man exploreyc <span className="text-white/35 group-hover:text-[#FB651E] transition-colors">→ full docs</span></span>
+              </Link>
             </div>
           </div>
 
@@ -223,9 +257,9 @@ export function DeveloperDashboard() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
             <HackerCard glowColor="orange" className="p-6">
               <div className="text-sm font-mono text-muted-foreground mb-1">PLAN</div>
-              <div className="text-2xl font-bold font-mono capitalize">{me?.plan_name || user.plan}</div>
+              <div className="text-3xl font-bold font-mono capitalize text-[#FB651E]">{me?.plan_name || user.plan}</div>
               <p className="text-xs text-muted-foreground font-mono mt-2">
-                {limit == null ? 'Unlimited requests' : `${limit} requests / day`}
+                {limit == null ? 'Unlimited requests' : `${limit.toLocaleString()} requests / day · rolling 24h window`}
               </p>
               {hasActiveSub && (
                 <button
@@ -241,12 +275,15 @@ export function DeveloperDashboard() {
 
             <HackerCard glowColor="green" className="p-6">
               <div className="text-sm font-mono text-muted-foreground mb-1">USAGE (LAST 24H)</div>
-              <div className="text-2xl font-bold font-mono">
-                {usage?.used_24h ?? 0}<span className="text-sm text-muted-foreground"> / {limit == null ? '∞' : limit}</span>
+              <div className="text-3xl font-bold font-mono tabular-nums">
+                {usage?.used_24h ?? 0}<span className="text-sm text-muted-foreground"> / {limit == null ? '∞' : limit.toLocaleString()}</span>
               </div>
               {limit != null && (
                 <div className="mt-3 h-2 w-full rounded-full bg-muted overflow-hidden">
-                  <div className={`h-full ${pct >= 100 ? 'bg-red-500' : 'bg-emerald-500'}`} style={{ width: `${pct}%` }} />
+                  <div
+                    className={`h-full transition-[width] duration-500 ease-out motion-reduce:transition-none ${pct >= 100 ? 'bg-red-500' : pct >= 80 ? 'bg-[#FB651E]' : 'bg-emerald-500'}`}
+                    style={{ width: `${pct}%` }}
+                  />
                 </div>
               )}
               <p className="text-xs text-muted-foreground font-mono mt-2">
@@ -278,26 +315,46 @@ export function DeveloperDashboard() {
                   : 'Monthly subscription via Stripe — cancel anytime from this dashboard.'}
               </p>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {paidPlans.map((p) => (
-                  <div key={p.key} className="rounded-lg border border-border p-4 flex flex-col gap-2">
-                    <div className="flex items-baseline justify-between">
-                      <span className="font-mono font-bold text-lg">{p.name}</span>
-                      <span className="font-mono text-[#FB651E] font-bold">${p.price_usd_month}<span className="text-xs text-muted-foreground font-normal">/mo</span></span>
-                    </div>
-                    <p className="text-xs text-muted-foreground font-mono">
-                      {p.daily_limit == null ? 'Unlimited requests' : `${p.daily_limit.toLocaleString()} requests / day`}
-                    </p>
-                    <Button
-                      className="bg-[#FB651E] hover:bg-[#E65C00] font-mono mt-1"
-                      disabled={checkout.isPending || portal.isPending}
-                      onClick={() => (hasActiveSub ? portal.mutate() : checkout.mutate(p.key))}
+                {paidPlans.map((p) => {
+                  const featured = p.key === 'pro' && plan === 'free'
+                  return (
+                    <div
+                      key={p.key}
+                      className={`rounded-lg border p-4 flex flex-col gap-2 transition-shadow ${
+                        featured
+                          ? 'border-[#FB651E]/60 shadow-[0_0_20px_rgba(251,101,30,0.12)]'
+                          : 'border-border'
+                      }`}
                     >
-                      {checkout.isPending || portal.isPending
-                        ? <Loader2 className="h-4 w-4 animate-spin" />
-                        : hasActiveSub ? 'Change plan' : `Subscribe — $${p.price_usd_month}/mo`}
-                    </Button>
-                  </div>
-                ))}
+                      <div className="flex items-baseline justify-between">
+                        <span className="font-mono font-bold text-lg flex items-center gap-2">
+                          {p.name}
+                          {featured && (
+                            <span className="text-[10px] font-bold uppercase tracking-wide text-[#FB651E] border border-[#FB651E]/50 rounded px-1.5 py-0.5">
+                              recommended
+                            </span>
+                          )}
+                        </span>
+                        <span className="font-mono text-[#FB651E] font-bold text-xl">${p.price_usd_month}<span className="text-xs text-muted-foreground font-normal">/mo</span></span>
+                      </div>
+                      <p className="text-xs text-muted-foreground font-mono">
+                        {p.daily_limit == null ? 'Unlimited requests' : `${p.daily_limit.toLocaleString()} requests / day`}
+                        {p.daily_limit != null && limit != null && p.daily_limit > limit && (
+                          <span className="text-emerald-500"> · {Math.round(p.daily_limit / Math.max(1, limit))}× your current limit</span>
+                        )}
+                      </p>
+                      <Button
+                        className={`font-mono mt-1 ${featured ? 'bg-[#FB651E] hover:bg-[#E65C00] shadow-[0_0_14px_rgba(251,101,30,0.3)]' : 'bg-[#FB651E]/90 hover:bg-[#E65C00]'}`}
+                        disabled={checkout.isPending || portal.isPending}
+                        onClick={() => (hasActiveSub ? portal.mutate() : checkout.mutate(p.key))}
+                      >
+                        {checkout.isPending || portal.isPending
+                          ? <Loader2 className="h-4 w-4 animate-spin" />
+                          : hasActiveSub ? 'Change plan' : `Subscribe — $${p.price_usd_month}/mo`}
+                      </Button>
+                    </div>
+                  )
+                })}
               </div>
             </HackerCard>
           )}
@@ -357,7 +414,7 @@ export function DeveloperDashboard() {
           </HackerCard>
 
           {/* API keys */}
-          <HackerCard glowColor="orange" className="p-6">
+          <HackerCard glowColor="orange" className="p-6 scroll-mt-24" id="keys">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
               <h2 className="text-xl font-bold font-mono flex items-center gap-2">
                 <KeyRound className="h-5 w-5 text-[#FB651E]" /> API Keys


### PR DESCRIPTION
Verified end-to-end with headless screenshots (desktop + iPhone) before
shipping; payments confirmed working in prod (live Checkout URL).

Dashboard:
- Quick-start terminal strip: create-key → example curl (copyable) →
  full docs. The signup→key→call→upgrade path is now visible up top.
- API Docs button is a glowing orange primary, not a ghost outline.
- Plan/usage cards: bigger orange numerals, "rolling 24h window" label,
  usage bar animates and shifts green→orange→red as quota burns.
- Upgrade card: Pro carries a "recommended" badge + glow for free users;
  each tier shows its multiplier over your current limit.

API docs:
- Primary CTA in the hero: "Get your free API key" (signed out) /
  "Your dashboard — keys & usage" (signed in).
- Signed-in account strip: email, plan, quota, link to usage.
- Founder Leaderboards banner no longer squishes on phones.

Adds PRODUCT.md (impeccable design context: register, personality,
anti-references, principles).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WPUSNVv6mUKY94w9Qk1oVh
