### PR TITLE
design(home): centered click-to-open FAQ, 12 questions, one data source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ wheels/
 !backend/railway.json
 # World feature runtime data (seeds + geometry) must ship with the backend
 !backend/data/*.json
+# Frontend content data (FAQ copy shared by the UI and the SEO prerender)
+!frontend/src/data/*.json
 
 # Environment variables
 .env

--- a/frontend/scripts/prerender-seo.mjs
+++ b/frontend/scripts/prerender-seo.mjs
@@ -162,16 +162,12 @@ const ROUTES = [
   },
 ];
 
-// FAQ — keep in sync with src/components/HomeFaq.tsx. Injected into the homepage
-// <head> as FAQPage JSON-LD so non-JS AI bots get the answers too.
-const FAQS = [
-  ['Is there an API for Y Combinator company data?', 'Yes. ExploreYC provides a free, open-source REST API for Y Combinator company data at api.exploreyc.com/api/v1. Authenticate with an API key and query companies, full-text search, stats and more — returned as structured JSON, no scraping required.'],
-  ['Does ExploreYC include a16z and Product Hunt data too?', 'Yes. Alongside Y Combinator, ExploreYC aggregates Andreessen Horowitz (a16z) portfolio companies, Product Hunt launches and Hacker News startups. You can search across all sources at once or filter to a single source.'],
-  ['Is the ExploreYC API free?', 'Yes, there is a free tier. Create a developer account, generate an API key, and start with 5 requests per day. Higher rate limits are available for heavier usage.'],
-  ['Is ExploreYC open source?', 'Yes — ExploreYC is an open-source project. Instead of scraping Y Combinator, a16z or Product Hunt yourself, you can pull clean, structured company data straight from the public API.'],
-  ['What startup data can I get?', 'For 8,600+ companies: name, one-liner, description, batch, industry, country, team size, hiring status, founders, funding, stage, exits and geo-coordinates — via the API or the filterable web database.'],
-  ['How do I get started with the API?', 'Grab an API key at exploreyc.com/signup, then send a request to the /companies endpoint with your bearer token. The full endpoint reference is at exploreyc.com/api-docs.'],
-];
+// FAQ — read from the same src/data/faqs.json that HomeFaq.tsx renders, so the
+// static JSON-LD can never drift from the visible answers. Injected into the
+// homepage <head> as FAQPage structured data so non-JS AI bots get them too.
+const FAQS = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'data', 'faqs.json'), 'utf8'),
+);
 
 function main() {
   const base = readFileSync(join(DIST, 'index.html'), 'utf8');
@@ -180,7 +176,7 @@ function main() {
   const faqSchema = {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
-    mainEntity: FAQS.map(([q, a]) => ({ '@type': 'Question', name: q, acceptedAnswer: { '@type': 'Answer', text: a } })),
+    mainEntity: FAQS.map(({ q, a }) => ({ '@type': 'Question', name: q, acceptedAnswer: { '@type': 'Answer', text: a } })),
   };
   writeFileSync(join(DIST, 'index.html'), appendJsonLd(base, faqSchema));
 

--- a/frontend/src/components/HomeFaq.tsx
+++ b/frontend/src/components/HomeFaq.tsx
@@ -1,41 +1,37 @@
-import { useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { motion } from 'framer-motion';
-import { HelpCircle, Plus, Minus } from 'lucide-react';
+import { HelpCircle, ChevronDown } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import faqs from '../data/faqs.json';
 
 // Answer-style content targeting the queries we want to win on Google + AI search
 // (YC/a16z/Product Hunt data API, open-source startup data). Rendered visibly AND
 // emitted as FAQPage structured data from the same source, so the schema always
 // matches what's on the page.
-const FAQS: { q: string; a: string }[] = [
-  {
-    q: 'Is there an API for Y Combinator company data?',
-    a: 'Yes. ExploreYC provides a free, open-source REST API for Y Combinator company data at api.exploreyc.com/api/v1. Authenticate with an API key and query companies, full-text search, stats and more — returned as structured JSON, no scraping required.',
-  },
-  {
-    q: 'Does ExploreYC include a16z and Product Hunt data too?',
-    a: 'Yes. Alongside Y Combinator, ExploreYC aggregates Andreessen Horowitz (a16z) portfolio companies, Product Hunt launches and Hacker News startups. You can search across all sources at once or filter to a single source with source=yc, source=a16z, and so on.',
-  },
-  {
-    q: 'Is the ExploreYC API free?',
-    a: 'Yes, there is a free tier. Create a developer account, generate an API key, and start with 5 requests per day. Higher rate limits are available for heavier usage.',
-  },
-  {
-    q: 'Is ExploreYC open source?',
-    a: 'Yes — ExploreYC is an open-source project. Instead of scraping Y Combinator, a16z or Product Hunt yourself, you can pull clean, structured company data straight from the public API.',
-  },
-  {
-    q: 'What startup data can I get?',
-    a: 'For 8,600+ companies: name, one-liner, description, batch, industry, country, team size, hiring status, founders, funding, stage, exits and geo-coordinates — via the API or the filterable web database.',
-  },
-  {
-    q: 'How do I get started with the API?',
-    a: 'Grab an API key at exploreyc.com/signup, then send a request to the /companies endpoint with your bearer token. The full endpoint reference, authentication and rate limits are at exploreyc.com/api-docs.',
-  },
-];
+//
+// The questions live in src/data/faqs.json because scripts/prerender-seo.mjs reads
+// the same file to bake the JSON-LD into the static homepage head — one source, no drift.
+const FAQS: { q: string; a: string }[] = faqs;
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const onChange = () => setReduced(mq.matches);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+  return reduced;
+}
 
 export function HomeFaq() {
-  const [open, setOpen] = useState<number | null>(0);
+  // Everything starts collapsed — answers appear only on click.
+  const [open, setOpen] = useState<number | null>(null);
+  const reduced = usePrefersReducedMotion();
+  const baseId = useId();
 
   const faqSchema = {
     '@context': 'https://schema.org',
@@ -53,45 +49,60 @@ export function HomeFaq() {
         <script type="application/ld+json">{JSON.stringify(faqSchema)}</script>
       </Helmet>
 
-      <div className="flex items-center gap-2 mb-6 font-mono">
-        <HelpCircle className="h-5 w-5 text-[#FB651E]" />
-        <span className="text-muted-foreground">$</span>
-        <h2 className="text-xl font-bold">FAQ — the API &amp; the data</h2>
-      </div>
+      <div className="mx-auto max-w-3xl">
+        <div className="mb-6 flex items-center justify-center gap-2 font-mono">
+          <HelpCircle className="h-5 w-5 text-[#FB651E]" />
+          <span className="text-muted-foreground">$</span>
+          <h2 className="text-xl font-bold">FAQ — the API &amp; the data</h2>
+        </div>
 
-      <div className="max-w-3xl space-y-2">
-        {FAQS.map((f, i) => {
-          const isOpen = open === i;
-          return (
-            <div
-              key={f.q}
-              className="border border-border/80 rounded-lg bg-card/40 dark:bg-white/[0.02] overflow-hidden"
-            >
-              <button
-                onClick={() => setOpen(isOpen ? null : i)}
-                className="w-full flex items-center justify-between gap-3 px-4 py-3.5 text-left font-mono font-semibold text-sm hover:text-[#FB651E] transition-colors"
-                aria-expanded={isOpen}
+        <div className="space-y-2">
+          {FAQS.map((f, i) => {
+            const isOpen = open === i;
+            const panelId = `${baseId}-faq-${i}`;
+            return (
+              <div
+                key={f.q}
+                className={`overflow-hidden rounded-lg border bg-card/40 transition-colors dark:bg-white/[0.02] ${
+                  isOpen ? 'border-[#FB651E]/40' : 'border-border/80 hover:border-[#FB651E]/25'
+                }`}
               >
-                <span>{f.q}</span>
-                {isOpen ? (
-                  <Minus className="h-4 w-4 text-[#FB651E] flex-shrink-0" />
-                ) : (
-                  <Plus className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                )}
-              </button>
-              <motion.div
-                initial={false}
-                animate={{ height: isOpen ? 'auto' : 0, opacity: isOpen ? 1 : 0 }}
-                transition={{ duration: 0.25, ease: 'easeInOut' }}
-                className="overflow-hidden"
-              >
-                <p className="px-4 pb-4 text-sm text-muted-foreground leading-relaxed font-mono">
-                  {f.a}
-                </p>
-              </motion.div>
-            </div>
-          );
-        })}
+                <button
+                  onClick={() => setOpen(isOpen ? null : i)}
+                  className="flex w-full items-center justify-between gap-3 px-4 py-3.5 text-left font-mono text-sm font-semibold transition-colors hover:text-[#FB651E]"
+                  aria-expanded={isOpen}
+                  aria-controls={panelId}
+                >
+                  <span className="[text-wrap:pretty]">{f.q}</span>
+                  <ChevronDown
+                    className={`h-4 w-4 flex-shrink-0 transition-transform duration-200 motion-reduce:transition-none ${
+                      isOpen ? 'rotate-180 text-[#FB651E]' : 'text-muted-foreground'
+                    }`}
+                  />
+                </button>
+                <motion.div
+                  id={panelId}
+                  initial={false}
+                  animate={{ height: isOpen ? 'auto' : 0, opacity: isOpen ? 1 : 0 }}
+                  transition={reduced ? { duration: 0 } : { duration: 0.25, ease: 'easeInOut' }}
+                  className="overflow-hidden"
+                  aria-hidden={!isOpen}
+                >
+                  <p className="px-4 pb-4 font-mono text-sm leading-relaxed text-muted-foreground">
+                    {f.a}
+                  </p>
+                </motion.div>
+              </div>
+            );
+          })}
+        </div>
+
+        <p className="mt-6 text-center font-mono text-sm text-muted-foreground">
+          Still have a question?{' '}
+          <Link to="/api-docs" className="text-[#FB651E] hover:underline">
+            Read the API docs
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/data/faqs.json
+++ b/frontend/src/data/faqs.json
@@ -1,0 +1,50 @@
+[
+  {
+    "q": "Is there an API for Y Combinator company data?",
+    "a": "Yes. ExploreYC provides a free, open-source REST API for Y Combinator company data at api.exploreyc.com/api/v1. Authenticate with an API key and query companies, full-text search, stats and more — returned as structured JSON, no scraping required."
+  },
+  {
+    "q": "Does ExploreYC include a16z and Product Hunt data too?",
+    "a": "Yes. Alongside Y Combinator, ExploreYC aggregates Andreessen Horowitz (a16z) portfolio companies, Product Hunt launches and Hacker News startups — 27,000+ companies in total. You can search across every source at once or filter to a single one with source=yc, source=a16z, and so on."
+  },
+  {
+    "q": "Is the ExploreYC API free?",
+    "a": "Yes, there is a free tier. Create a developer account, generate an API key, and start with 5 requests per day at no cost and no credit card. Paid plans lift that limit when you need more."
+  },
+  {
+    "q": "How much do the paid API plans cost?",
+    "a": "Free gives you 5 requests per day. Pro is $50/month for 500 requests per day, and Max is $500/month for 5,000 requests per day. You can upgrade from your dashboard in a few clicks — billing runs on Stripe."
+  },
+  {
+    "q": "What are the API rate limits?",
+    "a": "Limits are enforced per API key on a rolling 24-hour window. Every response includes X-RateLimit-Limit, X-RateLimit-Remaining and X-RateLimit-Reset headers so you can track your usage, and requests over the limit return HTTP 429 with a Retry-After header."
+  },
+  {
+    "q": "Can I cancel my subscription anytime?",
+    "a": "Yes. Open the billing portal from your developer dashboard to cancel, switch plans or update your card. Cancelling takes effect at the end of the paid period, after which your key returns to the free tier."
+  },
+  {
+    "q": "How often is the data updated?",
+    "a": "Every day. An automated job re-scrapes the sources each morning, so new batches, fresh launches and updated hiring status show up in both the web app and the API without you doing anything."
+  },
+  {
+    "q": "What startup data can I get?",
+    "a": "For every company: name, one-liner, description, batch, industry, country, team size, hiring status, founders, funding, stage, exits and geo-coordinates — available through the API or the filterable web database."
+  },
+  {
+    "q": "Does ExploreYC have a YC jobs board?",
+    "a": "Yes. The hiring board tracks 1,500+ open roles across Y Combinator companies, filterable by role, salary, remote or on-site, batch and location — refreshed daily alongside the company data."
+  },
+  {
+    "q": "What free tools does ExploreYC offer?",
+    "a": "All the tools are free: an idea validator that checks your startup idea against the YC portfolio for market crowding, a success predictor, Batch Wrapped stats, a funding leaderboard, and an interactive world map of startups."
+  },
+  {
+    "q": "Is ExploreYC open source?",
+    "a": "Yes — ExploreYC is an open-source project released under the MIT license. Instead of scraping Y Combinator, a16z or Product Hunt yourself, you can pull clean, structured company data straight from the public API."
+  },
+  {
+    "q": "How do I get started with the API?",
+    "a": "Grab an API key at exploreyc.com/signup, then send a request to the /companies endpoint with your bearer token. The full endpoint reference, authentication details and rate limits are at exploreyc.com/api-docs."
+  }
+]

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -21,6 +21,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
+    "resolveJsonModule": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },


### PR DESCRIPTION
- Centered the FAQ block (header + accordion) instead of hugging the
  left edge, and added a "read the API docs" closer.
- Chevron arrows that rotate on open, replacing the plus/minus icons;
  the open row is marked with an orange border + orange question.
- Nothing is expanded by default — answers appear only on click (was:
  the first answer always open).
- Extends 6 → 12 questions, covering what people ask now that billing
  is live: plan pricing, rate limits, cancelling, update cadence, the
  jobs board and the free tools.
- Corrects a stale claim: the old "8,600+ companies" answer predates
  the multi-source data (6,226 YC / 27,334 across all sources today).
- The questions move to src/data/faqs.json, read by BOTH HomeFaq.tsx
  and scripts/prerender-seo.mjs. The prerender script previously kept
  a hand-maintained copy behind a "keep in sync" comment; now the
  visible answers and the FAQPage JSON-LD cannot drift.

Verified: build emits all 12 into the static homepage schema; screenshots
of collapsed + expanded states on desktop and iPhone.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WPUSNVv6mUKY94w9Qk1oVh
